### PR TITLE
Adding a configurable thesaurus module with back-office CRUD.

### DIFF
--- a/src/module-elasticsuite-thesaurus/Api/Data/ThesaurusInterface.php
+++ b/src/module-elasticsuite-thesaurus/Api/Data/ThesaurusInterface.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile_ElasticSuiteThesaurus
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2016 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\ElasticSuiteThesaurus\Api\Data;
+
+/**
+ * Thesaurus Interface
+ *
+ * @category Smile
+ * @package  Smile_ElasticSuiteThesaurus
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+interface ThesaurusInterface
+{
+    /**
+     * Name of the main Mysql Table
+     */
+    const TABLE_NAME = 'smile_elasticsuite_thesaurus';
+
+    /**
+     * Constant for field thesaurus_id
+     */
+    const THESAURUS_ID = 'thesaurus_id';
+
+    /**
+     * Constant for field store_id
+     */
+    const STORE_ID = 'store_id';
+
+    /**
+     * Constant for field name
+     */
+    const NAME = 'name';
+
+    /**
+     * Constant for field name
+     */
+    const TYPE = 'type';
+
+    /**
+     * Name of the link thesaurus/expansion terms TABLE
+     */
+    const STORE_TABLE_NAME = 'smile_elasticsuite_thesaurus_store';
+
+    /**
+     * Name of the expanded terms table, which also contains synonyms.
+     */
+    const EXPANSION_TABLE_NAME = 'smile_elasticsuite_thesaurus_expanded_terms';
+
+    /**
+     * Name of the reference terms table
+     */
+    const REFERENCE_TABLE_NAME = 'smile_elasticsuite_thesaurus_reference_terms';
+
+    /**
+     * Type of the Synonym Thesaurus
+     */
+    const TYPE_SYNONYM = 'synonym';
+
+    /**
+     * Type of the Expansion Thesaurus
+     */
+    const TYPE_EXPANSION = 'expansion';
+
+    /**
+     * Get Thesaurus ID
+     *
+     * @return int|null
+     */
+    public function getThesaurusId();
+
+    /**
+     * Get name
+     *
+     * @return string
+     */
+    public function getName();
+
+    /**
+     * Get type
+     *
+     * @return string
+     */
+    public function getType();
+
+    /**
+     * Get store ids
+     *
+     * @return int[]
+     */
+    public function getStoreIds();
+
+    /**
+     * Set Thesaurus ID
+     *
+     * @param int $identifier the value to save
+     *
+     * @return ThesaurusInterface
+     */
+    public function setThesaurusId($identifier);
+
+    /**
+     * Set name
+     *
+     * @param string $name the value to save
+     *
+     * @return ThesaurusInterface
+     */
+    public function setName($name);
+
+    /**
+     * Set type
+     *
+     * @param string $type the type of thesaurus to save
+     *
+     * @return ThesaurusInterface
+     */
+    public function setType($type);
+
+    /**
+     * Set store ids
+     *
+     * @param int[] $storeIds the store ids
+     *
+     * @return ThesaurusInterface
+     */
+    public function setStoreIds($storeIds);
+}

--- a/src/module-elasticsuite-thesaurus/Api/Data/ThesaurusSearchResultsInterface.php
+++ b/src/module-elasticsuite-thesaurus/Api/Data/ThesaurusSearchResultsInterface.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile_ElasticSuiteThesaurus
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2016 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\ElasticSuiteThesaurus\Api\Data;
+
+use \Magento\Framework\Api\SearchResultsInterface;
+
+/**
+ * Search Result Interface for Thesaurus
+ *
+ * @category Smile
+ * @package  Smile_ElasticSuiteThesaurus
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+interface ThesaurusSearchResultsInterface extends SearchResultsInterface
+{
+    /**
+     * Get seller list.
+     *
+     * @return \Smile\ElasticSuiteThesaurus\Api\Data\ThesaurusInterface[]
+     */
+    public function getItems();
+
+    /**
+     * Set seller list.
+     *
+     * @param \Smile\ElasticSuiteThesaurus\Api\Data\ThesaurusInterface[] $items list of thesaurus
+     *
+     * @return \Smile\ElasticSuiteThesaurus\Api\Data\ThesaurusSearchResultsInterface
+     */
+    public function setItems(array $items);
+}

--- a/src/module-elasticsuite-thesaurus/Api/ThesaurusRepositoryInterface.php
+++ b/src/module-elasticsuite-thesaurus/Api/ThesaurusRepositoryInterface.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile_ElasticSuiteThesaurus
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2016 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+
+namespace Smile\ElasticSuiteThesaurus\Api;
+
+/**
+ * Thesaurus Repository interface
+ *
+ * @category Smile
+ * @package  Smile_ElasticSuiteThesaurus
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+interface ThesaurusRepositoryInterface
+{
+    /**
+     * Retrieve a thesaurus by its ID
+     *
+     * @param int $thesaurusId id of the thesaurus
+     *
+     * @return \Smile\ElasticSuiteThesaurus\Api\Data\ThesaurusInterface
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    public function getById($thesaurusId);
+
+    /**
+     * save a Thesaurus
+     *
+     * @param \Smile\ElasticSuiteThesaurus\Api\Data\ThesaurusInterface $thesaurus Thesaurus
+     *
+     * @return \Smile\ElasticSuiteThesaurus\Api\Data\ThesaurusInterface
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    public function save(\Smile\ElasticSuiteThesaurus\Api\Data\ThesaurusInterface $thesaurus);
+
+    /**
+     * delete a Thesaurus
+     *
+     * @param \Smile\ElasticSuiteThesaurus\Api\Data\ThesaurusInterface $thesaurus Thesaurus
+     *
+     * @return \Smile\ElasticSuiteThesaurus\Api\Data\ThesaurusInterface
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    public function delete(\Smile\ElasticSuiteThesaurus\Api\Data\ThesaurusInterface $thesaurus);
+}

--- a/src/module-elasticsuite-thesaurus/Block/Adminhtml/Thesaurus.php
+++ b/src/module-elasticsuite-thesaurus/Block/Adminhtml/Thesaurus.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile_ElasticSuiteThesaurus
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2016 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\ElasticSuiteThesaurus\Block\Adminhtml;
+
+use Magento\Backend\Block\Widget\Grid\Container as GridContainer;
+
+/**
+ * Thesaurus Grid container
+ *
+ * @category Smile
+ * @package  Smile_ElasticSuiteThesaurus
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class Thesaurus extends GridContainer
+{
+    /**
+     * @return string
+     */
+    public function getCreateUrl()
+    {
+        return $this->getUrl('*/*/create');
+    }
+
+    /**
+     * @SuppressWarnings(PHPMD.CamelCaseMethodName)
+     *
+     * @return void
+     */
+    // @codingStandardsIgnoreStart Method is inherited
+    protected function _construct()
+    {
+        // @codingStandardsIgnoreEnd
+        $this->_controller = 'thesaurus';
+        $this->_headerText = __('Thesaurus');
+        $this->_addButtonLabel = __('Add New Thesaurus');
+
+        parent::_construct();
+    }
+}

--- a/src/module-elasticsuite-thesaurus/Block/Adminhtml/Thesaurus/Create.php
+++ b/src/module-elasticsuite-thesaurus/Block/Adminhtml/Thesaurus/Create.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile_ElasticSuiteThesaurus
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2016 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\ElasticSuiteThesaurus\Block\Adminhtml\Thesaurus;
+
+/**
+ * Thesaurus creation form container
+ *
+ * @category Smile
+ * @package  Smile_ElasticSuiteThesaurus
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class Create extends \Magento\Backend\Block\Widget\Form\Container
+{
+    /**
+     * Core registry
+     *
+     * @var \Magento\Framework\Registry
+     */
+    protected $coreRegistry;
+
+    /**
+     * Constructor
+     *
+     * @param \Magento\Backend\Block\Widget\Context $context  Current context
+     * @param \Magento\Framework\Registry           $registry The registry
+     * @param array                                 $data     Block parameters
+     */
+    public function __construct(
+        \Magento\Backend\Block\Widget\Context $context,
+        \Magento\Framework\Registry $registry,
+        array $data = []
+    ) {
+        $this->coreRegistry = $registry;
+        $this->_mode = "create";
+
+        parent::__construct($context, $data);
+
+        $this->setFormActionUrl($this->getUrl('*/*/create'));
+    }
+
+    /**
+     * Internal constructor
+     *
+     * @SuppressWarnings(PHPMD.CamelCaseMethodName)
+     *
+     * @return void
+     */
+    // @codingStandardsIgnoreStart Method is inherited
+    protected function _construct()
+    {
+        // @codingStandardsIgnoreEnd
+        $this->_objectId = 'id';
+        $this->_blockGroup = 'Smile_ElasticSuiteThesaurus';
+        $this->_controller = 'adminhtml_thesaurus';
+
+        parent::_construct();
+
+        $this->buttonList->update('save', 'label', __('Create Thesaurus'));
+    }
+}

--- a/src/module-elasticsuite-thesaurus/Block/Adminhtml/Thesaurus/Create/Form.php
+++ b/src/module-elasticsuite-thesaurus/Block/Adminhtml/Thesaurus/Create/Form.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile_ElasticSuiteThesaurus
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2016 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\ElasticSuiteThesaurus\Block\Adminhtml\Thesaurus\Create;
+
+use Smile\ElasticSuiteThesaurus\Api\Data\ThesaurusInterface;
+
+/**
+ * Thesaurus creation form
+ *
+ * @category Smile
+ * @package  Smile_ElasticSuiteThesaurus
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class Form extends \Magento\Backend\Block\Widget\Form\Generic
+{
+    /**
+     * Init Form properties
+     *
+     * @SuppressWarnings(PHPMD.CamelCaseMethodName)
+     *
+     * @return void
+     */
+    // @codingStandardsIgnoreStart Method is inherited
+    protected function _construct()
+    {
+        //@codingStandardsIgnoreEnd
+        parent::_construct();
+        $this->setId('thesaurus_create_form');
+        $this->setTitle(__('Create a Thesaurus'));
+    }
+
+    /**
+     * Prepare form fields
+     *
+     * @SuppressWarnings(PHPMD.CamelCaseMethodName)
+     *
+     * @return Form
+     */
+    // @codingStandardsIgnoreStart Method is inherited
+    protected function _prepareForm()
+    {
+        //@codingStandardsIgnoreEnd
+        /** @var \Magento\Framework\Data\Form $form */
+        $form = $this->_formFactory->create(
+            ['data' => ['id' => 'edit_form', 'action' => $this->getData('action')]]
+        );
+
+        $thesaurusTypes = [
+            ['value' => ThesaurusInterface::TYPE_SYNONYM, 'label' => __('Synonym')],
+            ['value' => ThesaurusInterface::TYPE_EXPANSION, 'label' => __('Expansion')],
+        ];
+
+        $fieldset = $form->addFieldset('base_fieldset', ['legend' => __('Type')]);
+
+        $fieldset->addField(
+            'type',
+            'select',
+            [
+                'name' => 'type',
+                'label' => __('Thesarurus Type'),
+                'title' => __('Thesarurus Type'),
+                'values' => $thesaurusTypes,
+            ]
+        );
+
+        $form->setUseContainer(true);
+        $this->setForm($form);
+
+        return parent::_prepareForm();
+    }
+}

--- a/src/module-elasticsuite-thesaurus/Block/Adminhtml/Thesaurus/Edit.php
+++ b/src/module-elasticsuite-thesaurus/Block/Adminhtml/Thesaurus/Edit.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile_ElasticSuiteThesaurus
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2016 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\ElasticSuiteThesaurus\Block\Adminhtml\Thesaurus;
+
+use Smile\ElasticSuiteThesaurus\Api\Data\ThesaurusInterface;
+
+/**
+ * Thesaurus edition form container
+ *
+ * @category Smile
+ * @package  Smile_ElasticSuiteThesaurus
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class Edit extends \Magento\Backend\Block\Widget\Form\Container
+{
+    /**
+     * Core registry
+     *
+     * @var \Magento\Framework\Registry
+     */
+    protected $coreRegistry;
+
+    /**
+     * Constructor
+     *
+     * @param \Magento\Backend\Block\Widget\Context $context  Current context
+     * @param \Magento\Framework\Registry           $registry The registry
+     * @param array                                 $data     Block parameters
+     */
+    public function __construct(
+        \Magento\Backend\Block\Widget\Context $context,
+        \Magento\Framework\Registry $registry,
+        array $data = []
+    ) {
+        $this->coreRegistry = $registry;
+        parent::__construct($context, $data);
+    }
+
+    /**
+     * Internal constructor
+     *
+     * @SuppressWarnings(PHPMD.CamelCaseMethodName)
+     *
+     * @return void
+     */
+    // @codingStandardsIgnoreStart Method is inherited
+    protected function _construct()
+    {
+        // @codingStandardsIgnoreEnd
+        $this->_objectId = ThesaurusInterface::THESAURUS_ID;
+        $this->_blockGroup = 'Smile_ElasticSuiteThesaurus';
+        $this->_controller = 'adminhtml_thesaurus';
+
+        parent::_construct();
+
+        $this->buttonList->update('save', 'label', __('Save Thesaurus'));
+
+        $this->addButton(
+            'save_and_edit_button',
+            [
+                'label' => __('Save and Continue Edit'),
+                'class' => 'save',
+                'data_attribute' => [
+                    'mage-init' => [
+                        'button' => ['event' => 'saveAndContinueEdit', 'target' => '#edit_form'],
+                    ],
+                ],
+            ]
+        );
+
+        $this->buttonList->update('delete', 'label', __('Delete Thesaurus'));
+
+    }
+}

--- a/src/module-elasticsuite-thesaurus/Block/Adminhtml/Thesaurus/Edit/Form.php
+++ b/src/module-elasticsuite-thesaurus/Block/Adminhtml/Thesaurus/Edit/Form.php
@@ -1,0 +1,250 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile_ElasticSuiteThesaurus
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2016 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\ElasticSuiteThesaurus\Block\Adminhtml\Thesaurus\Edit;
+
+use Magento\Backend\Block\Template\Context;
+use Magento\Config\Model\Config\Source\Yesno;
+use Magento\Framework\Data\FormFactory;
+use Magento\Framework\Registry;
+use Magento\Store\Model\System\Store;
+use Smile\ElasticSuiteThesaurus\Api\Data\ThesaurusInterface;
+
+/**
+ * Thesaurus Edit form
+ *
+ * @category Smile
+ * @package  Smile_ElasticSuiteThesaurus
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class Form extends \Magento\Backend\Block\Widget\Form\Generic
+{
+    /**
+     * @var Store
+     */
+    private $systemStore;
+
+
+    /**
+     * Constructor
+     *
+     * @param Context                     $context     Application context
+     * @param \Magento\Framework\Registry $registry    The registry
+     * @param FormFactory                 $formFactory Form factory
+     * @param Store                       $systemStore Store Provider
+     * @param array                       $data        Object data
+     */
+    public function __construct(
+        Context $context,
+        Registry $registry,
+        FormFactory $formFactory,
+        Store $systemStore,
+        array $data = []
+    ) {
+        $this->systemStore = $systemStore;
+        parent::__construct($context, $registry, $formFactory, $data);
+    }
+
+    /**
+     * Init Form properties
+     * @SuppressWarnings(PHPMD.CamelCaseMethodName)
+     *
+     * @return void
+     */
+    // @codingStandardsIgnoreStart Method is inherited
+    protected function _construct()
+    {
+        //@codingStandardsIgnoreEnd
+        parent::_construct();
+        $this->setId('thesaurus_edit_form');
+        $this->setTitle(__('Edit a Thesaurus'));
+    }
+
+    /**
+     * Prepare form fields
+     * @SuppressWarnings(PHPMD.CamelCaseMethodName)
+     *
+     * @return Form
+     */
+    // @codingStandardsIgnoreStart Method is inherited
+    protected function _prepareForm()
+    {
+        //@codingStandardsIgnoreEnd
+
+        $model = $this->getModel();
+
+        /** @var \Magento\Framework\Data\Form $form */
+        $form = $this->_formFactory->create(
+            ['data' => ['id' => 'edit_form', 'action' => $this->getData('action'), 'method' => 'post']]
+        );
+
+        $fieldset = $form->addFieldset('base_fieldset', ['legend' => __('General Information')]);
+
+        if ($model->getId()) {
+            $fieldset->addField('thesaurus_id', 'hidden', ['name' => 'thesaurus_id']);
+        }
+
+        if ($model->getType()) {
+            $fieldset->addField('type', 'hidden', ['name' => 'type']);
+        }
+
+        $this->initBaseFields($fieldset, $model);
+        $this->initTypeFields($fieldset, $model);
+
+        $form->setValues($model->getData());
+
+        $form->setUseContainer(true);
+        $this->setForm($form);
+
+        return parent::_prepareForm();
+    }
+
+    /**
+     * Init base fields :
+     *  - thesaurus name
+     *  - store id
+     *
+     * @param \Magento\Framework\Data\Form\Element\Fieldset     $fieldset The fieldset
+     * @param \Smile\ElasticSuiteThesaurus\Model\Thesaurus|null $model    Current Thesaurus
+     *
+     * @throws \Magento\Framework\Exception\LocalizedException
+     * @SuppressWarnings(PHPMD.ElseExpression)
+     *
+     * @return \Smile\ElasticSuiteThesaurus\Block\Adminhtml\Thesaurus\Edit\Form
+     */
+    private function initBaseFields($fieldset, $model)
+    {
+        $fieldset->addField(
+            'name',
+            'text',
+            [
+                'name'     => 'name',
+                'label'    => __('Thesaurus Name'),
+                'title'    => __('Thesaurus Name'),
+                'required' => true,
+            ]
+        );
+
+        if (!$this->_storeManager->isSingleStoreMode()) {
+            $field = $fieldset->addField(
+                'store_id',
+                'multiselect',
+                [
+                    'name'     => 'stores[]',
+                    'label'    => __('Store'),
+                    'title'    => __('Store'),
+                    'values'   => $this->systemStore->getStoreValuesForForm(true, false),
+                    'required' => true,
+                ]
+            );
+            $renderer = $this->getLayout()->createBlock(
+                'Magento\Backend\Block\Store\Switcher\Form\Renderer\Fieldset\Element'
+            );
+
+            $field->setRenderer($renderer);
+        } else {
+            $fieldset->addField('store_id', 'hidden', ['name' => 'store_id']);
+            $model->setStoreIds([$this->_storeManager->getStore(true)->getId()]);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Init type fields : fields are different according to thesaurus type
+     *
+     * @param \Magento\Framework\Data\Form\Element\Fieldset     $fieldset The fieldset
+     * @param \Smile\ElasticSuiteThesaurus\Model\Thesaurus|null $model    Current Thesaurus
+     *
+     * @return \Smile\ElasticSuiteThesaurus\Block\Adminhtml\Thesaurus\Edit\Form
+     */
+    private function initTypeFields($fieldset, $model)
+    {
+        if ($model->getType() === ThesaurusInterface::TYPE_EXPANSION) {
+            $this->addExpansionFields($fieldset, $model);
+        } elseif ($model->getType() === ThesaurusInterface::TYPE_SYNONYM) {
+            $this->addSynonymFields($fieldset, $model);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Adding expansion-related fields
+     *
+     * @param \Magento\Framework\Data\Form\Element\Fieldset     $fieldset The fieldset
+     * @param \Smile\ElasticSuiteThesaurus\Model\Thesaurus|null $model    Current Thesaurus
+     *
+     * @return \Smile\ElasticSuiteThesaurus\Block\Adminhtml\Thesaurus\Edit\Form
+     */
+    private function addExpansionFields($fieldset, $model)
+    {
+        $form = $fieldset->getForm();
+
+        /* @var $bagRenderer \Smile\ElasticSuiteThesaurus\Block\Adminhtml\Thesaurus\Renderer\Expansions */
+        $bagRenderer = $this->getLayout()->createBlock(
+            'Smile\ElasticSuiteThesaurus\Block\Adminhtml\Thesaurus\Renderer\Expansions'
+        )->setForm($fieldset->getForm());
+
+        $fieldset = $form->addFieldset('bag_of_words_fieldset', ['legend' => __('Bag of words')]);
+        $fieldset->addField('bag_of_words', 'note', []);
+
+        $form->getElement('bag_of_words_fieldset')
+            ->setName('terms_relations')
+            ->setValue($model->getTermsData())
+            ->setRenderer($bagRenderer);
+        $form->getElement('bag_of_words_fieldset')->getRenderer()->setValues($model->getTermsData());
+
+        return $this;
+    }
+
+    /**
+     * Adding synonym-related fields
+     *
+     * @param \Magento\Framework\Data\Form\Element\Fieldset     $fieldset The fieldset
+     * @param \Smile\ElasticSuiteThesaurus\Model\Thesaurus|null $model    Current Thesaurus
+     *
+     * @return \Smile\ElasticSuiteThesaurus\Block\Adminhtml\Thesaurus\Edit\Form
+     */
+    private function addSynonymFields($fieldset, $model)
+    {
+        $form = $fieldset->getForm();
+
+        /* @var $synonymsRenderer \Smile\ElasticSuiteThesaurus\Block\Adminhtml\Thesaurus\Renderer\Synonym */
+        $synonymsRenderer = $this->getLayout()->createBlock(
+            'Smile\ElasticSuiteThesaurus\Block\Adminhtml\Thesaurus\Renderer\Synonyms'
+        )->setForm($fieldset->getForm());
+
+        $fieldset = $form->addFieldset('synonyms_fieldset', ['legend' => __('Synonyms')]);
+        $fieldset->addField('synonyms', 'note', []);
+        $form->getElement('synonyms_fieldset')
+            ->setName('terms_relations')
+            ->setValue($model->getTermsData())
+            ->setRenderer($synonymsRenderer);
+        $form->getElement('synonyms_fieldset')->getRenderer()->setValues($model->getTermsData());
+
+        return $this;
+    }
+
+    /**
+     * Retrieve current model if any
+     *
+     * @return \Smile\ElasticSuiteThesaurus\Model\Thesaurus
+     */
+    private function getModel()
+    {
+        /* @var $model \Smile\ElasticSuiteThesaurus\Model\Thesaurus */
+        $model = $this->_coreRegistry->registry('current_thesaurus');
+
+        return $model;
+    }
+}

--- a/src/module-elasticsuite-thesaurus/Block/Adminhtml/Thesaurus/Grid.php
+++ b/src/module-elasticsuite-thesaurus/Block/Adminhtml/Thesaurus/Grid.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile_ElasticSuiteThesaurus
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2016 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\ElasticSuiteThesaurus\Block\Adminhtml\Thesaurus;
+
+/**
+ * Adminhtml Grid for Thesaurus
+ *
+ * @category Smile
+ * @package  Smile_ElasticSuiteThesaurus
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class Grid extends \Magento\Backend\Block\Widget\Grid
+{
+    /**
+     * Append custom filter for Store Id
+     *
+     * @SuppressWarnings(PHPMD.CamelCaseMethodName)
+     */
+    // @codingStandardsIgnoreStart Method is inherited
+    protected function _preparePage()
+    {
+        //@codingStandardsIgnoreEnd
+        parent::_preparePage();
+        $this->getColumnSet()->getChildBlock('store_id')->setFilterConditionCallback([$this, 'filterStoreCondition']);
+        $this->getColumnSet()->getChildBlock('thesaurus_terms_summary')->setFilterConditionCallback([$this, 'filterTermsCondition']);
+    }
+
+    /**
+     * Apply store filter
+     *
+     * @param \Magento\Framework\Data\Collection        $collection The collection
+     * @param \Magento\Backend\Block\Widget\Grid\Column $column     Columns to filter
+     */
+    protected function filterStoreCondition($collection, $column)
+    {
+        if (!($value = $column->getFilter()->getValue())) {
+            return;
+        }
+
+        $collection->addStoreFilter($value);
+    }
+
+    /**
+     * Apply term filter
+     *
+     * @param \Magento\Framework\Data\Collection        $collection The collection
+     * @param \Magento\Backend\Block\Widget\Grid\Column $column     Columns to filter
+     */
+    protected function filterTermsCondition($collection, $column)
+    {
+        if (!($value = $column->getFilter()->getValue())) {
+            return;
+        }
+
+        $collection->setTermFilter($value);
+    }
+}

--- a/src/module-elasticsuite-thesaurus/Block/Adminhtml/Thesaurus/Renderer/AbstractRenderer.php
+++ b/src/module-elasticsuite-thesaurus/Block/Adminhtml/Thesaurus/Renderer/AbstractRenderer.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile_ElasticSuiteThesaurus
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2016 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\ElasticSuiteThesaurus\Block\Adminhtml\Thesaurus\Renderer;
+
+/**
+ * Abstract Renderer for array-composite fields
+ *
+ * @category Smile
+ * @package  Smile_ElasticSuiteThesaurus
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class AbstractRenderer extends \Magento\Config\Block\System\Config\Form\Field\FieldArray\AbstractFieldArray
+{
+    /**
+     * @var int Size of the textarea to display
+     */
+    protected $textAreaColsNumber = 100;
+
+    /**
+     * @var \Magento\Framework\Data\Form\Element\Factory
+     */
+    protected $elementFactory;
+
+    /**
+     * @param \Magento\Backend\Block\Template\Context      $context        Application context
+     * @param \Magento\Framework\Data\Form\Element\Factory $elementFactory Element Factory
+     * @param array                                        $data           Element Data
+     */
+    public function __construct(
+        \Magento\Backend\Block\Template\Context $context,
+        \Magento\Framework\Data\Form\Element\Factory $elementFactory,
+        array $data = []
+    ) {
+        $this->elementFactory = $elementFactory;
+
+        parent::__construct($context, $data);
+    }
+
+    /**
+     * Render array cell for JS template
+     *
+     * @param string $columnName The column name
+     *
+     * @return string
+     */
+    public function renderCellTemplate($columnName)
+    {
+        if ($columnName == 'term_id' && isset($this->_columns[$columnName])) {
+            $element = $this->elementFactory->create('hidden');
+            $element->setId("term_id")->setName("term_id");
+            $element->setForm($this->getForm())
+                ->setName($this->_getCellInputElementName($columnName))
+                ->setHtmlId($this->_getCellInputElementId('<%- _id %>', $columnName));
+
+            return $element->getElementHtml();
+        }
+
+        if ($columnName == 'values' && isset($this->_columns[$columnName])) {
+            $element = $this->elementFactory->create('textarea');
+            $element->setCols($this->textAreaColsNumber)
+                ->setForm($this->getForm())
+                ->setName($this->_getCellInputElementName($columnName))
+                ->setHtmlId($this->_getCellInputElementId('<%- _id %>', $columnName));
+
+            return str_replace("\n", '', $element->getElementHtml());
+        }
+
+        return parent::renderCellTemplate($columnName);
+    }
+
+    /**
+     * Render given element (return html of element)
+     *
+     * @param \Magento\Framework\Data\Form\Element\AbstractElement $element The element
+     *
+     * @return string
+     */
+    public function render(\Magento\Framework\Data\Form\Element\AbstractElement $element)
+    {
+        if ($this->getValues()) {
+            $element->setValue($this->getValues());
+        }
+
+        $this->setElement($element);
+
+        return $this->toHtml();
+    }
+}

--- a/src/module-elasticsuite-thesaurus/Block/Adminhtml/Thesaurus/Renderer/Expansions.php
+++ b/src/module-elasticsuite-thesaurus/Block/Adminhtml/Thesaurus/Renderer/Expansions.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile_ElasticSuiteThesaurus
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2016 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\ElasticSuiteThesaurus\Block\Adminhtml\Thesaurus\Renderer;
+
+/**
+ * Renderer for "bag of words" elements
+ *
+ * @category Smile
+ * @package  Smile_ElasticSuiteThesaurus
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class Expansions extends AbstractRenderer
+{
+    /**
+     * Initialise form fields
+     *
+     * @SuppressWarnings(PHPMD.CamelCaseMethodName)
+     */
+    // @codingStandardsIgnoreStart Method is inherited
+    protected function _construct()
+    {
+        //@codingStandardsIgnoreEnd
+        $this->addColumn('term_id', ['label' => __('')]);
+        $this->addColumn('reference_term', ['label' => __('Reference Term')]);
+        $this->addColumn('values', ['label' => __('Expansion terms')]);
+        $this->_addAfter = false;
+        $this->_addButtonLabel = __('Add Expansion');
+
+        parent::_construct();
+    }
+}

--- a/src/module-elasticsuite-thesaurus/Block/Adminhtml/Thesaurus/Renderer/Synonyms.php
+++ b/src/module-elasticsuite-thesaurus/Block/Adminhtml/Thesaurus/Renderer/Synonyms.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile_ElasticSuiteThesaurus
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2016 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\ElasticSuiteThesaurus\Block\Adminhtml\Thesaurus\Renderer;
+
+/**
+ * Renderer for synonyms inputs
+ *
+ * @category Smile
+ * @package  Smile_ElasticSuiteThesaurus
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class Synonyms extends AbstractRenderer
+{
+    /**
+     * @var int Size of the textarea to display
+     */
+    protected $textAreaColsNumber = 120;
+
+    /**
+     * Initialise form fields
+     *
+     * @SuppressWarnings(PHPMD.CamelCaseMethodName)
+     */
+    // @codingStandardsIgnoreStart Method is inherited
+    protected function _construct()
+    {
+        //@codingStandardsIgnoreEnd
+        $this->addColumn('term_id', ['label' => __('')]);
+        $this->addColumn(
+            'values',
+            ['label' => __('Synonym terms')]
+        );
+
+        $this->_addAfter = false;
+        $this->_addButtonLabel = __('Add Synonym');
+
+        parent::_construct();
+    }
+}

--- a/src/module-elasticsuite-thesaurus/Controller/Adminhtml/AbstractThesaurus.php
+++ b/src/module-elasticsuite-thesaurus/Controller/Adminhtml/AbstractThesaurus.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile_ElasticSuiteThesaurus
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2016 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\ElasticSuiteThesaurus\Controller\Adminhtml;
+
+use Magento\Backend\App\Action;
+use Magento\Framework\View\Result\PageFactory;
+use Smile\ElasticSuiteThesaurus\Api\ThesaurusRepositoryInterface;
+use Smile\ElasticSuiteThesaurus\Model\ThesaurusFactory;
+
+/**
+ * Abstract Thesaurus controller
+ *
+ * @category Smile
+ * @package  Smile_ElasticSuiteThesaurus
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+abstract class AbstractThesaurus extends Action
+{
+    /**
+     * @var \Magento\Framework\View\Result\PageFactory|null
+     */
+    protected $resultPageFactory = null;
+
+    /**
+     * Core registry
+     *
+     * @var \Magento\Framework\Registry
+     */
+    protected $coreRegistry;
+
+    /**
+     * @var ThesaurusRepositoryInterface
+     */
+    protected $thesaurusRepository;
+
+    /**
+     * Thesaurus Factory
+     *
+     * @var ThesaurusFactory
+     */
+    protected $thesaurusFactory;
+
+
+    /**
+     * Abstract constructor.
+     *
+     * @param \Magento\Backend\App\Action\Context        $context             Application context
+     * @param \Magento\Framework\View\Result\PageFactory $resultPageFactory   Tesult Page factory
+     * @param \Magento\Framework\Registry                $coreRegistry        Application registry
+     * @param ThesaurusRepositoryInterface               $thesaurusRepository Thesaurus Repository
+     * @param ThesaurusFactory                           $thesaurusFactory    Thesaurus Factory
+     */
+    public function __construct(
+        \Magento\Backend\App\Action\Context $context,
+        PageFactory $resultPageFactory,
+        \Magento\Framework\Registry $coreRegistry,
+        ThesaurusRepositoryInterface $thesaurusRepository,
+        ThesaurusFactory $thesaurusFactory
+    ) {
+        $this->resultPageFactory   = $resultPageFactory;
+        $this->coreRegistry        = $coreRegistry;
+        $this->thesaurusRepository = $thesaurusRepository;
+        $this->thesaurusFactory    = $thesaurusFactory;
+
+        parent::__construct($context);
+    }
+
+    /**
+     * Create result page
+     *
+     * @return \Magento\Backend\Model\View\Result\Page
+     */
+    protected function createPage()
+    {
+        /** @var \Magento\Backend\Model\View\Result\Page $resultPage */
+        $resultPage = $this->resultPageFactory->create();
+        $resultPage->setActiveMenu('Smile_ElasticsuiteThesaurus::manage')
+            ->addBreadcrumb(__('Thesaurus'), __('Thesaurus'));
+
+        return $resultPage;
+    }
+
+    /**
+     * @SuppressWarnings(PHPMD.CamelCaseMethodName)
+     *
+     * Check if allowed to manage thesaurus
+     *
+     * @return bool
+     */
+    // @codingStandardsIgnoreStart Method is inherited
+    protected function _isAllowed()
+    {
+        //@codingStandardsIgnoreEnd
+        return $this->_authorization->isAllowed('Smile_ElasticsuiteThesaurus::manage');
+    }
+}

--- a/src/module-elasticsuite-thesaurus/Controller/Adminhtml/Thesaurus/Create.php
+++ b/src/module-elasticsuite-thesaurus/Controller/Adminhtml/Thesaurus/Create.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile_ElasticSuiteThesaurus
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2016 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\ElasticSuiteThesaurus\Controller\Adminhtml\Thesaurus;
+
+use Smile\ElasticSuiteThesaurus\Controller\Adminhtml\AbstractThesaurus as ThesaurusController;
+
+/**
+ * Thesaurus creation controller
+ *
+ * @category Smile
+ * @package  Smile_ElasticSuiteThesaurus
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class Create extends ThesaurusController
+{
+    /**
+     * Render Thesaurus creation screen
+     *
+     * @return \Magento\Backend\Model\View\Result\Page
+     */
+    public function execute()
+    {
+        $resultPage = $this->createPage();
+
+        if ($this->getRequest()->getParam("type")) {
+            $this->_forward('edit');
+
+            return $resultPage;
+        }
+
+        $resultPage->getConfig()->getTitle()->prepend(__('Create Thesaurus'));
+        $resultPage->addBreadcrumb(__('Thesaurus'), __('Thesaurus'));
+
+        return $resultPage;
+    }
+}

--- a/src/module-elasticsuite-thesaurus/Controller/Adminhtml/Thesaurus/Delete.php
+++ b/src/module-elasticsuite-thesaurus/Controller/Adminhtml/Thesaurus/Delete.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile_ElasticSuiteThesaurus
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2016 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\ElasticSuiteThesaurus\Controller\Adminhtml\Thesaurus;
+
+use Smile\ElasticSuiteThesaurus\Controller\Adminhtml\AbstractThesaurus as ThesaurusController;
+
+/**
+ * Delete action for Thesaurus
+ *
+ * @category Smile
+ * @package  Smile_ElasticSuiteThesaurus
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class Delete extends ThesaurusController
+{
+    /**
+     * Delete a Thesaurus
+     *
+     * @return \Magento\Backend\Model\View\Result\Redirect
+     */
+    public function execute()
+    {
+        /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
+        $resultRedirect = $this->resultRedirectFactory->create();
+
+        $identifier = $this->getRequest()->getParam('thesaurus_id', false);
+        $model = $this->thesaurusFactory->create();
+        if ($identifier) {
+            $model->load($identifier);
+            if (!$model->getThesaurusId()) {
+                $this->messageManager->addError(__('This thesaurus no longer exists.'));
+
+                return $resultRedirect->setPath('*/*/index');
+            }
+        }
+
+        try {
+            $this->thesaurusRepository->delete($model);
+            $this->messageManager->addSuccess(__('You deleted the thesaurus %1.', $model->getName()));
+
+            return $resultRedirect->setPath('*/*/index');
+        } catch (\Exception $e) {
+            $this->messageManager->addError($e->getMessage());
+
+            return $resultRedirect->setPath('*/*/edit', ['thesaurus_id' => $this->getRequest()->getParam('thesaurus_id')]);
+        }
+    }
+}

--- a/src/module-elasticsuite-thesaurus/Controller/Adminhtml/Thesaurus/Edit.php
+++ b/src/module-elasticsuite-thesaurus/Controller/Adminhtml/Thesaurus/Edit.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile_ElasticSuiteThesaurus
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2016 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\ElasticSuiteThesaurus\Controller\Adminhtml\Thesaurus;
+
+use Magento\Backend\App\Action\Context;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\View\Result\PageFactory;
+use Smile\ElasticSuiteThesaurus\Api\Data\ThesaurusInterface;
+use Smile\ElasticSuiteThesaurus\Api\ThesaurusRepositoryInterface;
+use Smile\ElasticSuiteThesaurus\Controller\Adminhtml\AbstractThesaurus as ThesaurusController;
+use Smile\ElasticSuiteThesaurus\Model\ThesaurusFactory;
+
+/**
+ * Thesaurus edition controller
+ *
+ * @category Smile
+ * @package  Smile_ElasticSuiteThesaurus
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class Edit extends ThesaurusController
+{
+    /**
+     * Render Thesaurus edition screen
+     *
+     * @return \Magento\Backend\Model\View\Result\Page
+     */
+    public function execute()
+    {
+        $resultPage = $this->createPage();
+
+        $thesaurusId = (int) $this->getRequest()->getParam(ThesaurusInterface::THESAURUS_ID);
+        $type        = (string) $this->getRequest()->getParam('type');
+
+        $thesaurus = null;
+        $isExistingThesaurus = (bool) $thesaurusId;
+
+        if ($isExistingThesaurus) {
+            try {
+                $thesaurus = $this->thesaurusRepository->getById($thesaurusId);
+                $resultPage->getConfig()->getTitle()->prepend(
+                    __('Edit %1 (%2)', $thesaurus->getName(), $thesaurus->getType())
+                );
+            } catch (NoSuchEntityException $e) {
+                $this->messageManager->addException($e, __('Something went wrong while editing the thesaurus.'));
+                $resultRedirect = $this->resultRedirectFactory->create();
+                $resultRedirect->setPath('*/*/index');
+
+                return $resultRedirect;
+            }
+        }
+
+        if (!$isExistingThesaurus) {
+            $thesaurus = $this->thesaurusFactory->create();
+            $thesaurus->setType($type);
+            $resultPage->getConfig()->getTitle()->prepend(__('New Thesaurus (%1)', $type));
+        }
+
+        $this->coreRegistry->register('current_thesaurus', $thesaurus);
+        $resultPage->addBreadcrumb(__('Thesaurus'), __('Thesaurus'));
+
+        return $resultPage;
+    }
+}

--- a/src/module-elasticsuite-thesaurus/Controller/Adminhtml/Thesaurus/Index.php
+++ b/src/module-elasticsuite-thesaurus/Controller/Adminhtml/Thesaurus/Index.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile_ElasticSuiteThesaurus
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2016 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\ElasticSuiteThesaurus\Controller\Adminhtml\Thesaurus;
+
+use Smile\ElasticSuiteThesaurus\Controller\Adminhtml\AbstractThesaurus as ThesaurusController;
+
+/**
+ * Thesaurus index grid controller
+ *
+ * @category Smile
+ * @package  Smile_ElasticSuiteThesaurus
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class Index extends ThesaurusController
+{
+    /**
+     * Render Thesaurus grid
+     *
+     * @return \Magento\Backend\Model\View\Result\Page
+     */
+    public function execute()
+    {
+        $resultPage = $this->createPage();
+        $resultPage->getConfig()->getTitle()->prepend(__('Thesaurus'));
+        $resultPage->addBreadcrumb(__('Thesaurus'), __('Thesaurus'));
+
+        return $resultPage;
+    }
+}

--- a/src/module-elasticsuite-thesaurus/Controller/Adminhtml/Thesaurus/MassDelete.php
+++ b/src/module-elasticsuite-thesaurus/Controller/Adminhtml/Thesaurus/MassDelete.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile_ElasticSuiteThesaurus
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2016 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\ElasticSuiteThesaurus\Controller\Adminhtml\Thesaurus;
+
+use Smile\ElasticSuiteThesaurus\Controller\Adminhtml\AbstractThesaurus as ThesaurusController;
+
+/**
+ * Massive deletion action for Thesaurus
+ *
+ * @category Smile
+ * @package  Smile_ElasticSuiteThesaurus
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class MassDelete extends ThesaurusController
+{
+    /**
+     * Delete a Thesaurus
+     *
+     * @return \Magento\Backend\Model\View\Result\Redirect
+     */
+    public function execute()
+    {
+        /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
+        $resultRedirect = $this->resultRedirectFactory->create();
+
+        $thesauriIds = $this->getRequest()->getParam('thesauri');
+        if (!is_array($thesauriIds)) {
+            $this->messageManager->addError(__('Please select searches.'));
+
+            return $resultRedirect->setPath('*/*/index');
+        }
+
+        try {
+            foreach ($thesauriIds as $searchId) {
+                $model = $this->thesaurusFactory->create();
+                $model->load($searchId);
+                if (!$model->getThesaurusId()) {
+                    $this->messageManager->addError(__('This thesaurus no longer exists.'));
+
+                    return $resultRedirect->setPath('*/*/index');
+                }
+                $this->thesaurusRepository->delete($model);
+            }
+            $this->messageManager->addSuccess(__('Total of %1 record(s) were deleted.', count($thesauriIds)));
+        } catch (\Exception $e) {
+            $this->messageManager->addError($e->getMessage());
+        }
+
+        return $resultRedirect->setPath('*/*/index');
+    }
+}

--- a/src/module-elasticsuite-thesaurus/Controller/Adminhtml/Thesaurus/Save.php
+++ b/src/module-elasticsuite-thesaurus/Controller/Adminhtml/Thesaurus/Save.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile_ElasticSuiteThesaurus
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2016 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\ElasticSuiteThesaurus\Controller\Adminhtml\Thesaurus;
+
+use Magento\Backend\App\Action\Context;
+use Magento\Framework\View\Result\PageFactory;
+use Smile\ElasticSuiteThesaurus\Api\ThesaurusRepositoryInterface;
+use Smile\ElasticSuiteThesaurus\Controller\Adminhtml\AbstractThesaurus as ThesaurusController;
+use Smile\ElasticSuiteThesaurus\Model\ThesaurusFactory;
+
+/**
+ * Save action for Thesaurus
+ *
+ * @category Smile
+ * @package  Smile_ElasticSuiteThesaurus
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class Save extends ThesaurusController
+{
+    /**
+     * Save a Thesaurus
+     *
+     * @return \Magento\Backend\Model\View\Result\Redirect
+     */
+    public function execute()
+    {
+        /** @var \Magento\Backend\Model\View\Result\Redirect $resultRedirect */
+        $resultRedirect = $this->resultRedirectFactory->create();
+
+        $data         = $this->getRequest()->getPostValue();
+        $redirectBack = $this->getRequest()->getParam('back', false);
+
+        if ($data) {
+            $identifier = $this->getRequest()->getParam('thesaurus_id');
+            $model = $this->thesaurusFactory->create();
+
+            if ($identifier) {
+                $model->load($identifier);
+                if (!$model->getThesaurusId()) {
+                    $this->messageManager->addError(__('This thesaurus no longer exists.'));
+
+                    return $resultRedirect->setPath('*/*/');
+                }
+            }
+
+            $model->setData($data);
+
+            try {
+                $this->thesaurusRepository->save($model);
+                $this->messageManager->addSuccess(__('You saved the thesaurus %1.', $model->getName()));
+                $this->_objectManager->get('Magento\Backend\Model\Session')->setFormData(false);
+
+                if ($redirectBack) {
+                    return $resultRedirect->setPath('*/*/edit', ['thesaurus_id' => $model->getId()]);
+                }
+
+                return $resultRedirect->setPath('*/*/');
+            } catch (\Exception $e) {
+                $this->messageManager->addError($e->getMessage());
+                $this->_objectManager->get('Magento\Backend\Model\Session')->setFormData($data);
+
+                $returnParams = [
+                    'thesaurus_id' => $this->getRequest()->getParam('thesaurus_id'),
+                    'type'         => $this->getRequest()->getParam('type'),
+                ];
+
+                return $resultRedirect->setPath('*/*/edit', $returnParams);
+            }
+        }
+
+        return $resultRedirect->setPath('*/*/');
+    }
+}

--- a/src/module-elasticsuite-thesaurus/Model/ResourceModel/Thesaurus.php
+++ b/src/module-elasticsuite-thesaurus/Model/ResourceModel/Thesaurus.php
@@ -1,0 +1,269 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile_ElasticSuiteThesaurus
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2016 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\ElasticSuiteThesaurus\Model\ResourceModel;
+
+use Smile\ElasticSuiteThesaurus\Api\Data\ThesaurusInterface;
+
+/**
+ * Thesaurus Resource Model
+ *
+ * @category Smile
+ * @package  Smile_ElasticSuiteThesaurus
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class Thesaurus extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
+{
+    /**
+     * Retrieve Store Ids for a given thesaurus
+     *
+     * @param int $thesaurusId The thesaurus Id
+     *
+     * @return array
+     */
+    public function getStoreIdsFromThesaurusId($thesaurusId)
+    {
+        $connection = $this->getConnection();
+
+        $select = $connection->select()->from(
+            $this->getTable(ThesaurusInterface::STORE_TABLE_NAME),
+            ThesaurusInterface::STORE_ID
+        )->where(
+            ThesaurusInterface::THESAURUS_ID . ' = :thesaurus_id'
+        );
+
+        $binds = [':thesaurus_id' => (int) $thesaurusId];
+
+        return $connection->fetchCol($select, $binds);
+    }
+
+    /**
+     * Retrieve Store Ids for a given thesaurus
+     *
+     * @param \Magento\Framework\Model\AbstractModel $object The thesaurus
+     *
+     * @return array
+     */
+    public function getTermsDataFromThesaurus($object)
+    {
+        $connection = $this->getConnection();
+        $binds      = [':thesaurus_id' => (int) $object->getThesaurusId()];
+
+        $select = $connection->select()->from(
+            [ 'expansion_table' => $this->getTable(ThesaurusInterface::EXPANSION_TABLE_NAME)],
+            [
+                ThesaurusInterface::THESAURUS_ID => ThesaurusInterface::THESAURUS_ID,
+                'term_id' => 'term_id',
+                'values' => new \Zend_Db_Expr("GROUP_CONCAT( expansion_table.term SEPARATOR ',')"),
+            ]
+        )->where(
+            'expansion_table.' . ThesaurusInterface::THESAURUS_ID . ' = :thesaurus_id'
+        )->group('term_id');
+
+        // Retrieve also reference term if needed.
+        if ($object->getType() === ThesaurusInterface::TYPE_EXPANSION) {
+            $select->joinLeft(
+                ['ref' => $this->getTable(ThesaurusInterface::REFERENCE_TABLE_NAME)],
+                new \Zend_Db_Expr("ref.term_id = expansion_table.term_id"),
+                ['reference_term' => 'term']
+            );
+        }
+
+        $termsData = $connection->fetchAll($select, $binds);
+
+        return $termsData;
+    }
+
+    /**
+     * Internal Constructor
+     *
+     * @SuppressWarnings(PHPMD.CamelCaseMethodName)
+     */
+    // @codingStandardsIgnoreStart Method is inherited
+    protected function _construct()
+    {
+        //@codingStandardsIgnoreEnd
+        $this->_init(ThesaurusInterface::TABLE_NAME, ThesaurusInterface::THESAURUS_ID);
+    }
+
+    /**
+     * Saves thesaurus linking to terms and stores after save
+     *
+     * @param \Magento\Framework\Model\AbstractModel $object Thesaurus to save
+     *
+     * @SuppressWarnings(PHPMD.CamelCaseMethodName)
+     *
+     * @return $this
+     */
+    // @codingStandardsIgnoreStart Method is inherited
+    protected function _afterSave(\Magento\Framework\Model\AbstractModel $object)
+    {
+        //@codingStandardsIgnoreEnd
+        parent::_afterSave($object);
+
+        $this->saveStoreRelation($object);
+        $this->saveTermsRelation($object);
+
+        return $this;
+    }
+
+    /**
+     * Perform operations after object load, restore linking with terms and stores
+     *
+     * @param \Magento\Framework\Model\AbstractModel $object Thesaurus being loaded
+     *
+     * @SuppressWarnings(PHPMD.CamelCaseMethodName)
+     *
+     * @return $this
+     */
+    // @codingStandardsIgnoreStart Method is inherited
+    protected function _afterLoad(\Magento\Framework\Model\AbstractModel $object)
+    {
+        //@codingStandardsIgnoreEnd
+        if ($object->getId()) {
+            $stores = $this->getStoreIdsFromThesaurusId($object->getId());
+            $object->setData('store_id', $stores);
+            $object->setData('stores', $stores);
+        }
+
+        return parent::_afterLoad($object);
+    }
+
+    /**
+     * Saves relation between thesaurus and store
+     *
+     * @param \Magento\Framework\Model\AbstractModel $object Thesaurus to save
+     *
+     * @return void
+     */
+    private function saveStoreRelation(\Magento\Framework\Model\AbstractModel $object)
+    {
+        $storeIds = $object->getStoreIds();
+
+        if (is_array($storeIds) && (count($storeIds) > 0)) {
+            $storeLinks = [];
+            $deleteCondition = [ThesaurusInterface::THESAURUS_ID . " = ?" => $object->getThesaurusId()];
+
+            foreach ($storeIds as $key => $storeId) {
+                $storeLinks[] = [
+                    ThesaurusInterface::THESAURUS_ID  => (int) $object->getThesaurusId(),
+                    ThesaurusInterface::STORE_ID      => (int) $storeId,
+                ];
+                $storeIds[$key] = (int) $storeId;
+            }
+
+            $deleteCondition[ThesaurusInterface::STORE_ID . " NOT IN (?)"] = array_keys($storeIds);
+
+            $this->getConnection()->delete(
+                ThesaurusInterface::STORE_TABLE_NAME,
+                $deleteCondition
+            );
+
+            $this->getConnection()->insertOnDuplicate(
+                ThesaurusInterface::STORE_TABLE_NAME,
+                $storeLinks,
+                array_keys(current($storeLinks))
+            );
+        }
+    }
+
+    /**
+     * Saves relation between thesaurus and store
+     *
+     * @param \Magento\Framework\Model\AbstractModel $object Thesaurus to save
+     *
+     * @return void
+     */
+    private function saveTermsRelation(\Magento\Framework\Model\AbstractModel $object)
+    {
+        $termRelations = $object->getTermsRelations();
+        $termRelations = array_filter($termRelations);
+
+        if (is_array($termRelations) && (count($termRelations) > 0)) {
+            $expansionTermLinks = [];
+            $referenceTermLinks = [];
+
+            $termId = 0;
+            foreach ($termRelations as $termData) {
+                $termId++;
+
+                if ($object->getType() === ThesaurusInterface::TYPE_EXPANSION) {
+                    $referenceTermLinks[] = [
+                        'term_id'                        => $termId,
+                        'term'                           => trim(strtolower($termData['reference_term'])),
+                        ThesaurusInterface::THESAURUS_ID => (int) $object->getThesaurusId(),
+                    ];
+                }
+
+                $termList = explode(",", $termData['values']);
+                foreach ($termList as $term) {
+                    $expansionTermLinks[] = [
+                        'term_id'                        => $termId,
+                        'term'                           => trim(strtolower($term)),
+                        ThesaurusInterface::THESAURUS_ID => (int) $object->getThesaurusId(),
+                    ];
+                }
+            }
+
+            $this->deleteThesaurusRelations($object);
+
+            // Saves expansion terms for a thesaurus. Expansion terms are used by expansion AND synonym thesauri.
+            $this->getConnection()->insertOnDuplicate(
+                ThesaurusInterface::EXPANSION_TABLE_NAME,
+                $expansionTermLinks,
+                array_keys(current($expansionTermLinks))
+            );
+
+            $this->saveReferenceTerms($object, $referenceTermLinks);
+        }
+    }
+
+    /**
+     * Delete thesaurus previous relations.
+     *
+     * @param \Magento\Framework\Model\AbstractModel $object Thesaurus to save
+     *
+     * @return $this
+     */
+    private function deleteThesaurusRelations(\Magento\Framework\Model\AbstractModel $object)
+    {
+        $deleteCondition = [ThesaurusInterface::THESAURUS_ID . " = ?" => $object->getThesaurusId()];
+
+        $this->getConnection()->delete(
+            ThesaurusInterface::EXPANSION_TABLE_NAME,
+            $deleteCondition
+        );
+
+        return $this;
+    }
+
+    /**
+     * Saves reference terms for a thesaurus. Reference term are used by expansions thesaurus only.
+     *
+     * @param \Magento\Framework\Model\AbstractModel $object         Thesaurus to save
+     * @param array                                  $referenceTerms Thesaurus reference terms
+     *
+     * @return $this
+     */
+    private function saveReferenceTerms(\Magento\Framework\Model\AbstractModel $object, $referenceTerms)
+    {
+        if ($object->getType() === ThesaurusInterface::TYPE_EXPANSION) {
+            $this->getConnection()->insertOnDuplicate(
+                ThesaurusInterface::REFERENCE_TABLE_NAME,
+                $referenceTerms,
+                array_keys(current($referenceTerms))
+            );
+        }
+
+        return $this;
+    }
+}

--- a/src/module-elasticsuite-thesaurus/Model/ResourceModel/Thesaurus/Collection.php
+++ b/src/module-elasticsuite-thesaurus/Model/ResourceModel/Thesaurus/Collection.php
@@ -1,0 +1,316 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile_ElasticSuite________
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2016 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\ElasticSuiteThesaurus\Model\ResourceModel\Thesaurus;
+
+use Magento\Store\Model\Store;
+use Smile\ElasticSuiteThesaurus\Api\Data\ThesaurusInterface;
+
+/**
+ * Thesaurus Collection Resource Model
+ *
+ * @category Smile
+ * @package  Smile_ElasticSuiteThesaurus
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection
+{
+    /**
+     * Store for filter
+     *
+     * @var integer
+     */
+    private $storeId;
+
+    /**
+     * Store manager
+     *
+     * @var \Magento\Store\Model\StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
+     * Search resource helper
+     *
+     * @var \Magento\Framework\DB\Helper
+     */
+    private $resourceHelper;
+
+    /**
+     * If link with terms has already been established
+     *
+     * @var boolean
+     */
+    private $termsLinked = false;
+
+    /**
+     * @param \Magento\Framework\Data\Collection\EntityFactory             $entityFactory  Entity Factory
+     * @param \Psr\Log\LoggerInterface                                     $logger         Logger
+     * @param \Magento\Framework\Data\Collection\Db\FetchStrategyInterface $fetchStrategy  Fetch Strategy
+     * @param \Magento\Framework\Event\ManagerInterface                    $eventManager   Event Manager
+     * @param \Magento\Store\Model\StoreManagerInterface                   $storeManager   Store Manager
+     * @param \Magento\Framework\DB\Helper                                 $resourceHelper Resource Helper
+     * @param \Magento\Framework\DB\Adapter\AdapterInterface               $connection     Database Connection
+     * @param \Magento\Framework\Model\ResourceModel\Db\AbstractDb         $resource       Abstract Resource
+     */
+    public function __construct(
+        \Magento\Framework\Data\Collection\EntityFactoryInterface $entityFactory,
+        \Psr\Log\LoggerInterface $logger,
+        \Magento\Framework\Data\Collection\Db\FetchStrategyInterface $fetchStrategy,
+        \Magento\Framework\Event\ManagerInterface $eventManager,
+        \Magento\Store\Model\StoreManagerInterface $storeManager,
+        \Magento\Framework\DB\Helper $resourceHelper,
+        \Magento\Framework\DB\Adapter\AdapterInterface $connection = null,
+        \Magento\Framework\Model\ResourceModel\Db\AbstractDb $resource = null
+    ) {
+        $this->storeManager = $storeManager;
+        $this->resourceHelper = $resourceHelper;
+        parent::__construct($entityFactory, $logger, $fetchStrategy, $eventManager, $connection, $resource);
+    }
+
+    /**
+     * Set Store ID for filter
+     *
+     * @param Store|int $store The store
+     *
+     * @return $this
+     */
+    public function setStoreId($store)
+    {
+        if ($store instanceof Store) {
+            $store = $store->getId();
+        }
+        $this->storeId = $store;
+
+        return $this;
+    }
+
+    /**
+     * Retrieve Store ID Filter
+     *
+     * @return int|null
+     */
+    public function getStoreId()
+    {
+        return $this->storeId;
+    }
+
+    /**
+     * Set thesaurus term to filter
+     *
+     * @param string $term The term to filter
+     *
+     * @return $this
+     */
+    public function setTermFilter($term)
+    {
+        $this->initSelectWithTerms();
+
+        $this->getSelect()
+            ->where("expansion_table.term LIKE '%{$term}%'", $term)
+            ->orWhere("reference_table.term LIKE '%{$term}%'", $term);
+
+        return $this;
+    }
+
+    /**
+     * Filter collection by specified store ids
+     *
+     * @param array|int $storeIds The store ids to filter
+     *
+     * @return $this
+     */
+    public function addStoreFilter($storeIds)
+    {
+        if (!is_array($storeIds)) {
+            $storeIds = [$storeIds];
+        }
+
+        $this->getSelect()->join(
+            ['store_table' => $this->getTable(ThesaurusInterface::STORE_TABLE_NAME)],
+            'main_table.' . ThesaurusInterface::THESAURUS_ID . ' = store_table.' . ThesaurusInterface::THESAURUS_ID,
+            []
+        )->where('store_table.store_id IN (?)', $storeIds)
+            ->group('main_table.' . ThesaurusInterface::THESAURUS_ID);
+
+        return $this;
+    }
+
+    /**
+     * Join store relation table if there is store filter
+     *
+     * @SuppressWarnings(PHPMD.CamelCaseMethodName)
+     *
+     */
+    // @codingStandardsIgnoreStart Method is inherited
+    protected function _renderFiltersBefore()
+    {
+        //@codingStandardsIgnoreEnd
+        if ($this->getFilter('store')) {
+            $this->getSelect()->join(
+                ['store_table' => $this->getTable(ThesaurusInterface::STORE_TABLE_NAME)],
+                'main_table.' . ThesaurusInterface::THESAURUS_ID . ' = store_table.' . ThesaurusInterface::THESAURUS_ID,
+                []
+            )->group(
+                'main_table.' . ThesaurusInterface::THESAURUS_ID
+            );
+        }
+
+        parent::_renderFiltersBefore();
+    }
+
+    /**
+     * Init model for collection
+     *
+     * @SuppressWarnings(PHPMD.CamelCaseMethodName)
+     */
+    // @codingStandardsIgnoreStart Method is inherited
+    protected function _construct()
+    {
+        //@codingStandardsIgnoreEnd
+        $this->_init(
+            'Smile\ElasticSuiteThesaurus\Model\Thesaurus',
+            'Smile\ElasticSuiteThesaurus\Model\ResourceModel\Thesaurus'
+        );
+    }
+
+    /**
+     * Perform operations after collection load
+     *
+     * @SuppressWarnings(PHPMD.CamelCaseMethodName)
+     *
+     * @return $this
+     */
+    // @codingStandardsIgnoreStart Method is inherited
+    protected function _afterLoad()
+    {
+        //@codingStandardsIgnoreEnd
+        $this->injectStoresData(ThesaurusInterface::STORE_TABLE_NAME, ThesaurusInterface::THESAURUS_ID);
+        $this->injectTermsData();
+
+        return parent::_afterLoad();
+    }
+
+    /**
+     * Inject terms data on collection
+     *
+     * @return $this
+     */
+    private function initSelectWithTerms()
+    {
+        $select = $this->getSelect();
+
+        if ($this->termsLinked === false) {
+            $select->joinLeft(
+                ['expansion_table' => $this->getTable(ThesaurusInterface::EXPANSION_TABLE_NAME)],
+                new \Zend_Db_Expr("main_table.thesaurus_id = expansion_table.thesaurus_id"),
+                [
+                    'expansion_terms' => new \Zend_Db_Expr("GROUP_CONCAT( DISTINCT expansion_table.term SEPARATOR ',')"),
+                ]
+            );
+
+            $select->joinLeft(
+                ['reference_table' => $this->getTable(ThesaurusInterface::REFERENCE_TABLE_NAME)],
+                new \Zend_Db_Expr(
+                    "reference_table.term_id = expansion_table.term_id " .
+                    "AND main_table." . ThesaurusInterface::THESAURUS_ID . " = reference_table." . ThesaurusInterface::THESAURUS_ID
+                ),
+                ['reference_terms' => new \Zend_Db_Expr("GROUP_CONCAT( DISTINCT reference_table.term SEPARATOR ',')")]
+            );
+
+            $select->group("main_table." . ThesaurusInterface::THESAURUS_ID);
+            $this->termsLinked = true;
+        }
+
+        return $select;
+    }
+
+    /**
+     * Perform operations after collection load
+     *
+     * @return void
+     */
+    private function injectTermsData()
+    {
+        $select    = $this->initSelectWithTerms();
+        $termsData = $this->getConnection()->fetchAssoc($select);
+        $this->appendTermsSummary($termsData);
+    }
+
+    /**
+     * Perform operations after collection load
+     *
+     * @param string $tableName  Table name to fetch data from
+     * @param string $columnName Column name to fetch
+     * @return void
+     */
+    private function injectStoresData($tableName, $columnName)
+    {
+        $items = $this->getColumnValues($columnName);
+
+        if (count($items)) {
+            $connection = $this->getConnection();
+            $select = $connection->select()->from(['thesaurus_entity_store' => $this->getTable($tableName)])
+                ->where('thesaurus_entity_store.' . $columnName . ' IN (?)', $items);
+            $result = $connection->fetchPairs($select);
+
+            if ($result) {
+                foreach ($this as $item) {
+                    $entityId = $item->getData($columnName);
+                    if (!isset($result[$entityId])) {
+                        continue;
+                    }
+                    $storeId = $result[$item->getData($columnName)];
+                    $storeCode = $this->storeManager->getStore($storeId)->getCode();
+
+                    if ($result[$entityId] == 0) {
+                        $stores = $this->storeManager->getStores(false, true);
+                        $storeId = current($stores)->getId();
+                        $storeCode = key($stores);
+                    }
+
+                    $item->setData('_first_store_id', $storeId);
+                    $item->setData('store_code', $storeCode);
+                    $item->setData('store_id', [$result[$entityId]]);
+                }
+            }
+        }
+    }
+
+    /**
+     * Append terms summary to items
+     *
+     * @param array $termsData All terms data for items
+     */
+    private function appendTermsSummary($termsData)
+    {
+        if (count($termsData)) {
+            foreach ($this as $item) {
+                $entityId = $item->getId();
+                if (!isset($termsData[$entityId])) {
+                    continue;
+                }
+                $concatenatedTerms = '';
+                if (trim($termsData[$entityId]['reference_terms']) != '') {
+                    $termsLabel = $termsData[$entityId]['reference_terms'];
+                    $concatenatedTerms .= "[" . $termsLabel . "] => ";
+                }
+                if ($termsData[$entityId]['expansion_terms'] !== '') {
+                    $termsLabel = $termsData[$entityId]['expansion_terms'];
+                    $concatenatedTerms .= $termsLabel;
+                }
+
+                $item->setData('terms_summary', $concatenatedTerms);
+            }
+        }
+    }
+}

--- a/src/module-elasticsuite-thesaurus/Model/Thesaurus.php
+++ b/src/module-elasticsuite-thesaurus/Model/Thesaurus.php
@@ -1,0 +1,248 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile_ElasticSuiteThesaurus
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2016 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\ElasticSuiteThesaurus\Model;
+
+use Smile\ElasticSuiteThesaurus\Api\Data\ThesaurusInterface;
+use Smile\ElasticSuiteThesaurus\Model\Indexer\Thesaurus as ThesaurusIndexer;
+use Magento\Framework\Indexer\IndexerRegistry;
+
+/**
+ * Thesaurus Model
+ *
+ * @SuppressWarnings(PHPMD.CamelCasePropertyName)
+ *
+ * @category Smile
+ * @package  Smile_ElasticSuiteThesaurus
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class Thesaurus extends \Magento\Framework\Model\AbstractModel implements ThesaurusInterface
+{
+    /**
+     * Prefix of model events names
+     *
+     * @var string
+     */
+    // @codingStandardsIgnoreStart Property is inherited
+    protected $_eventPrefix = 'smile_elasticsuite_thesaurus';
+    // @codingStandardsIgnoreEnd
+
+    /**
+     * Parameter name in event
+     * In observer method you can use $observer->getEvent()->getThesaurus() in this case
+     *
+     * @var string
+     */
+    // @codingStandardsIgnoreStart Property is inherited
+    protected $_eventObject = 'thesaurus';
+    // @codingStandardsIgnoreEnd
+
+    /**
+     * @var array The store ids of this thesaurus
+     */
+    private $storeIds = [];
+
+    /**
+     * @var array The term data of this thesaurus
+     */
+    private $termsData;
+
+    /**
+     * @var IndexerRegistry
+     */
+    protected $indexerRegistry;
+
+    /**
+     * PHP constructor
+     *
+     * @param \Magento\Framework\Model\Context                        $context            Magento Context
+     * @param \Magento\Framework\Registry                             $registry           Magento Registry
+     * @param IndexerRegistry                                         $indexerRegistry    Indexers registry.
+     * @param \Magento\Framework\Model\ResourceModel\AbstractResource $resource           Magento Resource
+     * @param \Magento\Framework\Data\Collection\AbstractDb           $resourceCollection Magento Collection
+     * @param array                                                   $data               Magento Data
+     */
+    public function __construct(
+        \Magento\Framework\Model\Context $context,
+        \Magento\Framework\Registry $registry,
+        IndexerRegistry $indexerRegistry,
+        \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
+        \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
+        array $data = []
+    ) {
+        $this->indexerRegistry = $indexerRegistry;
+
+        parent::__construct($context, $registry, $resource, $resourceCollection, $data);
+    }
+
+    /**
+     * Process after save operations
+     *
+     * @return $this
+     */
+    public function afterSave()
+    {
+        parent::afterSave();
+
+        $this->invalidateIndex();
+
+        return $this;
+    }
+
+    /**
+     * Process after delete operations
+     *
+     * @return $this
+     */
+    public function afterDeleteCommit()
+    {
+        parent::afterDeleteCommit();
+
+        $this->invalidateIndex();
+
+        return $this;
+    }
+
+    /**
+     * Retrieve thesaurus name
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return (string) $this->getData(self::NAME);
+    }
+
+    /**
+     * Set name
+     *
+     * @param string $name the value to save
+     *
+     * @return Thesaurus
+     */
+    public function setName($name)
+    {
+        return $this->setData(self::NAME, (string) $name);
+    }
+
+    /**
+     * Get Thesaurus ID
+     *
+     * @return int|null
+     */
+    public function getThesaurusId()
+    {
+        return $this->getId();
+    }
+
+    /**
+     * Set Thesaurus ID
+     *
+     * @param int $identifier the value to save
+     *
+     * @return ThesaurusInterface
+     */
+    public function setThesaurusId($identifier)
+    {
+        return $this->setId($identifier);
+    }
+
+    /**
+     * Retrieve thesaurus type
+     *
+     * @return string
+     */
+    public function getType()
+    {
+        return (string) $this->getData(self::TYPE);
+    }
+
+    /**
+     * Set type
+     *
+     * @param string $type the type of thesaurus to save
+     *
+     * @return ThesaurusInterface
+     */
+    public function setType($type)
+    {
+        return $this->setData(self::TYPE, (string) $type);
+    }
+
+    /**
+     * Get store ids
+     *
+     * @return int[]
+     */
+    public function getStoreIds()
+    {
+        if ($this->getStores()) {
+            $this->setStoreIds($this->getStores());
+        }
+
+        if (empty($this->storeIds)) {
+            $this->storeIds = $this->getResource()->getStoreIdsFromThesaurusId($this->getThesaurusId());
+        }
+
+        return $this->storeIds;
+    }
+
+    /**
+     * Set store ids
+     *
+     * @param int[] $storeIds the store ids
+     *
+     * @return ThesaurusInterface
+     */
+    public function setStoreIds($storeIds)
+    {
+        $this->storeIds = $storeIds;
+    }
+
+    /**
+     * Get terms data
+     *
+     * @return array
+     */
+    public function getTermsData()
+    {
+        if (empty($this->termsData)) {
+            $this->termsData = $this->getResource()->getTermsDataFromThesaurus($this);
+        }
+
+        return $this->termsData;
+    }
+
+    /**
+     * Internal Constructor
+     *
+     * @SuppressWarnings(PHPMD.CamelCaseMethodName)
+     */
+    // @codingStandardsIgnoreStart Method is inherited
+    protected function _construct()
+    {
+        //@codingStandardsIgnoreEnd
+        $this->_init('Smile\ElasticSuiteThesaurus\Model\ResourceModel\Thesaurus');
+    }
+
+    /**
+     * Invalidate Thesaurus index
+     *
+     * @return $this
+     */
+    private function invalidateIndex()
+    {
+        $this->indexerRegistry->get(ThesaurusIndexer::INDEXER_ID)->invalidate();
+
+        return $this;
+    }
+}

--- a/src/module-elasticsuite-thesaurus/Model/ThesaurusRepository.php
+++ b/src/module-elasticsuite-thesaurus/Model/ThesaurusRepository.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile_ElasticSuiteThesaurus
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2016 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\ElasticSuiteThesaurus\Model;
+
+use Magento\Framework\Api\FilterBuilder;
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\Api\SearchCriteriaInterface;
+use Magento\Framework\Api\SortOrder;
+use Magento\Framework\Exception\InputException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Smile\ElasticSuiteThesaurus\Api\Data\ThesaurusSearchResultsInterfaceFactory;
+use Smile\ElasticSuiteThesaurus\Api\ThesaurusRepositoryInterface;
+
+/**
+ * Thesaurus Repository Object
+ *
+ * @category Smile
+ * @package  Smile_ElasticSuiteThesaurus
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class ThesaurusRepository implements ThesaurusRepositoryInterface
+{
+    /**
+     * Thesaurus Factory
+     *
+     * @var ThesaurusFactory
+     */
+    private $thesaurusFactory;
+
+    /**
+     * Search Result Factory
+     *
+     * @var ThesaurusSearchResultsInterfaceFactory
+     */
+    private $searchResultsFactory;
+
+    /**
+     * Magento Filter Builder
+     *
+     * @var FilterBuilder
+     */
+    private $filterBuilder;
+
+    /**
+     * Search Criteria Builder
+     *
+     * @var SearchCriteriaBuilder
+     */
+    private $searchCriteriaBuilder;
+
+    /**
+     * repository cache for thesaurus, by ids
+     *
+     * @var \Smile\ElasticSuiteThesaurus\Api\Data\ThesaurusInterface[]
+     */
+    private $thesaurusRepositoryById = [];
+
+    /**
+     * PHP Constructor
+     *
+     * @param ThesaurusFactory                       $thesaurusFactory      Thesaurus Factory
+     * @param ThesaurusSearchResultsInterfaceFactory $searchResultsFactory  Search Result Factory
+     * @param FilterBuilder                          $filterBuilder         Filter Builder
+     * @param SearchCriteriaBuilder                  $searchCriteriaBuilder Search Criteria Builder
+     *
+     * @return ThesaurusRepository
+     */
+    public function __construct(
+        ThesaurusFactory $thesaurusFactory,
+        ThesaurusSearchResultsInterfaceFactory $searchResultsFactory,
+        FilterBuilder $filterBuilder,
+        SearchCriteriaBuilder $searchCriteriaBuilder
+    ) {
+        $this->thesaurusFactory = $thesaurusFactory;
+        $this->searchResultsFactory = $searchResultsFactory;
+        $this->filterBuilder = $filterBuilder;
+        $this->searchCriteriaBuilder = $searchCriteriaBuilder;
+    }
+
+    /**
+     * Retrieve a thesaurus by its ID
+     *
+     * @param int $thesaurusId id of the thesaurus
+     *
+     * @return \Smile\ElasticSuiteThesaurus\Api\Data\ThesaurusInterface
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    public function getById($thesaurusId)
+    {
+        if (!isset($this->thesaurusRepositoryById[$thesaurusId])) {
+
+            /** @var ThesaurusInterface $thesaurus */
+            $thesaurus = $this->thesaurusFactory->create()->load($thesaurusId);
+            if (!$thesaurus->getThesaurusId()) {
+                $exception = new NoSuchEntityException();
+                throw $exception->singleField('thesaurusId', $thesaurusId);
+            }
+
+            $this->thesaurusRepositoryById[$thesaurusId] = $thesaurus;
+        }
+
+        return $this->thesaurusRepositoryById[$thesaurusId];
+    }
+
+    /**
+     * Save a thesaurus
+     *
+     * @param \Smile\ElasticSuiteThesaurus\Api\Data\ThesaurusInterface $thesaurus Thesaurus data
+     *
+     * @return \Smile\ElasticSuiteThesaurus\Api\Data\ThesaurusInterface
+     *
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    public function save(\Smile\ElasticSuiteThesaurus\Api\Data\ThesaurusInterface $thesaurus)
+    {
+        $this->validate($thesaurus);
+
+        $thesaurus->save();
+
+        $this->thesaurusRepositoryById[$thesaurus->getThesaurusId()] = $thesaurus;
+
+        return $thesaurus;
+    }
+
+    /**
+     * Delete a thesaurus
+     *
+     * @param \Smile\ElasticSuiteThesaurus\Api\Data\ThesaurusInterface $thesaurus Thesaurus data
+     *
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     *
+     * @return void
+     */
+    public function delete(\Smile\ElasticSuiteThesaurus\Api\Data\ThesaurusInterface $thesaurus)
+    {
+        $thesaurusId = $thesaurus->getThesaurusId();
+
+        $thesaurus->delete();
+
+        if (isset($this->thesaurusRepositoryById[$thesaurusId])) {
+            unset($this->thesaurusRepositoryById[$thesaurusId]);
+        }
+    }
+
+    /**
+     * Validate thesaurus values
+     *
+     * @param \Smile\ElasticSuiteThesaurus\Api\Data\ThesaurusInterface $thesaurus the thesaurus to validate
+     *
+     * @return void
+     * @throws \Magento\Framework\Exception\InputException
+     */
+    protected function validate(\Smile\ElasticSuiteThesaurus\Api\Data\ThesaurusInterface $thesaurus)
+    {
+        $exception = new \Magento\Framework\Exception\InputException();
+
+        $validator = new \Zend_Validate();
+        if (!$validator->is(trim($thesaurus->getName()), 'NotEmpty')) {
+            $exception->addError(__(InputException::REQUIRED_FIELD, ['fieldName' => 'name']));
+        }
+
+        if ($exception->wasErrorAdded()) {
+            throw $exception;
+        }
+    }
+}

--- a/src/module-elasticsuite-thesaurus/Setup/InstallSchema.php
+++ b/src/module-elasticsuite-thesaurus/Setup/InstallSchema.php
@@ -1,0 +1,218 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile_ElasticSuiteThesaurus
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2016 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\ElasticSuiteThesaurus\Setup;
+
+use Magento\Framework\Setup\InstallSchemaInterface;
+use Magento\Framework\Setup\ModuleContextInterface;
+use Magento\Framework\Setup\SchemaSetupInterface;
+use Smile\ElasticSuiteThesaurus\Api\Data\ThesaurusInterface;
+
+/**
+ * Install Schema for Thesaurus Module
+ *
+ * @category Smile
+ * @package  Smile_ElasticSuiteThesaurus
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class InstallSchema implements InstallSchemaInterface
+{
+    /**
+     * Installs DB schema for a module
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     *
+     * @param SchemaSetupInterface   $setup   Setup
+     * @param ModuleContextInterface $context Context
+     *
+     * @return void
+     */
+    // @codingStandardsIgnoreStart Conform to interface
+    public function install(SchemaSetupInterface $setup, ModuleContextInterface $context)
+    {
+        // @codingStandardsIgnoreEnd
+        $setup->startSetup();
+
+        $this->createThesaurusTable($setup);
+        $this->createThesaurusStoreTable($setup);
+        $this->createExpandedTermsTable($setup);
+        $this->createExpansionReferenceTable($setup);
+
+        $setup->endSetup();
+    }
+
+    /**
+     * Create Thesaurus main table
+     *
+     * @param \Magento\Framework\Setup\SchemaSetupInterface $setup Setup instance
+     */
+    private function createThesaurusTable(SchemaSetupInterface $setup)
+    {
+        $table = $setup->getConnection()
+            ->newTable($setup->getTable(ThesaurusInterface::TABLE_NAME))
+            ->addColumn(
+                ThesaurusInterface::THESAURUS_ID,
+                \Magento\Framework\DB\Ddl\Table::TYPE_INTEGER,
+                null,
+                ['identity' => true, 'unsigned' => true, 'nullable' => false, 'primary' => true],
+                'Thesaurus Id'
+            )->addColumn(
+                ThesaurusInterface::NAME,
+                \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
+                255,
+                ['nullable' => false],
+                'Thesaurus Name'
+            )->addColumn(
+                ThesaurusInterface::TYPE,
+                \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
+                50,
+                ['nullable' => false],
+                'Thesaurus Type'
+            )->setComment('Smile Elastic Suite Thesaurus Table');
+
+        $setup->getConnection()->createTable($table);
+    }
+
+    /**
+     * Create Thesaurus/store link table
+     *
+     * @param \Magento\Framework\Setup\SchemaSetupInterface $setup Setup instance
+     */
+    private function createThesaurusStoreTable(SchemaSetupInterface $setup)
+    {
+        $table = $setup->getConnection()
+            ->newTable($setup->getTable(ThesaurusInterface::STORE_TABLE_NAME))
+            ->addColumn(
+                ThesaurusInterface::THESAURUS_ID,
+                \Magento\Framework\DB\Ddl\Table::TYPE_INTEGER,
+                null,
+                ['identity' => true, 'unsigned' => true, 'nullable' => false, 'primary' => true],
+                'Thesaurus Id'
+            )->addColumn(
+                'store_id',
+                \Magento\Framework\DB\Ddl\Table::TYPE_SMALLINT,
+                null,
+                ['unsigned' => true, 'nullable' => false, 'primary' => true],
+                'Store ID'
+            )->addForeignKey(
+                $setup->getFkName(
+                    ThesaurusInterface::STORE_TABLE_NAME,
+                    ThesaurusInterface::THESAURUS_ID,
+                    ThesaurusInterface::TABLE_NAME,
+                    ThesaurusInterface::THESAURUS_ID
+                ),
+                ThesaurusInterface::THESAURUS_ID,
+                $setup->getTable(ThesaurusInterface::TABLE_NAME),
+                ThesaurusInterface::THESAURUS_ID,
+                \Magento\Framework\DB\Ddl\Table::ACTION_CASCADE
+            )->addForeignKey(
+                $setup->getFkName(ThesaurusInterface::STORE_TABLE_NAME, ThesaurusInterface::STORE_ID, 'store', 'store_id'),
+                ThesaurusInterface::STORE_ID,
+                $setup->getTable('store'),
+                'store_id',
+                \Magento\Framework\DB\Ddl\Table::ACTION_CASCADE
+            )->setComment('Smile Elastic Suite Thesaurus Table for link between thesauri and stores');
+
+        $setup->getConnection()->createTable($table);
+    }
+
+    /**
+     * Create Thesaurus/expansion reference terms link table
+     *
+     * @param \Magento\Framework\Setup\SchemaSetupInterface $setup Setup instance
+     */
+    private function createExpansionReferenceTable(SchemaSetupInterface $setup)
+    {
+        $table = $setup->getConnection()
+            ->newTable($setup->getTable(ThesaurusInterface::REFERENCE_TABLE_NAME))
+            ->addColumn(
+                ThesaurusInterface::THESAURUS_ID,
+                \Magento\Framework\DB\Ddl\Table::TYPE_INTEGER,
+                null,
+                ['unsigned' => true, 'nullable' => false, 'primary' => true],
+                'Thesaurus Id'
+            )->addColumn(
+                'term_id',
+                \Magento\Framework\DB\Ddl\Table::TYPE_INTEGER,
+                null,
+                ['unsigned' => true, 'nullable' => false, 'primary' => true],
+                'Reference Term Id'
+            )
+            ->addColumn(
+                'term',
+                \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
+                255,
+                ['nullable' => false],
+                'Reference Term'
+            )->addForeignKey(
+                $setup->getFkName(
+                    ThesaurusInterface::REFERENCE_TABLE_NAME,
+                    ThesaurusInterface::THESAURUS_ID,
+                    ThesaurusInterface::TABLE_NAME,
+                    ThesaurusInterface::THESAURUS_ID
+                ),
+                ThesaurusInterface::THESAURUS_ID,
+                $setup->getTable(ThesaurusInterface::TABLE_NAME),
+                ThesaurusInterface::THESAURUS_ID,
+                \Magento\Framework\DB\Ddl\Table::ACTION_CASCADE
+            )->setComment('Smile Elastic Suite Thesaurus Table for link between thesauri and reference terms');
+
+        $setup->getConnection()->createTable($table);
+    }
+
+    /**
+     * Create Relation between Thesaurus and expanded terms (which are also synonyms) link table
+     *
+     * @param \Magento\Framework\Setup\SchemaSetupInterface $setup Setup instance
+     */
+    private function createExpandedTermsTable(SchemaSetupInterface $setup)
+    {
+        $table = $setup->getConnection()
+            ->newTable($setup->getTable(ThesaurusInterface::EXPANSION_TABLE_NAME))
+            ->addColumn(
+                ThesaurusInterface::THESAURUS_ID,
+                \Magento\Framework\DB\Ddl\Table::TYPE_INTEGER,
+                null,
+                ['unsigned' => true, 'nullable' => false, 'primary' => true],
+                'Thesaurus Id'
+            )->addColumn(
+                'term_id',
+                \Magento\Framework\DB\Ddl\Table::TYPE_INTEGER,
+                null,
+                ['unsigned' => true, 'nullable' => false, 'primary' => true],
+                'Reference Term Id'
+            )
+            ->addColumn(
+                'term',
+                \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
+                255,
+                ['nullable' => false, 'primary' => true],
+                'Reference Term'
+            )->addIndex(
+                $setup->getIdxName(ThesaurusInterface::EXPANSION_TABLE_NAME, ['term_id']),
+                ['term_id']
+            )->addForeignKey(
+                $setup->getFkName(
+                    ThesaurusInterface::EXPANSION_TABLE_NAME,
+                    ThesaurusInterface::THESAURUS_ID,
+                    ThesaurusInterface::TABLE_NAME,
+                    ThesaurusInterface::THESAURUS_ID
+                ),
+                ThesaurusInterface::THESAURUS_ID,
+                $setup->getTable(ThesaurusInterface::TABLE_NAME),
+                ThesaurusInterface::THESAURUS_ID,
+                \Magento\Framework\DB\Ddl\Table::ACTION_CASCADE
+            )->setComment('Smile Elastic Suite Thesaurus Table for link between thesauri and expanded terms');
+
+        $setup->getConnection()->createTable($table);
+    }
+}

--- a/src/module-elasticsuite-thesaurus/etc/acl.xml
+++ b/src/module-elasticsuite-thesaurus/etc/acl.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Smile_ElasticSuiteThesaurus ACLs.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile_ElasticSuiteThesaurus
+ * @author    Romain RUAUD <romain.ruaud@smile.fr>
+ * @copyright 2016 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+ -->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Acl/etc/acl.xsd">
+    <acl>
+        <resources>
+            <resource id="Magento_Backend::admin">
+                <resource id="Magento_Backend::stores">
+                    <resource id="Smile_ElasticsuiteThesaurus::manage" title="Manage Smile ElasticSuite Thesaurus"/>
+                </resource>
+            </resource>
+        </resources>
+    </acl>
+</config>

--- a/src/module-elasticsuite-thesaurus/etc/adminhtml/menu.xml
+++ b/src/module-elasticsuite-thesaurus/etc/adminhtml/menu.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Smile ElasticSuite Thesaurus menu configuration
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade Smile Searchandising Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile_ElasticSuiteThesaurus
+ * @author    Romain RUAUD <romain.ruaud@smile.fr>
+ * @copyright 2016 Smile
+ * @license   Apache License Version 2.0
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Backend:etc/menu.xsd">
+    <menu>
+        <add
+            id="Smile_ElasticSuiteThesaurus::manage"
+            title="Thesaurus"
+            module="Smile_ElasticSuiteThesaurus"
+            sortOrder="10"
+            parent="Smile_ElasticSuiteCore::manage_search"
+            action="smile_elasticsuite_thesaurus/thesaurus/index"
+            resource="Smile_ElasticSuiteThesaurus::manage"/>
+    </menu>
+</config>

--- a/src/module-elasticsuite-thesaurus/etc/adminhtml/routes.xml
+++ b/src/module-elasticsuite-thesaurus/etc/adminhtml/routes.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:App/etc/routes.xsd">
+    <router id="admin">
+        <route id="smile_elasticsuite_thesaurus" frontName="smile_elasticsuite_thesaurus">
+            <module name="Smile_ElasticSuiteThesaurus" before="Magento_Backend" />
+        </route>
+    </router>
+</config>

--- a/src/module-elasticsuite-thesaurus/etc/di.xml
+++ b/src/module-elasticsuite-thesaurus/etc/di.xml
@@ -12,6 +12,7 @@
  * @category  Smile
  * @package   Smile_ElasticSuiteCore
  * @author    Aurelien FOUCRET <aurelien.foucret@smile.fr>
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
  * @copyright 2016 Smile
  * @license   Open Software License ("OSL") v. 3.0
  */
@@ -20,8 +21,13 @@
     <type name="\Smile\ElasticSuiteCore\Search\Request\Query\Fulltext\QueryBuilder">
         <plugin name="queryRewriteSynonyms" type="\Smile\ElasticSuiteThesaurus\Plugin\QueryRewrite" />
     </type>
-    
+
     <type name="\Magento\Search\Model\Query">
         <plugin name="synonymQueryPlugin" type="\Smile\ElasticSuiteThesaurus\Plugin\Query" />
     </type>
+
+    <!-- Dependency Injection for Thesaurus Models -->
+    <preference for="Smile\ElasticSuiteThesaurus\Api\ThesaurusRepositoryInterface" type="Smile\ElasticSuiteThesaurus\Model\ThesaurusRepository" />
+    <preference for="Smile\ElasticSuiteThesaurus\Api\Data\ThesaurusInterface" type="Smile\ElasticSuiteThesaurus\Model\Thesaurus" />
+    <preference for="Smile\ElasticSuiteThesaurus\Api\Data\ThesaurusSearchResultsInterface" type="Magento\Framework\Api\SearchResults" />
 </config>

--- a/src/module-elasticsuite-thesaurus/view/adminhtml/layout/smile_elasticsuite_thesaurus_grid_block.xml
+++ b/src/module-elasticsuite-thesaurus/view/adminhtml/layout/smile_elasticsuite_thesaurus_grid_block.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Thesaurus grid layout
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade Smile Searchandising Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile_ElasticSuiteThesaurus
+ * @author    Romain RUAUD <romain.ruaud@smile.fr>
+ * @copyright 2016 Smile
+ * @license   Apache License Version 2.0
+ */
+-->
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceBlock name="adminhtml.elasticsuite.thesaurus.grid.container">
+            <block class="Smile\ElasticSuiteThesaurus\Block\Adminhtml\Thesaurus\Grid" name="adminhtml.elasticsuite.thesaurus.grid" as="grid">
+                <arguments>
+                    <argument name="id" xsi:type="string">smile_elasticsuite_thesaurus_grid</argument>
+                    <argument name="dataSource" xsi:type="object">Smile\ElasticSuiteThesaurus\Model\ResourceModel\Thesaurus\Collection</argument>
+                    <argument name="default_sort" xsi:type="string">name</argument>
+                    <argument name="default_dir" xsi:type="string">ASC</argument>
+                    <argument name="save_parameters_in_session" xsi:type="string">1</argument>
+                </arguments>
+                <block class="Magento\Backend\Block\Widget\Grid\Massaction" name="adminhtml.elasticsuite.thesaurus.grid.massaction" as="grid.massaction">
+                    <arguments>
+                        <argument name="massaction_id_field" xsi:type="string">thesaurus_id</argument>
+                        <argument name="form_field_name" xsi:type="string">thesauri</argument>
+                        <argument name="use_select_all" xsi:type="string">1</argument>
+                        <argument name="options" xsi:type="array">
+                            <item name="delete" xsi:type="array">
+                                <item name="label" xsi:type="string" translate="true">Delete</item>
+                                <item name="url" xsi:type="string">*/*/massDelete</item>
+                                <item name="confirm" xsi:type="string" translate="true">Are you sure?</item>
+                            </item>
+                        </argument>
+                    </arguments>
+                </block>
+                <block class="Magento\Backend\Block\Widget\Grid\ColumnSet" name="adminhtml.elasticsuite.thesaurus.grid.columnSet" as="grid.columnSet">
+                    <arguments>
+                        <argument name="rowUrl" xsi:type="array">
+                            <item name="path" xsi:type="string">*/*/edit</item>
+                            <item name="extraParamsTemplate" xsi:type="array">
+                                <item name="thesaurus_id" xsi:type="string">getId</item>
+                            </item>
+                        </argument>
+                    </arguments>
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="thesaurus_name">
+                        <arguments>
+                            <argument name="header" xsi:type="string" translate="true">Name</argument>
+                            <argument name="index" xsi:type="string">name</argument>
+                        </arguments>
+                    </block>
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="thesaurus_type">
+                        <arguments>
+                            <argument name="header" xsi:type="string" translate="true">Type</argument>
+                            <argument name="index" xsi:type="string">type</argument>
+                            <argument name="type" xsi:type="string">options</argument>
+                            <argument name="options" xsi:type="array">
+                                <item name="expansion" xsi:type="array">
+                                    <item name="value" xsi:type="string">expansion</item>
+                                    <item name="label" xsi:type="string" translate="true">Expansions</item>
+                                </item>
+                                <item name="synonym" xsi:type="array">
+                                    <item name="value" xsi:type="string">synonym</item>
+                                    <item name="label" xsi:type="string" translate="true">Synonyms</item>
+                                </item>
+                            </argument>
+                        </arguments>
+                    </block>
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="thesaurus_terms_summary">
+                        <arguments>
+                            <argument name="header" xsi:type="string" translate="true">Terms</argument>
+                            <argument name="index" xsi:type="string">terms_summary</argument>
+                        </arguments>
+                    </block>
+                    <block class="Magento\Backend\Block\Widget\Grid\Column\Multistore" as="store_id">
+                        <arguments>
+                            <argument name="header" xsi:type="string" translate="true">Store</argument>
+                            <argument name="type" xsi:type="string">store</argument>
+                            <argument name="id" xsi:type="string">store_id</argument>
+                            <argument name="index" xsi:type="string">store_id</argument>
+                            <argument name="store_view" xsi:type="string">1</argument>
+                            <argument name="sortable" xsi:type="string">0</argument>
+                        </arguments>
+                    </block>
+                    <block class="Magento\Backend\Block\Widget\Grid\Column" as="action">
+                        <arguments>
+                            <argument name="type" xsi:type="string">action</argument>
+                            <argument name="header" xsi:type="string" translate="true">Action</argument>
+                            <argument name="filter" xsi:type="string">0</argument>
+                            <argument name="sortable" xsi:type="string">0</argument>
+                            <argument name="index" xsi:type="string">thesaurus_id</argument>
+                            <argument name="actions" xsi:type="array">
+                                <item name="edit" xsi:type="array">
+                                    <item name="caption" xsi:type="string" translate="true">Edit</item>
+                                    <item name="url" xsi:type="array">
+                                        <item name="base" xsi:type="string">*/*/edit</item>
+                                    </item>
+                                    <item name="field" xsi:type="string">thesaurus_id</item>
+                                </item>
+                                <item name="delete" xsi:type="array">
+                                    <item name="caption" xsi:type="string" translate="true">Delete</item>
+                                    <item name="url" xsi:type="array">
+                                        <item name="base" xsi:type="string">*/*/delete</item>
+                                    </item>
+                                    <item name="field" xsi:type="string">thesaurus_id</item>
+                                </item>
+                            </argument>
+                        </arguments>
+                    </block>
+                </block>
+            </block>
+        </referenceBlock>
+    </body>
+</page>

--- a/src/module-elasticsuite-thesaurus/view/adminhtml/layout/smile_elasticsuite_thesaurus_thesaurus_create.xml
+++ b/src/module-elasticsuite-thesaurus/view/adminhtml/layout/smile_elasticsuite_thesaurus_thesaurus_create.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Thesaurus creation layout
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade Smile Searchandising Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile_ElasticSuiteThesaurus
+ * @author    Romain RUAUD <romain.ruaud@smile.fr>
+ * @copyright 2016 Smile
+ * @license   Apache License Version 2.0
+ */
+-->
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="content">
+            <block class="Smile\ElasticSuiteThesaurus\Block\Adminhtml\Thesaurus\Create" name="adminhtml.elasticsuite.thesaurus.create"/>
+        </referenceContainer>
+    </body>
+</page>

--- a/src/module-elasticsuite-thesaurus/view/adminhtml/layout/smile_elasticsuite_thesaurus_thesaurus_edit.xml
+++ b/src/module-elasticsuite-thesaurus/view/adminhtml/layout/smile_elasticsuite_thesaurus_thesaurus_edit.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Thesaurus edition layout
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade Smile Searchandising Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile_ElasticSuiteThesaurus
+ * @author    Romain RUAUD <romain.ruaud@smile.fr>
+ * @copyright 2016 Smile
+ * @license   Apache License Version 2.0
+ */
+-->
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="content">
+            <block class="Smile\ElasticSuiteThesaurus\Block\Adminhtml\Thesaurus\Edit" name="adminhtml.elasticsuite.thesaurus.create"/>
+        </referenceContainer>
+    </body>
+</page>

--- a/src/module-elasticsuite-thesaurus/view/adminhtml/layout/smile_elasticsuite_thesaurus_thesaurus_index.xml
+++ b/src/module-elasticsuite-thesaurus/view/adminhtml/layout/smile_elasticsuite_thesaurus_thesaurus_index.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Thesaurus grid layout
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade Smile Searchandising Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile_ElasticSuiteThesaurus
+ * @author    Romain RUAUD <romain.ruaud@smile.fr>
+ * @copyright 2016 Smile
+ * @license   Apache License Version 2.0
+ */
+-->
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <update handle="smile_elasticsuite_thesaurus_grid_block"/>
+    <body>
+        <referenceContainer name="content">
+            <block class="Smile\ElasticSuiteThesaurus\Block\Adminhtml\Thesaurus" name="adminhtml.elasticsuite.thesaurus.grid.container"/>
+        </referenceContainer>
+    </body>
+</page>


### PR DESCRIPTION
Added :

- basic CRUD in Back-Office
- expansions & synonyms types
- index invalidation on save/delete
- basic filtering on grid

Missing : 

- Unicity check between several wordbags of a thesaurus.