### PR TITLE
Conf product may have conf. attribute not used in layered nav

### DIFF
--- a/src/module-elasticsuite-catalog/Model/Product/Indexer/Fulltext/Datasource/AttributeData.php
+++ b/src/module-elasticsuite-catalog/Model/Product/Indexer/Fulltext/Datasource/AttributeData.php
@@ -152,7 +152,9 @@ class AttributeData extends AbstractAttributeData implements DatasourceInterface
 
             $configurableAttributesCodes = array_map(
                 function ($attributeId) {
-                    return $this->attributesById[(int) $attributeId]->getAttributeCode();
+                    if (isset($this->attributesById[(int) $attributeId])) {
+                        return $this->attributesById[(int) $attributeId]->getAttributeCode();
+                    }
                 },
                 $relation['configurable_attributes']
             );


### PR DESCRIPTION
When configurable attribute is not used in LayeredNav, L155 fails indexation due to attribute is not in array.

E.g. you have clothing with color and size, where color is always some complex naming "crimson/blood red/peach" and color_group for this is "red". Color is not used in layered while color_group is. Such solution results in Notice: Undefined offset: which is fixable by isset proposed here.