### PR TITLE
Adding the ability to use the Manual mode for price navigation step, …

### DIFF
--- a/src/module-elasticsuite-catalog/Block/Navigation/Renderer/PriceSlider.php
+++ b/src/module-elasticsuite-catalog/Block/Navigation/Renderer/PriceSlider.php
@@ -12,7 +12,9 @@
  */
 namespace Smile\ElasticsuiteCatalog\Block\Navigation\Renderer;
 
+use Magento\Store\Model\ScopeInterface;
 use Smile\ElasticsuiteCatalog\Model\Layer\Filter\Price;
+use Magento\Catalog\Model\Layer\Filter\DataProvider\Price as PriceDataProvider;
 
 /**
  * This block handle price slider rendering.
@@ -44,5 +46,82 @@ class PriceSlider extends Slider
     protected function getFieldFormat()
     {
         return $this->localeFormat->getPriceFormat();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getConfig()
+    {
+        $config = parent::getConfig();
+
+        if ($this->isManualCalculation() && ($this->getStepValue() > 0)) {
+            $config['step'] = $this->getStepValue();
+        }
+
+        return $config;
+    }
+
+    /**
+     * Returns min value of the slider.
+     *
+     * @return int
+     */
+    protected function getMinValue()
+    {
+        $minValue = $this->getFilter()->getMinValue();
+
+        if ($this->isManualCalculation() && ($this->getStepValue() > 0)) {
+            $stepValue = $this->getStepValue();
+            $minValue  = floor($minValue / $stepValue) * $stepValue;
+        }
+
+        return $minValue;
+    }
+
+    /**
+     * Returns max value of the slider.
+     *
+     * @return int
+     */
+    protected function getMaxValue()
+    {
+        $maxValue = $this->getFilter()->getMaxValue() + 1;
+
+        if ($this->isManualCalculation() && ($this->getStepValue() > 0)) {
+            $stepValue = $this->getStepValue();
+            $maxValue  = ceil($maxValue / $stepValue) * $stepValue;
+        }
+
+        return $maxValue;
+    }
+
+    /**
+     * Check if price interval is manually set in the configuration
+     *
+     * @return bool
+     */
+    private function isManualCalculation()
+    {
+        $result      = false;
+        $calculation = $this->_scopeConfig->getValue(PriceDataProvider::XML_PATH_RANGE_CALCULATION, ScopeInterface::SCOPE_STORE);
+
+        if ($calculation === PriceDataProvider::RANGE_CALCULATION_MANUAL) {
+            $result = true;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Retrieve the value for "Default Price Navigation Step".
+     *
+     * @return int
+     */
+    private function getStepValue()
+    {
+        $value = $this->_scopeConfig->getValue(PriceDataProvider::XML_PATH_RANGE_STEP, ScopeInterface::SCOPE_STORE);
+
+        return (int) $value;
     }
 }

--- a/src/module-elasticsuite-catalog/Block/Navigation/Renderer/Slider.php
+++ b/src/module-elasticsuite-catalog/Block/Navigation/Renderer/Slider.php
@@ -73,18 +73,7 @@ class Slider extends AbstractRenderer
      */
     public function getJsonConfig()
     {
-        $config = [
-            'minValue'         => $this->getMinValue(),
-            'maxValue'         => $this->getMaxValue(),
-            'currentValue'     => $this->getCurrentValue(),
-            'fieldFormat'      => $this->getFieldFormat(),
-            'intervals'        => $this->getIntervals(),
-            'urlTemplate'      => $this->getUrlTemplate(),
-            'messageTemplates' => [
-                'displayCount' => __('<%- count %> products'),
-                'displayEmpty' => __('No products in the selected range.'),
-            ],
-        ];
+        $config = $this->getConfig();
 
         return $this->jsonEncoder->encode($config);
     }
@@ -129,11 +118,34 @@ class Slider extends AbstractRenderer
     }
 
     /**
+     * Retrieve configuration
+     *
+     * @return array
+     */
+    protected function getConfig()
+    {
+        $config = [
+            'minValue'         => $this->getMinValue(),
+            'maxValue'         => $this->getMaxValue(),
+            'currentValue'     => $this->getCurrentValue(),
+            'fieldFormat'      => $this->getFieldFormat(),
+            'intervals'        => $this->getIntervals(),
+            'urlTemplate'      => $this->getUrlTemplate(),
+            'messageTemplates' => [
+                'displayCount' => __('<%- count %> products'),
+                'displayEmpty' => __('No products in the selected range.'),
+            ],
+        ];
+
+        return $config;
+    }
+
+    /**
      * Returns min value of the slider.
      *
      * @return int
      */
-    private function getMinValue()
+    protected function getMinValue()
     {
         return $this->getFilter()->getMinValue();
     }
@@ -143,7 +155,7 @@ class Slider extends AbstractRenderer
      *
      * @return int
      */
-    private function getMaxValue()
+    protected function getMaxValue()
     {
         return $this->getFilter()->getMaxValue() + 1;
     }

--- a/src/module-elasticsuite-catalog/Model/Layer/Filter/Price.php
+++ b/src/module-elasticsuite-catalog/Model/Layer/Filter/Price.php
@@ -105,6 +105,13 @@ class Price extends \Magento\CatalogSearch\Model\Layer\Filter\Price
 
         $facetConfig = ['nestedFilter' => ['price.customer_group_id' => $customerGroupId]];
 
+        $calculation = $this->dataProvider->getRangeCalculationValue();
+        if ($calculation === \Magento\Catalog\Model\Layer\Filter\DataProvider\Price::RANGE_CALCULATION_MANUAL) {
+            if ((int) $this->dataProvider->getRangeStepValue() > 0) {
+                $facetConfig['interval'] = (int) $this->dataProvider->getRangeStepValue();
+            }
+        }
+
         $productCollection = $this->getLayer()->getProductCollection();
         $productCollection->addFacet($facetField, $facetType, $facetConfig);
 

--- a/src/module-elasticsuite-catalog/view/frontend/web/js/range-slider-widget.js
+++ b/src/module-elasticsuite-catalog/view/frontend/web/js/range-slider-widget.js
@@ -48,7 +48,8 @@ define(["jquery", 'Magento_Catalog/js/price-utils', 'mage/template', "jquery/ui"
                 min: this.options.minValue,
                 max: this.options.maxValue,
                 values: [ this.from, this.to ],
-                slide: this._onSliderChange.bind(this)
+                slide: this._onSliderChange.bind(this),
+                step: this.options.step
             });
         },
 


### PR DESCRIPTION
Add the ability to use the Magento configuration for the Price Navigation Step Calculation : the "Manual" mode is now supported and will use the "Default Price Navigation Step" field when rendering the price slider.

This can allow to have much lighter aggregations when having a wide range of prices displayed, like in #77 

Could be merged only in 2.2.x since it's more a new feature than a bugfix.