### PR TITLE
First-time Magento 2 setups fail if they include a category creation

### DIFF
--- a/src/module-elasticsuite-core/Index/IndexOperation.php
+++ b/src/module-elasticsuite-core/Index/IndexOperation.php
@@ -123,7 +123,7 @@ class IndexOperation implements IndexOperationInterface
         if (!isset($this->indicesByIdentifier[$indexAlias])) {
             if (!$this->indexExists($indexIdentifier, $store)) {
                 throw new \LogicException(
-                    "{$indexIdentifier} index does not exist yet. Make sure everything is reindexed"
+                    "{$indexIdentifier} index does not exist yet. Make sure everything is reindexed."
                 );
             }
             $this->initIndex($indexIdentifier, $store, true);

--- a/src/module-elasticsuite-core/Indexer/GenericIndexerHandler.php
+++ b/src/module-elasticsuite-core/Indexer/GenericIndexerHandler.php
@@ -77,7 +77,11 @@ class GenericIndexerHandler implements IndexerInterface
     {
         foreach ($dimensions as $dimension) {
             $storeId = $dimension->getValue();
-            $index = $this->indexOperation->getIndexByName($this->indexName, $storeId);
+            try {
+                $index = $this->indexOperation->getIndexByName($this->indexName, $storeId);
+            } catch (\LogicException $e) {
+                continue;
+            }
             $type  = $index->getType($this->typeName);
 
             foreach ($this->batch->getItems($documents, $this->batchSize) as $batchDocuments) {
@@ -103,7 +107,11 @@ class GenericIndexerHandler implements IndexerInterface
     {
         foreach ($dimensions as $dimension) {
             $storeId = $dimension->getValue();
-            $index = $this->indexOperation->getIndexByName($this->indexName, $storeId);
+            try {
+                $index = $this->indexOperation->getIndexByName($this->indexName, $storeId);
+            } catch (\LogicException $e) {
+                continue;
+            }
             $type  = $index->getType($this->typeName);
 
             foreach ($this->batch->getItems($documents, $this->batchSize) as $batchDocuments) {


### PR DESCRIPTION
I suppose this is a valid approach to solving issue #121, since saving and the deletion of specific non-existing indexes is a logical fault, but does not require any further action. If the index does not exist, the owners will still see the exception being thrown when trying to perform a search on the specific store. Pull request should be denied if there's a better option I missed though.