### PR TITLE
Make elasticsuite use the dummy data provider for search suggestions

### DIFF
--- a/src/module-elasticsuite-core/etc/di.xml
+++ b/src/module-elasticsuite-core/etc/di.xml
@@ -347,4 +347,12 @@
 
     <type name="Smile\ElasticsuiteCore\Model\Search\Request\RelevanceConfig\Structure\Element\Group\Proxy" shared="false"/>
 
+    <!-- Setting ElasticSuite to use the default (which does nothing) data provider for suggestions -->
+    <type name="Magento\AdvancedSearch\Model\SuggestedQueries">
+        <arguments>
+            <argument name="data" xsi:type="array">
+                <item name="elasticsuite" xsi:type="string">Magento\AdvancedSearch\Model\DataProvider\Suggestions</item>
+            </argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
This is a proposal for fixing the issue where a fatal error is thrown on catalogsearch result page on Magento 2.1 EE with `module-advanced-search` is enabled.

This bug affects the "standard" search result page.

I think this is better to fix it on our side by just declaring a dummy (the default one which does nothing) data provider for search suggestions, instead of asking people to simply shut down the Advanced Search module.

=> It's easier for people to not being forced to disable EE module when using our engine. 

=> This way, people can continue to use Advanced Search features like Recommendations (even if it is a perf killer, they have the choice to use it if they want).

=> We will be able to switch to our custom implementation later without having to say to people "ok now you can re-active module-advanced-search".

Let me know