### PR TITLE
Explicit casting to int when building visibility filter.

### DIFF
--- a/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Indexer/Fulltext/Action/Full.php
+++ b/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Indexer/Fulltext/Action/Full.php
@@ -98,7 +98,7 @@ class Full extends Indexer
 
         $select->useStraightJoin(true)
             ->join(['visibility' => $indexTable], $visibilityJoinCond, ['visibility'])
-            ->where('visibility.category_id = ?', $rootCategoryId);
+            ->where('visibility.category_id = ?', (int) $rootCategoryId);
 
         return $this;
     }


### PR DESCRIPTION
Performance related. This query is processed so many times that an explicit casting here should be worth it.