### PR TITLE
Set requirements for Elasticsearch client to 2.2.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "magento/module-catalog": ">=100.1.0",
         "magento/module-catalog-search": ">=100.1.0",
         "magento/magento-composer-installer": "*",
-        "elasticsearch/elasticsearch": "^2.2.0"
+        "elasticsearch/elasticsearch": "^2.2.3"
     },
     "replace": {
         "smile/module-elasticsuite-core": "self.version",


### PR DESCRIPTION
This is due to the previous merging of #212 which does not work with prior versions of the Elasticsearch PHP Client.