### PR TITLE
Feature virtual categories subtree

### DIFF
--- a/src/module-elasticsuite-catalog/Model/Layer/Filter/Category.php
+++ b/src/module-elasticsuite-catalog/Model/Layer/Filter/Category.php
@@ -42,7 +42,7 @@ class Category extends \Magento\CatalogSearch\Model\Layer\Filter\Category implem
     /**
      * @var \Magento\Catalog\Model\ResourceModel\Category\Collection|\Magento\Catalog\Model\Category[]
      */
-    private $childrenCategories;
+    protected $childrenCategories;
 
     /**
      * Constructor.
@@ -145,7 +145,7 @@ class Category extends \Magento\CatalogSearch\Model\Layer\Filter\Category implem
                             'label' => $this->escaper->escapeHtml($category->getName()),
                             'value' => $category->getId(),
                             'count' => $optionsFacetedData[$category->getId()]['count'],
-                            'url'   => $category->getUrl(),
+                            'url'   => $this->getCategoryFilterUrl($category),
                         ];
 
                         $items[] = $item;
@@ -236,5 +236,17 @@ class Category extends \Magento\CatalogSearch\Model\Layer\Filter\Category implem
     protected function getDataProvider()
     {
         return $this->dataProvider;
+    }
+
+    /**
+     * Retrieve Category Url to build filter
+     *
+     * @param \Magento\Catalog\Api\Data\CategoryInterface $category Category.
+     *
+     * @return string
+     */
+    protected function getCategoryFilterUrl($category)
+    {
+        return $category->getUrl();
     }
 }

--- a/src/module-elasticsuite-virtual-category/Controller/Router.php
+++ b/src/module-elasticsuite-virtual-category/Controller/Router.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\ElasticsuiteVirtualCategory
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2016 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\ElasticsuiteVirtualCategory\Controller;
+
+use Magento\Framework\App\ActionFactory;
+use Magento\Framework\Event\ManagerInterface;
+use Magento\Framework\UrlInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use Smile\ElasticsuiteVirtualCategory\Model\Url;
+
+/**
+ * Router used when accessing a product via an url containing a virtual category request path.
+ *
+ * @category Smile
+ * @package  Smile\ElasticsuiteVirtualCategory
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class Router implements \Magento\Framework\App\RouterInterface
+{
+    /**
+     * @var ActionFactory
+     */
+    private $actionFactory;
+
+    /**
+     * @var ManagerInterface
+     */
+    private $eventManager;
+
+    /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
+     * @var Url
+     */
+    private $urlModel;
+
+    /**
+     * Router Constructor
+     *
+     * @param ActionFactory         $actionFactory Action Factory
+     * @param ManagerInterface      $eventManager  Event Manager
+     * @param StoreManagerInterface $storeManager  Store Manager
+     * @param Url                   $urlModel      Url Model
+     */
+    public function __construct(
+        ActionFactory $actionFactory,
+        ManagerInterface $eventManager,
+        StoreManagerInterface $storeManager,
+        Url $urlModel
+    ) {
+        $this->actionFactory = $actionFactory;
+        $this->eventManager  = $eventManager;
+        $this->storeManager  = $storeManager;
+        $this->urlModel      = $urlModel;
+    }
+
+    /**
+     * Validate and match Product Page and modify request
+     *
+     * @param \Magento\Framework\App\RequestInterface $request The Request
+     *
+     * @return bool
+     */
+    public function match(\Magento\Framework\App\RequestInterface $request)
+    {
+        $action = null;
+
+        $identifier = trim($request->getPathInfo(), '/');
+        $condition = new \Magento\Framework\DataObject(['identifier' => $identifier]);
+
+        $chunks = explode('/', $identifier);
+        $productPath = array_pop($chunks);
+        $categoryPath = implode('/', $chunks);
+
+        if (!empty($categoryPath) && !empty($productPath)) {
+            $this->eventManager->dispatch(
+                'smile_elasticsuite_virtualcategory_controller_router_match_before',
+                ['router' => $this, 'condition' => $condition]
+            );
+
+            $storeId = $this->storeManager->getStore()->getId();
+            $productRewrite = $this->urlModel->getProductRewrite($productPath, $categoryPath, $storeId);
+
+            if ($productRewrite) {
+                $request->setAlias(UrlInterface::REWRITE_REQUEST_PATH_ALIAS, $productRewrite->getRequestPath());
+                $request->setPathInfo('/' . $productRewrite->getTargetPath());
+
+                return $this->actionFactory->create('Magento\Framework\App\Action\Forward');
+            }
+        }
+
+        return $action;
+    }
+}

--- a/src/module-elasticsuite-virtual-category/Controller/Router.php
+++ b/src/module-elasticsuite-virtual-category/Controller/Router.php
@@ -12,11 +12,12 @@
  */
 namespace Smile\ElasticsuiteVirtualCategory\Controller;
 
+use Magento\Catalog\Api\Data\CategoryInterface;
 use Magento\Framework\App\ActionFactory;
-use Magento\Framework\Event\ManagerInterface;
 use Magento\Framework\UrlInterface;
 use Magento\Store\Model\StoreManagerInterface;
 use Smile\ElasticsuiteVirtualCategory\Model\Url;
+use Smile\ElasticsuiteVirtualCategory\Model\VirtualCategory\Root as VirtualCategoryRoot;
 
 /**
  * Router used when accessing a product via an url containing a virtual category request path.
@@ -33,11 +34,6 @@ class Router implements \Magento\Framework\App\RouterInterface
     private $actionFactory;
 
     /**
-     * @var ManagerInterface
-     */
-    private $eventManager;
-
-    /**
      * @var StoreManagerInterface
      */
     private $storeManager;
@@ -48,27 +44,32 @@ class Router implements \Magento\Framework\App\RouterInterface
     private $urlModel;
 
     /**
+     * @var VirtualCategoryRoot
+     */
+    private $virtualCategoryRoot;
+
+    /**
      * Router Constructor
      *
-     * @param ActionFactory         $actionFactory Action Factory
-     * @param ManagerInterface      $eventManager  Event Manager
-     * @param StoreManagerInterface $storeManager  Store Manager
-     * @param Url                   $urlModel      Url Model
+     * @param ActionFactory         $actionFactory       Action Factory
+     * @param StoreManagerInterface $storeManager        Store Manager
+     * @param Url                   $urlModel            Url Model
+     * @param VirtualCategoryRoot   $virtualCategoryRoot Virtual Category Root
      */
     public function __construct(
         ActionFactory $actionFactory,
-        ManagerInterface $eventManager,
         StoreManagerInterface $storeManager,
-        Url $urlModel
+        Url $urlModel,
+        VirtualCategoryRoot $virtualCategoryRoot
     ) {
-        $this->actionFactory = $actionFactory;
-        $this->eventManager  = $eventManager;
-        $this->storeManager  = $storeManager;
-        $this->urlModel      = $urlModel;
+        $this->actionFactory        = $actionFactory;
+        $this->storeManager         = $storeManager;
+        $this->urlModel             = $urlModel;
+        $this->virtualCategoryRoot  = $virtualCategoryRoot;
     }
 
     /**
-     * Validate and match Product Page and modify request
+     * Validate and match Product or Category Page under virtual category navigation and modify request
      *
      * @param \Magento\Framework\App\RequestInterface $request The Request
      *
@@ -79,29 +80,77 @@ class Router implements \Magento\Framework\App\RouterInterface
         $action = null;
 
         $identifier = trim($request->getPathInfo(), '/');
-        $condition = new \Magento\Framework\DataObject(['identifier' => $identifier]);
 
-        $chunks = explode('/', $identifier);
-        $productPath = array_pop($chunks);
-        $categoryPath = implode('/', $chunks);
+        $appliedRoot = $this->getAppliedVirtualCategoryRoot($identifier);
 
-        if (!empty($categoryPath) && !empty($productPath)) {
-            $this->eventManager->dispatch(
-                'smile_elasticsuite_virtualcategory_controller_router_match_before',
-                ['router' => $this, 'condition' => $condition]
-            );
+        if ($appliedRoot && $appliedRoot->getId()) {
+            $this->virtualCategoryRoot->setAppliedRootCategory($appliedRoot);
+        }
 
-            $storeId = $this->storeManager->getStore()->getId();
-            $productRewrite = $this->urlModel->getProductRewrite($productPath, $categoryPath, $storeId);
+        $productRewrite = $this->getProductRewrite($identifier);
+        if ($productRewrite) {
+            $request->setAlias(UrlInterface::REWRITE_REQUEST_PATH_ALIAS, $productRewrite->getRequestPath());
+            $request->setPathInfo('/' . $productRewrite->getTargetPath());
 
-            if ($productRewrite) {
-                $request->setAlias(UrlInterface::REWRITE_REQUEST_PATH_ALIAS, $productRewrite->getRequestPath());
-                $request->setPathInfo('/' . $productRewrite->getTargetPath());
+            return $this->actionFactory->create('Magento\Framework\App\Action\Forward');
+        }
 
-                return $this->actionFactory->create('Magento\Framework\App\Action\Forward');
-            }
+        $categoryRewrite = $this->getCategoryRewrite($identifier);
+        if ($categoryRewrite) {
+            $request->setAlias(UrlInterface::REWRITE_REQUEST_PATH_ALIAS, $identifier);
+            $request->setPathInfo('/' . $categoryRewrite->getTargetPath());
+
+            return $this->actionFactory->create('Magento\Framework\App\Action\Forward');
         }
 
         return $action;
+    }
+
+    /**
+     * Check if the current request could match a product.
+     *
+     * @param string $identifier Current identifier
+     *
+     * @return \Magento\UrlRewrite\Service\V1\Data\UrlRewrite|null
+     */
+    private function getProductRewrite($identifier)
+    {
+        $chunks       = explode('/', $identifier);
+        $productPath  = array_pop($chunks);
+        $categoryPath = implode('/', $chunks);
+        $storeId      = $this->storeManager->getStore()->getId();
+
+        return $this->urlModel->getProductRewrite($productPath, $categoryPath, $storeId);
+    }
+
+    /**
+     * Check if the current request could match a category under a virtual category subtree.
+     *
+     * @param string $identifier Current identifier
+     *
+     * @return \Magento\UrlRewrite\Service\V1\Data\UrlRewrite|null
+     */
+    private function getCategoryRewrite($identifier)
+    {
+        $chunks       = explode('/', $identifier);
+        $categoryPath = array_pop($chunks);
+        $storeId      = $this->storeManager->getStore()->getId();
+
+        return $this->urlModel->getCategoryRewrite($categoryPath, $storeId);
+    }
+
+    /**
+     * Retrieve the current applied virtual category root.
+     *
+     * @param string $identifier Current identifier
+     *
+     * @return CategoryInterface
+     */
+    private function getAppliedVirtualCategoryRoot($identifier)
+    {
+        $urlKeys = explode('/', $identifier);
+        array_pop($urlKeys);
+
+        return $this->virtualCategoryRoot->getByUrlKeys($urlKeys);
     }
 }

--- a/src/module-elasticsuite-virtual-category/Model/Layer/Filter/Category.php
+++ b/src/module-elasticsuite-virtual-category/Model/Layer/Filter/Category.php
@@ -128,11 +128,12 @@ class Category extends \Smile\ElasticsuiteCatalog\Model\Layer\Filter\Category
     {
         if ($this->childrenCategories === null) {
             $currentCategory = $this->getDataProvider()->getCategory();
+            $this->childrenCategories = $currentCategory->getChildrenCategories();
             // Use the root category to retrieve children if needed.
             if ($this->useVirtualRootCategorySubtree($currentCategory)) {
-                $currentCategory = $this->getVirtualRootCategory($currentCategory);
+                $this->childrenCategories = $this->getVirtualRootCategory($currentCategory)->getChildrenCategories();
+                $this->childrenCategories->clear()->addFieldToFilter('entity_id', ['neq' => $currentCategory->getId()]);
             }
-            $this->childrenCategories = $currentCategory->getChildrenCategories();
         }
 
         return $this->childrenCategories;

--- a/src/module-elasticsuite-virtual-category/Model/Layer/Filter/DataProvider/Category.php
+++ b/src/module-elasticsuite-virtual-category/Model/Layer/Filter/DataProvider/Category.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\ElasticsuiteVirtualCategory
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2016 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\ElasticsuiteVirtualCategory\Model\Layer\Filter\DataProvider;
+
+use Magento\Catalog\Model\Category as CategoryModel;
+use Magento\Catalog\Model\CategoryFactory as CategoryModelFactory;
+use Magento\Catalog\Model\Layer;
+use Magento\Framework\Registry;
+use Smile\ElasticsuiteVirtualCategory\Model\VirtualCategory\Root as VirtualCategoryRoot;
+
+/**
+ * Custom Data Provider for Virtual Category Filter
+ *
+ * @category Smile
+ * @package  Smile\ElasticsuiteVirtualCategory
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class Category extends \Magento\Catalog\Model\Layer\Filter\DataProvider\Category
+{
+    /**
+     * @var VirtualCategoryRoot
+     */
+    private $virtualCategoryRoot;
+
+    /**
+     * @param Registry             $coreRegistry        Core Registry
+     * @param CategoryModelFactory $categoryFactory     Category Factory
+     * @param Layer                $layer               Layer
+     * @param VirtualCategoryRoot  $virtualCategoryRoot Virtual Category Root
+     */
+    public function __construct(
+        Registry $coreRegistry,
+        CategoryModelFactory $categoryFactory,
+        Layer $layer,
+        VirtualCategoryRoot $virtualCategoryRoot
+    ) {
+        $this->virtualCategoryRoot = $virtualCategoryRoot;
+
+        parent::__construct($coreRegistry, $categoryFactory, $layer);
+    }
+
+    /**
+     * Retrieve the currently applied root category.
+     * This is true when browsing a subtree of a virtual category having a "Virtual Root Category".
+     *
+     * @return \Magento\Catalog\Api\Data\CategoryInterface|null
+     */
+    public function getAppliedRootCategory()
+    {
+        return $this->virtualCategoryRoot->getAppliedRootCategory();
+    }
+}

--- a/src/module-elasticsuite-virtual-category/Model/Rule.php
+++ b/src/module-elasticsuite-virtual-category/Model/Rule.php
@@ -165,7 +165,7 @@ class Rule extends \Smile\ElasticsuiteCatalogRule\Model\Rule implements VirtualR
      *
      * @return CategoryInterface
      */
-    private function getVirtualRootCategory(CategoryInterface $category)
+    public function getVirtualRootCategory(CategoryInterface $category)
     {
         $storeId      = $this->getStoreId();
         $rootCategory = $this->categoryFactory->create()->setStoreId($storeId);
@@ -180,6 +180,24 @@ class Rule extends \Smile\ElasticsuiteCatalogRule\Model\Rule implements VirtualR
         }
 
         return $rootCategory;
+    }
+
+    /**
+     * Combine several category queries
+     *
+     * @param CategoryInterface[] $categories The categories
+     *
+     * @return QueryInterface
+     */
+    public function mergeCategoryQueries(array $categories)
+    {
+        $queries = [];
+
+        foreach ($categories as $category) {
+            $queries[] = $this->getCategorySearchQuery($category);
+        }
+
+        return $this->queryFactory->create(QueryInterface::TYPE_BOOL, ['must' => $queries]);
     }
 
     /**
@@ -227,7 +245,7 @@ class Rule extends \Smile\ElasticsuiteCatalogRule\Model\Rule implements VirtualR
      * Append children queries to the rule.
      *
      * @param QueryInterface|NULL $query              Base query.
-     * @param CategoryInterface   $category           Current cayegory.
+     * @param CategoryInterface   $category           Current category.
      * @param array               $excludedCategories Category already used into the building stack. Avoid short circuit.
      *
      * @return \Smile\ElasticsuiteCore\Search\Request\QueryInterface

--- a/src/module-elasticsuite-virtual-category/Model/Url.php
+++ b/src/module-elasticsuite-virtual-category/Model/Url.php
@@ -12,14 +12,16 @@
  */
 namespace Smile\ElasticsuiteVirtualCategory\Model;
 
-use Magento\Catalog\Api\CategoryRepositoryInterface;
+use Magento\Catalog\Api\Data\CategoryInterface;
+use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\UrlInterface;
 use Magento\Store\Model\ScopeInterface;
 use Magento\Store\Model\StoreManagerInterface;
-use Magento\Catalog\Model\ResourceModel\Category\CollectionFactory as CategoryCollectionFactory;
+use Smile\ElasticsuiteVirtualCategory\Model\ResourceModel\VirtualCategory\CollectionFactory as CategoryCollectionFactory;
 use Magento\UrlRewrite\Model\UrlFinderInterface;
 use Magento\UrlRewrite\Service\V1\Data\UrlRewrite;
+use Smile\ElasticsuiteVirtualCategory\Model\VirtualCategory\Root as VirtualCategoryRoot;
 
 /**
  * Url Model for Virtual Categories
@@ -36,16 +38,16 @@ class Url
     const XML_PATH_PRODUCT_URL_SUFFIX = 'catalog/seo/product_url_suffix';
 
     /**
+     * XML path for product url suffix
+     */
+    const XML_PATH_CATEGORY_URL_SUFFIX = 'catalog/seo/category_url_suffix';
+
+    /**
      * Store config
      *
      * @var \Magento\Framework\App\Config\ScopeConfigInterface
      */
     private $scopeConfig;
-
-    /**
-     * @var CategoryRepositoryInterface
-     */
-    private $categoryRepository;
 
     /**
      * @var \Magento\Store\Model\StoreManagerInterface
@@ -63,36 +65,31 @@ class Url
     private $urlFinder;
 
     /**
-     * Url Builder
-     *
-     * @var \Magento\Framework\UrlInterface
+     * @var VirtualCategoryRoot
      */
-    private $urlBuilder;
+    private $virtualCategoryRoot;
 
     /**
      * ProductPlugin constructor.
      *
-     * @param ScopeConfigInterface        $scopeConfig               Scope Configuration
-     * @param CategoryRepositoryInterface $categoryRepository        Category Repository
-     * @param StoreManagerInterface       $storeManager              Store Manager Interface
-     * @param CategoryCollectionFactory   $categoryCollectionFactory Category Collection Factory
-     * @param UrlFinderInterface          $urlFinder                 URL Finder
-     * @param UrlInterface                $urlInterface              URL Interface
+     * @param ScopeConfigInterface      $scopeConfig               Scope Configuration
+     * @param StoreManagerInterface     $storeManager              Store Manager Interface
+     * @param CategoryCollectionFactory $categoryCollectionFactory Category Collection Factory
+     * @param UrlFinderInterface        $urlFinder                 URL Finder
+     * @param VirtualCategoryRoot       $virtualCategoryRoot       Virtual Category Root model
      */
     public function __construct(
         ScopeConfigInterface $scopeConfig,
-        CategoryRepositoryInterface $categoryRepository,
         StoreManagerInterface $storeManager,
         CategoryCollectionFactory $categoryCollectionFactory,
         UrlFinderInterface $urlFinder,
-        UrlInterface $urlInterface
+        VirtualCategoryRoot $virtualCategoryRoot
     ) {
         $this->scopeConfig               = $scopeConfig;
-        $this->categoryRepository        = $categoryRepository;
         $this->storeManager              = $storeManager;
         $this->categoryCollectionFactory = $categoryCollectionFactory;
         $this->urlFinder                 = $urlFinder;
-        $this->urlBuilder                = $urlInterface;
+        $this->virtualCategoryRoot       = $virtualCategoryRoot;
     }
 
     /**
@@ -111,7 +108,8 @@ class Url
 
     /**
      * Retrieve rewrite object for a given product/category request path couple.
-     * Will only succeed if the category path is related to a virtual one.
+     *
+     * @SuppressWarnings(PHPMD.ElseExpression)
      *
      * @param string   $productRequestPath  A product Request Path
      * @param string   $categoryRequestPath A category Request Path
@@ -127,7 +125,15 @@ class Url
             $storeId = $this->storeManager->getStore()->getId();
         }
 
-        $categoryId = $this->getVirtualCategoryIdByPath($categoryRequestPath);
+        if (!$this->virtualCategoryRoot->getAppliedRootCategory()) {
+            $categoryId = $this->getVirtualCategoryIdByPath($categoryRequestPath);
+        } else {
+            $urlKeys = explode('/', $categoryRequestPath);
+            $urlKey  = array_pop($urlKeys);
+            $category = $this->loadCategoryByUrlKey($urlKey);
+            $categoryId = $category->getId();
+        }
+
         if ($categoryId) {
             $productRewrite = $this->urlFinder->findOneByData([
                 UrlRewrite::REQUEST_PATH => trim($productRequestPath, '/'),
@@ -154,18 +160,69 @@ class Url
      */
     public function getProductRequestPath($product, $category)
     {
-        $requestPath = null;
+        $requestPath     = null;
+        $categoryUrlPath = null;
+        $productUrlKey   = $product->getUrlKey();
 
         if ($this->isVirtualCategory($category) && $this->useCategoryPath()) {
             $categoryUrlPath = $category->getUrlPath();
-            $productUrlKey = $product->getUrlKey();
-            if ($productUrlKey) {
-                $suffix = $this->scopeConfig->getValue(self::XML_PATH_PRODUCT_URL_SUFFIX, ScopeInterface::SCOPE_STORE);
-                $requestPath = $categoryUrlPath . '/' . $productUrlKey . $suffix;
-            }
+        } elseif ($this->virtualCategoryRoot->getAppliedRootCategory() && $this->useCategoryPath()) {
+            $categoryUrlPath = $this->virtualCategoryRoot->getVirtualCategorySubtreePath(
+                $this->virtualCategoryRoot->getAppliedRootCategory(),
+                $category
+            );
+        }
+
+        if ($categoryUrlPath && $productUrlKey) {
+            $requestPath = $categoryUrlPath . '/' . $productUrlKey . $this->getProductUrlSuffix();
         }
 
         return $requestPath;
+    }
+
+    /**
+     * Build an url for a category being viewed under the subtree of a virtual category
+     *
+     * @param CategoryInterface $appliedRootCategory The applied root category
+     * @param CategoryInterface $childCategory       The child category to retrieve Url for.
+     *
+     * @return string
+     */
+    public function getVirtualCategorySubtreeUrl($appliedRootCategory, $childCategory)
+    {
+        $path = $this->virtualCategoryRoot->getVirtualCategorySubtreePath($appliedRootCategory, $childCategory);
+        $url  = $path . $this->getCategoryUrlSuffix();
+
+        $baseUrl = $childCategory->getUrlInstance()->getBaseUrl();
+
+        return $baseUrl . $url;
+    }
+
+    /**
+     * Retrieve Category Url Rewrite by path and Store.
+     *
+     * @param string $categoryPath A category Path
+     * @param int    $storeId      The Store Id
+     *
+     * @return \Magento\UrlRewrite\Service\V1\Data\UrlRewrite|null
+     */
+    public function getCategoryRewrite($categoryPath, $storeId)
+    {
+        $categoryPath = str_replace($this->getCategoryUrlSuffix(), '', $categoryPath);
+        $category = $this->loadCategoryByUrlKey($categoryPath);
+        $rewrite  = null;
+
+        if ($category && $category->getId()) {
+            $rewrite = $this->urlFinder->findOneByData([
+                UrlRewrite::ENTITY_ID   => $category->getId(),
+                UrlRewrite::STORE_ID    => $storeId,
+                UrlRewrite::ENTITY_TYPE => 'category',
+            ]);
+
+            $rewrite->setRequestPath($rewrite->getTargetPath());
+        }
+
+        return $rewrite;
     }
 
     /**
@@ -183,6 +240,24 @@ class Url
         }
 
         return false;
+    }
+
+    /**
+     * Load a category by Url key.
+     *
+     * @param string $requestPath The Request Path
+     *
+     * @return \Magento\Framework\DataObject
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    private function loadCategoryByUrlKey($requestPath)
+    {
+        $collection = $this->categoryCollectionFactory->create();
+
+        $collection->setStoreId($this->storeManager->getStore()->getId())
+            ->addAttributeToFilter('url_key', ['eq' => $requestPath]);
+
+        return $collection->getFirstItem();
     }
 
     /**
@@ -225,7 +300,27 @@ class Url
     {
         return (bool) $this->scopeConfig->getValue(
             \Magento\Catalog\Helper\Product::XML_PATH_PRODUCT_URL_USE_CATEGORY,
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+            ScopeInterface::SCOPE_STORE
         );
+    }
+
+    /**
+     * Retrieve Product Url suffix
+     *
+     * @return string
+     */
+    private function getProductUrlSuffix()
+    {
+        return $this->scopeConfig->getValue(self::XML_PATH_PRODUCT_URL_SUFFIX, ScopeInterface::SCOPE_STORE);
+    }
+
+    /**
+     * Retrieve Category Url suffix
+     *
+     * @return string
+     */
+    private function getCategoryUrlSuffix()
+    {
+        return $this->scopeConfig->getValue(self::XML_PATH_CATEGORY_URL_SUFFIX, ScopeInterface::SCOPE_STORE);
     }
 }

--- a/src/module-elasticsuite-virtual-category/Model/Url.php
+++ b/src/module-elasticsuite-virtual-category/Model/Url.php
@@ -159,8 +159,10 @@ class Url
         if ($this->isVirtualCategory($category) && $this->useCategoryPath()) {
             $categoryUrlPath = $category->getUrlPath();
             $productUrlKey = $product->getUrlKey();
-            $suffix = $this->scopeConfig->getValue(self::XML_PATH_PRODUCT_URL_SUFFIX, ScopeInterface::SCOPE_STORE);
-            $requestPath = $categoryUrlPath . '/' . $productUrlKey . $suffix;
+            if ($productUrlKey) {
+                $suffix = $this->scopeConfig->getValue(self::XML_PATH_PRODUCT_URL_SUFFIX, ScopeInterface::SCOPE_STORE);
+                $requestPath = $categoryUrlPath . '/' . $productUrlKey . $suffix;
+            }
         }
 
         return $requestPath;

--- a/src/module-elasticsuite-virtual-category/Model/Url.php
+++ b/src/module-elasticsuite-virtual-category/Model/Url.php
@@ -1,0 +1,229 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\ElasticsuiteVirtualCategory
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2016 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\ElasticsuiteVirtualCategory\Model;
+
+use Magento\Catalog\Api\CategoryRepositoryInterface;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\UrlInterface;
+use Magento\Store\Model\ScopeInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\Catalog\Model\ResourceModel\Category\CollectionFactory as CategoryCollectionFactory;
+use Magento\UrlRewrite\Model\UrlFinderInterface;
+use Magento\UrlRewrite\Service\V1\Data\UrlRewrite;
+
+/**
+ * Url Model for Virtual Categories
+ *
+ * @category Smile
+ * @package  Smile\ElasticsuiteVirtualCategory
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class Url
+{
+    /**
+     * XML path for product url suffix
+     */
+    const XML_PATH_PRODUCT_URL_SUFFIX = 'catalog/seo/product_url_suffix';
+
+    /**
+     * Store config
+     *
+     * @var \Magento\Framework\App\Config\ScopeConfigInterface
+     */
+    private $scopeConfig;
+
+    /**
+     * @var CategoryRepositoryInterface
+     */
+    private $categoryRepository;
+
+    /**
+     * @var \Magento\Store\Model\StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
+     * @var \Magento\Catalog\Model\ResourceModel\Category\CollectionFactory
+     */
+    private $categoryCollectionFactory;
+
+    /**
+     * @var \Magento\UrlRewrite\Model\UrlFinderInterface
+     */
+    private $urlFinder;
+
+    /**
+     * Url Builder
+     *
+     * @var \Magento\Framework\UrlInterface
+     */
+    private $urlBuilder;
+
+    /**
+     * ProductPlugin constructor.
+     *
+     * @param ScopeConfigInterface        $scopeConfig               Scope Configuration
+     * @param CategoryRepositoryInterface $categoryRepository        Category Repository
+     * @param StoreManagerInterface       $storeManager              Store Manager Interface
+     * @param CategoryCollectionFactory   $categoryCollectionFactory Category Collection Factory
+     * @param UrlFinderInterface          $urlFinder                 URL Finder
+     * @param UrlInterface                $urlInterface              URL Interface
+     */
+    public function __construct(
+        ScopeConfigInterface $scopeConfig,
+        CategoryRepositoryInterface $categoryRepository,
+        StoreManagerInterface $storeManager,
+        CategoryCollectionFactory $categoryCollectionFactory,
+        UrlFinderInterface $urlFinder,
+        UrlInterface $urlInterface
+    ) {
+        $this->scopeConfig               = $scopeConfig;
+        $this->categoryRepository        = $categoryRepository;
+        $this->storeManager              = $storeManager;
+        $this->categoryCollectionFactory = $categoryCollectionFactory;
+        $this->urlFinder                 = $urlFinder;
+        $this->urlBuilder                = $urlInterface;
+    }
+
+    /**
+     * Retrieve Url for a given product/category couple
+     *
+     * @param \Magento\Catalog\Model\Product  $product  A Product
+     * @param \Magento\Catalog\Model\Category $category A Category
+     * @param array                           $params   Additional Url Params, if needed
+     *
+     * @return string
+     */
+    public function getProductUrl($product, $category, $params = null)
+    {
+        return trim($this->urlBuilder->getUrl($this->getProductRequestPath($product, $category), $params), '/');
+    }
+
+    /**
+     * Retrieve rewrite object for a given product/category request path couple.
+     * Will only succeed if the category path is related to a virtual one.
+     *
+     * @param string   $productRequestPath  A product Request Path
+     * @param string   $categoryRequestPath A category Request Path
+     * @param int|null $storeId             Store Id
+     *
+     * @return \Magento\UrlRewrite\Service\V1\Data\UrlRewrite|null
+     */
+    public function getProductRewrite($productRequestPath, $categoryRequestPath, $storeId = null)
+    {
+        $productRewrite = null;
+
+        if (null === $storeId) {
+            $storeId = $this->storeManager->getStore()->getId();
+        }
+
+        $categoryId = $this->getVirtualCategoryIdByPath($categoryRequestPath);
+        if ($categoryId) {
+            $productRewrite = $this->urlFinder->findOneByData([
+                UrlRewrite::REQUEST_PATH => trim($productRequestPath, '/'),
+                UrlRewrite::STORE_ID     => $storeId,
+            ]);
+
+            if (null !== $productRewrite) {
+                $targetPath = $productRewrite->getTargetPath();
+                $targetPath .= "/category/{$categoryId}";
+                $productRewrite->setTargetPath($targetPath);
+            }
+        }
+
+        return $productRewrite;
+    }
+
+    /**
+     * Retrieve request path for the product and a virtual category.
+     *
+     * @param \Magento\Catalog\Model\Product  $product  The product
+     * @param \Magento\Catalog\Model\Category $category The product
+     *
+     * @return string
+     */
+    public function getProductRequestPath($product, $category)
+    {
+        $requestPath = null;
+
+        if ($this->isVirtualCategory($category) && $this->useCategoryPath()) {
+            $categoryUrlPath = $category->getUrlPath();
+            $productUrlKey = $product->getUrlKey();
+            $suffix = $this->scopeConfig->getValue(self::XML_PATH_PRODUCT_URL_SUFFIX, ScopeInterface::SCOPE_STORE);
+            $requestPath = $categoryUrlPath . '/' . $productUrlKey . $suffix;
+        }
+
+        return $requestPath;
+    }
+
+    /**
+     * Retrieve a virtual Category Id by its path
+     *
+     * @param string $categoryPath The category Path
+     *
+     * @return int|bool
+     */
+    private function getVirtualCategoryIdByPath($categoryPath)
+    {
+        $category = $this->loadVirtualCategoryByUrlPath($categoryPath);
+        if ($category->getId()) {
+            return $category->getId();
+        }
+
+        return false;
+    }
+
+    /**
+     * Load a virtual category by request path.
+     *
+     * @param string $requestPath The Request Path
+     *
+     * @return \Magento\Framework\DataObject
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    private function loadVirtualCategoryByUrlPath($requestPath)
+    {
+        $collection = $this->categoryCollectionFactory->create();
+
+        $collection->setStoreId($this->storeManager->getStore()->getId())
+            ->addAttributeToFilter('url_path', ['eq' => $requestPath])
+            ->addAttributeToFilter('is_virtual_category', ['eq' => 1]);
+
+        return $collection->getFirstItem();
+    }
+
+    /**
+     * Check if a category is virtual.
+     *
+     * @param \Magento\Catalog\Model\Category $category The category
+     *
+     * @return bool
+     */
+    private function isVirtualCategory($category)
+    {
+        return (bool) $category->getIsVirtualCategory();
+    }
+
+    /**
+     * Check if urls should be rendered by including the category path.
+     *
+     * @return bool
+     */
+    private function useCategoryPath()
+    {
+        return (bool) $this->scopeConfig->getValue(
+            \Magento\Catalog\Helper\Product::XML_PATH_PRODUCT_URL_USE_CATEGORY,
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+        );
+    }
+}

--- a/src/module-elasticsuite-virtual-category/Model/VirtualCategory/Root.php
+++ b/src/module-elasticsuite-virtual-category/Model/VirtualCategory/Root.php
@@ -154,8 +154,7 @@ class Root
         array_pop($rootPathIds);
         array_push($rootPathIds, $appliedRoot->getId());
 
-        $pathInStore = $category->getPathInStore();
-        $pathIds     = array_reverse(explode(',', $pathInStore));
+        $pathIds     = $category->getPathIds();
         $pivotIndex  = array_search($appliedRootId, $pathIds);
         $pathIds     = array_slice($pathIds, $pivotIndex + 1);
         $categoryIds = array_merge($rootPathIds, $pathIds);

--- a/src/module-elasticsuite-virtual-category/Model/VirtualCategory/Root.php
+++ b/src/module-elasticsuite-virtual-category/Model/VirtualCategory/Root.php
@@ -1,0 +1,186 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\ElasticsuiteVirtualCategory
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2016 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\ElasticsuiteVirtualCategory\Model\VirtualCategory;
+
+use Magento\Catalog\Api\Data\CategoryInterface;
+use Magento\Framework\Registry;
+use Magento\Store\Model\StoreManagerInterface;
+use Smile\ElasticsuiteVirtualCategory\Model\ResourceModel\VirtualCategory\CollectionFactory as CategoryCollectionFactory;
+
+/**
+ * Model for "Root Category" of virtual categories.
+ *
+ * @category Smile
+ * @package  Smile\ElasticsuiteVirtualCategory
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class Root
+{
+    /**
+     * @var Registry
+     */
+    private $coreRegistry;
+
+    /**
+     * @var \Smile\ElasticsuiteVirtualCategory\Model\ResourceModel\VirtualCategory\CollectionFactory
+     */
+    private $categoryCollectionFactory;
+
+    /**
+     * @var \Magento\Store\Model\StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
+     * Virtual Category Root constructor.
+     *
+     * @param Registry                  $coreRegistry              Category Repository
+     * @param CategoryCollectionFactory $categoryCollectionFactory Category Collection Factory
+     * @param StoreManagerInterface     $storeManagerInterface     Store Manager
+     */
+    public function __construct(
+        Registry $coreRegistry,
+        CategoryCollectionFactory $categoryCollectionFactory,
+        StoreManagerInterface $storeManagerInterface
+    ) {
+        $this->coreRegistry = $coreRegistry;
+        $this->categoryCollectionFactory = $categoryCollectionFactory;
+        $this->storeManager = $storeManagerInterface;
+    }
+
+    /**
+     * Set the currently applied "virtual root category", if any
+     *
+     * @param CategoryInterface $category The category
+     *
+     * @return $this
+     */
+    public function setAppliedRootCategory(CategoryInterface $category)
+    {
+        $this->coreRegistry->register('applied_virtual_root_category', $category);
+
+        return $this;
+    }
+
+    /**
+     * Retrieve the currently applied root category, if any.
+     *
+     * @return \Magento\Catalog\Model\Category|null
+     */
+    public function getAppliedRootCategory()
+    {
+        if ($this->coreRegistry->registry('applied_virtual_root_category')) {
+            $appliedRoot = $this->coreRegistry->registry('applied_virtual_root_category');
+            if ($appliedRoot && $appliedRoot->getId()) {
+                return $appliedRoot;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Rebuild an URL path for a category under a virtual root category
+     *
+     * @param CategoryInterface $appliedRootCategory The applied root category
+     * @param CategoryInterface $childCategory       The child category to retrieve Url for.
+     *
+     * @return string
+     */
+    public function getVirtualCategorySubtreePath($appliedRootCategory, $childCategory)
+    {
+        $categoryIds = $this->getSubtreePathIds($appliedRootCategory, $childCategory);
+
+        $categories = $this->getCategoriesByIds($categoryIds);
+
+        $urls = [];
+        foreach ($categoryIds as $categoryId) {
+            $category = $categories[$categoryId];
+            $urls[] = $category->getUrlKey();
+        }
+
+        return implode('/', $urls);
+    }
+
+    /**
+     * Retrieve the "virtual category root" currently applied.
+     * This is the case when browsing the subtree of a virtual category.
+     *
+     * @param array $urlKeys Url keys currently applied. Extracted from current Url.
+     *
+     * @return \Magento\Framework\DataObject
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function getByUrlKeys($urlKeys)
+    {
+        $collection = $this->categoryCollectionFactory->create();
+
+        $collection->setStoreId($this->storeManager->getStore()->getId())
+            ->addIsActiveFilter()
+            ->addNameToResult()
+            ->addAttributeToSelect('virtual_category_root')
+            ->addAttributeToSelect('virtual_rule')
+            ->addAttributeToSelect('url_path')
+            ->addAttributeToFilter('url_key', ['in' => $urlKeys])
+            ->addAttributeToFilter('is_virtual_category', ['eq' => 1])
+            ->addAttributeToFilter('generate_root_category_subtree', ['eq' => 1]);
+
+        return $collection->getFirstItem();
+    }
+
+    /**
+     * Retrieve a rebuilt path_ids for a given child category under a virtual category subtree.
+     *
+     * @param CategoryInterface $appliedRoot Applied Root Category
+     * @param CategoryInterface $category    Child Category
+     *
+     * @return array
+     */
+    public function getSubtreePathIds($appliedRoot, $category)
+    {
+        $rootPathIds   = array_reverse(explode(',', $appliedRoot->getPathInStore()));
+        $appliedRootId = $appliedRoot->getVirtualCategoryRoot();
+
+        array_pop($rootPathIds);
+        array_push($rootPathIds, $appliedRoot->getId());
+
+        $pathInStore = $category->getPathInStore();
+        $pathIds     = array_reverse(explode(',', $pathInStore));
+        $pivotIndex  = array_search($appliedRootId, $pathIds);
+        $pathIds     = array_slice($pathIds, $pivotIndex + 1);
+        $categoryIds = array_merge($rootPathIds, $pathIds);
+
+        return $categoryIds;
+    }
+
+    /**
+     * Retrieve categories by their Ids
+     *
+     * @param array $categoryIds The category Ids
+     *
+     * @return CategoryInterface[]
+     */
+    private function getCategoriesByIds($categoryIds)
+    {
+        $collection = $this->categoryCollectionFactory->create();
+
+        $collection->addIsActiveFilter()
+            ->addUrlRewriteToResult()
+            ->addNameToResult()
+            ->addAttributeToSelect('url_path')
+            ->addAttributeToSelect('url_key')
+            ->addIdFilter($categoryIds);
+
+        return $collection->getItems();
+    }
+}

--- a/src/module-elasticsuite-virtual-category/Observer/DisplaySubtreeCategoryAsProductOnly.php
+++ b/src/module-elasticsuite-virtual-category/Observer/DisplaySubtreeCategoryAsProductOnly.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\ElasticsuiteVirtualCategory
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2016 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\ElasticsuiteVirtualCategory\Observer;
+
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use Smile\ElasticsuiteVirtualCategory\Model\VirtualCategory\Root as VirtualCategoryRoot;
+use Magento\Framework\Registry;
+
+/**
+ * Observer that handle proper category display when rendered under subtree of a virtual category root.
+ *
+ * @category Smile
+ * @package  Smile\ElasticsuiteVirtualCategory
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class DisplaySubtreeCategoryAsProductOnly implements ObserverInterface
+{
+    /**
+     * @var VirtualCategoryRoot
+     */
+    private $virtualCategoryRoot;
+
+    /**
+     * @var \Magento\Framework\Registry
+     */
+    private $registry;
+
+    /**
+     * Topmenu constructor.
+     *
+     * @param VirtualCategoryRoot $virtualCategoryRoot Virtual Category Root
+     * @param Registry            $registry            Registry
+     */
+    public function __construct(VirtualCategoryRoot $virtualCategoryRoot, Registry $registry)
+    {
+        $this->virtualCategoryRoot = $virtualCategoryRoot;
+        $this->registry            = $registry;
+    }
+
+    /**
+     * Set the category to display mode "product only" if viewed under the subtree of a virtual category root.
+     *
+     * @param Observer $observer The observer
+     *
+     * @return void
+     */
+    public function execute(\Magento\Framework\Event\Observer $observer)
+    {
+        if ($this->virtualCategoryRoot->getAppliedRootCategory()) {
+            $category = $observer->getCategory();
+            $category->setDisplayMode(\Magento\Catalog\Model\Category::DM_PRODUCT);
+            if ($this->registry->registry('current_category')) {
+                $this->registry->registry('current_category')->setDisplayMode(\Magento\Catalog\Model\Category::DM_PRODUCT);
+            }
+        }
+    }
+}

--- a/src/module-elasticsuite-virtual-category/Observer/Topmenu.php
+++ b/src/module-elasticsuite-virtual-category/Observer/Topmenu.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\ElasticsuiteVirtualCategory
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2016 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\ElasticsuiteVirtualCategory\Observer;
+
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use Smile\ElasticsuiteVirtualCategory\Model\VirtualCategory\Root as VirtualCategoryRoot;
+
+/**
+ * Topmenu observer for virtual categories.
+ * Used to properly set "has_active" property on categories when being viewed under a virtual category subtree
+ *
+ * @category Smile
+ * @package  Smile\ElasticsuiteVirtualCategory
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class Topmenu implements ObserverInterface
+{
+    /**
+     * @var VirtualCategoryRoot
+     */
+    private $virtualCategoryRoot;
+
+    /**
+     * Topmenu constructor.
+     *
+     * @param VirtualCategoryRoot $virtualCategoryRoot Virtual Category Root
+     */
+    public function __construct(VirtualCategoryRoot $virtualCategoryRoot)
+    {
+        $this->virtualCategoryRoot = $virtualCategoryRoot;
+    }
+
+    /**
+     * @param Observer $observer The observer
+     *
+     * @return void
+     */
+    public function execute(\Magento\Framework\Event\Observer $observer)
+    {
+        $appliedRoot = $this->virtualCategoryRoot->getAppliedRootCategory();
+        if ($appliedRoot && $appliedRoot->getPath()) {
+            foreach ($observer->getMenu()->getChildren() as $category) {
+                $categoryId = preg_replace("/[^0-9]/", "", $category->getId());
+                $hasActive  = in_array((string) $categoryId, explode('/', $appliedRoot->getPath()), true);
+                $category->setHasActive($hasActive);
+            }
+        }
+    }
+}

--- a/src/module-elasticsuite-virtual-category/Plugin/Catalog/DesignPlugin.php
+++ b/src/module-elasticsuite-virtual-category/Plugin/Catalog/DesignPlugin.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\ElasticSuite________
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2016 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\ElasticsuiteVirtualCategory\Plugin\Catalog;
+
+use Magento\Catalog\Model\Design;
+use Smile\ElasticsuiteVirtualCategory\Model\VirtualCategory\Root as VirtualCategoryRoot;
+
+/**
+ * Plugin for Catalog Design, to ensure discarding custom design for categories being viewed under the subtree of a virtual category.
+ *
+ * @category Smile
+ * @package  Smile\ElasticsuiteVirtualCategory
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class DesignPlugin
+{
+    /**
+     * @var VirtualCategoryRoot
+     */
+    private $virtualCategoryRoot;
+
+    /**
+     * DesignPlugin constructor.
+     *
+     * @param VirtualCategoryRoot $virtualCategoryRoot Virtual Category Root Model
+     */
+    public function __construct(VirtualCategoryRoot $virtualCategoryRoot)
+    {
+        $this->virtualCategoryRoot = $virtualCategoryRoot;
+    }
+
+    /**
+     * Discard custom rendering for category if being viewed under a virtual root category.
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     *
+     * @param Design                                                         $design  Catalog Design Model
+     * @param \Closure                                                       $proceed The legacy getDesignSettings method
+     * @param \Magento\Catalog\Model\Category|\Magento\Catalog\Model\Product $object  Catalog Object
+     *
+     * @return mixed
+     */
+    public function aroundGetDesignSettings(Design $design, \Closure $proceed, $object)
+    {
+        if (!($object instanceof \Magento\Catalog\Model\Product)) {
+            if ($this->virtualCategoryRoot->getAppliedRootCategory()) {
+                return new \Magento\Framework\DataObject();
+            }
+        }
+
+        return $proceed($object);
+    }
+}

--- a/src/module-elasticsuite-virtual-category/Plugin/Catalog/Helper/BreadcrumbPlugin.php
+++ b/src/module-elasticsuite-virtual-category/Plugin/Catalog/Helper/BreadcrumbPlugin.php
@@ -1,0 +1,193 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\ElasticsuiteVirtualCategory
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2016 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\ElasticsuiteVirtualCategory\Plugin\Catalog\Helper;
+
+use Magento\Catalog\Api\Data\CategoryInterface;
+use Smile\ElasticsuiteVirtualCategory\Model\VirtualCategory\Root as VirtualCategoryRoot;
+use Smile\ElasticsuiteVirtualCategory\Model\ResourceModel\VirtualCategory\CollectionFactory as CategoryCollectionFactory;
+use Smile\ElasticsuiteVirtualCategory\Model\Url as UrlModel;
+
+/**
+ * Plugin on Catalog Helper Data, to ensure breadcrumb is correctly displayed when browsing a virtual category subtree.
+ *
+ * @category Smile
+ * @package  Smile\ElasticsuiteVirtualCategory
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class BreadcrumbPlugin
+{
+    /**
+     * @var VirtualCategoryRoot
+     */
+    private $virtualCategoryRoot;
+
+    /**
+     * @var null
+     */
+    private $categoryPath;
+
+    /**
+     * @var \Smile\ElasticsuiteVirtualCategory\Model\ResourceModel\VirtualCategory\CollectionFactory
+     */
+    private $categoryCollectionFactory;
+
+    /**
+     * @var \Smile\ElasticsuiteVirtualCategory\Model\Url
+     */
+    private $urlModel;
+
+    /**
+     * BreadCrumb plugin constructor.
+     *
+     * @param VirtualCategoryRoot       $virtualCategoryRoot       Virtual Category Root
+     * @param CategoryCollectionFactory $categoryCollectionFactory Category Collection Factory
+     * @param UrlModel                  $urlModel                  Category URL Model
+     */
+    public function __construct(
+        VirtualCategoryRoot $virtualCategoryRoot,
+        CategoryCollectionFactory $categoryCollectionFactory,
+        UrlModel $urlModel
+    ) {
+        $this->virtualCategoryRoot = $virtualCategoryRoot;
+        $this->categoryCollectionFactory = $categoryCollectionFactory;
+        $this->urlModel = $urlModel;
+    }
+
+    /**
+     * Modify breadcrumb path if needed :
+     *  - if viewing a category under the subtree of a virtual category.
+     *
+     * @param \Magento\Catalog\Helper\Data $helper  Catalog Helper
+     * @param \Closure                     $proceed The Catalog Helper getBreadcrumbPath() function
+     *
+     * @return array
+     */
+    public function aroundGetBreadcrumbPath(\Magento\Catalog\Helper\Data $helper, \Closure $proceed)
+    {
+        $appliedRoot = $this->virtualCategoryRoot->getAppliedRootCategory();
+        if ($appliedRoot) {
+            return $this->getSubtreeBreadcrumbPath($helper, $appliedRoot);
+        }
+
+        return $proceed();
+    }
+
+    /**
+     * Retrieve Breadcrumb for a category viewed under a virtual root category subtree.
+     *
+     * @param \Magento\Catalog\Helper\Data    $helper      Catalog Helper
+     * @param \Magento\Catalog\Model\Category $appliedRoot Currently applied root category
+     *
+     * @return array
+     */
+    private function getSubtreeBreadcrumbPath($helper, $appliedRoot)
+    {
+        if (!$this->categoryPath) {
+            $path     = [];
+            $category = $helper->getCategory();
+
+            if ($category) {
+                $appliedRootId = $appliedRoot->getVirtualCategoryRoot();
+                $pathIds       = array_reverse(explode(',', $category->getPathInStore()));
+                $pathIds       = array_slice($pathIds, array_search($appliedRootId, $pathIds) + 1);
+
+                $categoryIds = $this->virtualCategoryRoot->getSubtreePathIds($appliedRoot, $category);
+                $categories  = $this->getCategoriesByIds($categoryIds);
+                foreach ($categoryIds as $categoryId) {
+                    if (isset($categories[$categoryId]) && $categories[$categoryId]->getName()) {
+                        $link = '';
+                        if ($this->isCategoryLink($helper, $categoryId)) {
+                            $link = $this->getCategoryUrl($categories[$categoryId], $pathIds);
+                        }
+                        $path['category' . $categoryId] = [
+                            'label' => $categories[$categoryId]->getName(),
+                            'link' => $link,
+                        ];
+                    }
+                }
+            }
+
+            if ($helper->getProduct()) {
+                $path['product'] = ['label' => $helper->getProduct()->getName()];
+            }
+
+            $this->categoryPath = $path;
+        }
+
+        return $this->categoryPath;
+    }
+
+    /**
+     * Retrieve a category URL for Breadcrumb item.
+     *
+     * @param CategoryInterface $category Category
+     * @param array             $pathIds  Path Ids of the categories belonging to the subtree
+     *
+     * @return string
+     */
+    private function getCategoryUrl($category, $pathIds)
+    {
+        $url = $category->getUrl();
+
+        // This category is under the subtree, recompute its url.
+        if (in_array($category->getId(), $pathIds)) {
+            $url = $this->urlModel->getVirtualCategorySubtreeUrl(
+                $this->virtualCategoryRoot->getAppliedRootCategory(),
+                $category
+            );
+        }
+
+        return $url;
+    }
+
+    /**
+     * Check is category link
+     *
+     * @param \Magento\Catalog\Helper\Data $helper     Catalog Helper
+     * @param int                          $categoryId Category Id
+     *
+     * @return bool
+     */
+    private function isCategoryLink($helper, $categoryId)
+    {
+        if ($helper->getProduct()) {
+            return true;
+        }
+        if ($categoryId != $helper->getCategory()->getId()) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Retrieve categories by their Ids
+     *
+     * @param array $categoryIds The category Ids
+     *
+     * @return CategoryInterface[]
+     */
+    private function getCategoriesByIds($categoryIds)
+    {
+        $collection = $this->categoryCollectionFactory->create();
+
+        $collection->addIsActiveFilter()
+            ->addUrlRewriteToResult()
+            ->addNameToResult()
+            ->addAttributeToSelect('url_path')
+            ->addAttributeToSelect('url_key')
+            ->addIdFilter($categoryIds);
+
+        return $collection->getItems();
+    }
+}

--- a/src/module-elasticsuite-virtual-category/Plugin/Catalog/ProductPlugin.php
+++ b/src/module-elasticsuite-virtual-category/Plugin/Catalog/ProductPlugin.php
@@ -14,9 +14,8 @@ namespace Smile\ElasticsuiteVirtualCategory\Plugin\Catalog;
 
 use Magento\Catalog\Api\CategoryRepositoryInterface;
 use Magento\Catalog\Model\Product;
-use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Exception\NoSuchEntityException;
-use Magento\Store\Model\ScopeInterface;
+use Smile\ElasticsuiteVirtualCategory\Model\VirtualCategory\Root as VirtualCategoryRoot;
 use Smile\ElasticsuiteVirtualCategory\Model\Url;
 
 /**
@@ -39,15 +38,25 @@ class ProductPlugin
     private $categoryRepository;
 
     /**
+     * @var VirtualCategoryRoot
+     */
+    private $virtualCategoryRoot;
+
+    /**
      * ProductPlugin constructor.
      *
-     * @param Url                         $urlModel           Virtual Categories URL Model
-     * @param CategoryRepositoryInterface $categoryRepository Category Repository
+     * @param Url                         $urlModel            Virtual Categories URL Model
+     * @param CategoryRepositoryInterface $categoryRepository  Category Repository
+     * @param VirtualCategoryRoot         $virtualCategoryRoot Virtual Category Root Model
      */
-    public function __construct(Url $urlModel, CategoryRepositoryInterface $categoryRepository)
-    {
+    public function __construct(
+        Url $urlModel,
+        CategoryRepositoryInterface $categoryRepository,
+        VirtualCategoryRoot $virtualCategoryRoot
+    ) {
         $this->urlModel           = $urlModel;
         $this->categoryRepository = $categoryRepository;
+        $this->virtualCategoryRoot = $virtualCategoryRoot;
     }
 
     /**
@@ -62,7 +71,7 @@ class ProductPlugin
     public function aroundGetProductUrl(Product $product, \Closure $proceed, $useSid = null)
     {
         $requestPath = $product->getRequestPath();
-        if (empty($requestPath)) {
+        if (empty($requestPath) || $this->getAppliedRootCategory()) {
             $requestPath = $this->getRequestPath($product);
             if (null !== $requestPath) {
                 $product->setRequestPath($requestPath);
@@ -113,5 +122,15 @@ class ProductPlugin
         }
 
         return $requestPath;
+    }
+
+    /**
+     * Retrieve the currently applied root category, if any.
+     *
+     * @return \Magento\Catalog\Model\Category|null
+     */
+    private function getAppliedRootCategory()
+    {
+        return $this->virtualCategoryRoot->getAppliedRootCategory();
     }
 }

--- a/src/module-elasticsuite-virtual-category/Plugin/Catalog/ProductPlugin.php
+++ b/src/module-elasticsuite-virtual-category/Plugin/Catalog/ProductPlugin.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\ElasticsuiteVirtualCategory
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2016 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\ElasticsuiteVirtualCategory\Plugin\Catalog;
+
+use Magento\Catalog\Api\CategoryRepositoryInterface;
+use Magento\Catalog\Model\Product;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Store\Model\ScopeInterface;
+use Smile\ElasticsuiteVirtualCategory\Model\Url;
+
+/**
+ * Product Plugin for Virtual Categories.
+ *
+ * @category Smile
+ * @package  Smile\ElasticsuiteVirtualCategory
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class ProductPlugin
+{
+    /**
+     * @var \Smile\ElasticsuiteVirtualCategory\Model\Url
+     */
+    private $urlModel;
+
+    /**
+     * @var CategoryRepositoryInterface
+     */
+    private $categoryRepository;
+
+    /**
+     * ProductPlugin constructor.
+     *
+     * @param Url                         $urlModel           Virtual Categories URL Model
+     * @param CategoryRepositoryInterface $categoryRepository Category Repository
+     */
+    public function __construct(Url $urlModel, CategoryRepositoryInterface $categoryRepository)
+    {
+        $this->urlModel           = $urlModel;
+        $this->categoryRepository = $categoryRepository;
+    }
+
+    /**
+     * Append virtual category Url to product request path, if needed.
+     *
+     * @param \Magento\Catalog\Model\Product $product The Product
+     * @param \Closure                       $proceed The legacy getProductUrl method
+     * @param null                           $useSid  If the SID should be used or not
+     *
+     * @return mixed
+     */
+    public function aroundGetProductUrl(Product $product, \Closure $proceed, $useSid = null)
+    {
+        $requestPath = $product->getRequestPath();
+        if (empty($requestPath)) {
+            $requestPath = $this->getRequestPath($product);
+            if (null !== $requestPath) {
+                $product->setRequestPath($requestPath);
+            }
+        }
+
+        return $proceed($useSid);
+    }
+
+    /**
+     * Bypass the legacy check for displaying product in category, by returning true for virtual categories.
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     *
+     * @param \Magento\Catalog\Model\Product $product    The product
+     * @param \Closure                       $proceed    The legacy canBeShowInCategory function
+     * @param int                            $categoryId The category id
+     *
+     * @return bool
+     */
+    public function aroundCanBeShowInCategory(Product $product, \Closure $proceed, $categoryId)
+    {
+        try {
+            $category = $this->categoryRepository->get($categoryId);
+            if ((bool) $category->getIsVirtualCategory() === true) {
+                return true;
+            }
+        } catch (NoSuchEntityException $e) {
+            $category = null;
+        }
+
+        return $proceed($categoryId);
+    }
+
+    /**
+     * Retrieve request path for the product and the current category.
+     *
+     * @param \Magento\Catalog\Model\Product $product The product
+     *
+     * @return string
+     */
+    private function getRequestPath($product)
+    {
+        $requestPath = null;
+
+        if ($product->getCategory()) {
+            $requestPath = $this->urlModel->getProductRequestPath($product, $product->getCategory());
+        }
+
+        return $requestPath;
+    }
+}

--- a/src/module-elasticsuite-virtual-category/Setup/UpgradeData.php
+++ b/src/module-elasticsuite-virtual-category/Setup/UpgradeData.php
@@ -61,6 +61,10 @@ class UpgradeData implements UpgradeDataInterface
             $this->updateVirtualCategoryRootTypeToInt($setup);
         }
 
+        if (version_compare($context->getVersion(), '1.2.0', '<')) {
+            $this->addGenerateVirtualCategorySubtreeAttribute($setup);
+        }
+
         $setup->endSetup();
     }
 
@@ -110,5 +114,35 @@ class UpgradeData implements UpgradeDataInterface
         $setup->getConnection()->delete($originalTable, "attribute_id = {$virtualRootAttributeId}");
 
         return $this;
+    }
+
+    /**
+     * Append the "generate_root_category_subtree" attribute to categories
+     *
+     * @param \Magento\Framework\Setup\ModuleDataSetupInterface $setup Setup.
+     */
+    private function addGenerateVirtualCategorySubtreeAttribute(ModuleDataSetupInterface $setup)
+    {
+        /**
+         * @var \Magento\Eav\Setup\EavSetup $eavSetup
+         */
+        $eavSetup = $this->eavSetupFactory->create(['setup' => $setup]);
+
+        $eavSetup->addAttribute(
+            Category::ENTITY,
+            'generate_root_category_subtree',
+            [
+                'type'       => 'int',
+                'label'      => 'Generate Virtual Category Subtree',
+                'input'      => null,
+                'global'     => \Magento\Eav\Model\Entity\Attribute\ScopedAttributeInterface::SCOPE_GLOBAL,
+                'required'   => false,
+                'default'    => 0,
+                'visible'    => true,
+                'note'       => "If the subtree of this virtual category should be displayed into category search filter",
+                'sort_order' => 200,
+                'group'      => 'General Information',
+            ]
+        );
     }
 }

--- a/src/module-elasticsuite-virtual-category/etc/frontend/di.xml
+++ b/src/module-elasticsuite-virtual-category/etc/frontend/di.xml
@@ -54,4 +54,22 @@
             </argument>
         </arguments>
     </type>
+
+    <virtualType name="Smile\ElasticsuiteVirtualCategory\Model\Layer\Filter\DataProvider\CategoryFactory"
+                 type="Magento\Catalog\Model\Layer\Filter\DataProvider\CategoryFactory">
+        <arguments>
+            <argument name="instanceName" xsi:type="string">Smile\ElasticsuiteVirtualCategory\Model\Layer\Filter\DataProvider\Category</argument>
+        </arguments>
+    </virtualType>
+
+    <type name="Smile\ElasticsuiteVirtualCategory\Model\Layer\Filter\Category">
+        <arguments>
+            <argument name="dataProviderFactory" xsi:type="object">Smile\ElasticsuiteVirtualCategory\Model\Layer\Filter\DataProvider\CategoryFactory</argument>
+        </arguments>
+    </type>
+
+    <type name="Magento\Catalog\Helper\Data">
+        <plugin name="smile_elasticsuite_virtual_categories_breadcrumb"
+                type="Smile\ElasticsuiteVirtualCategory\Plugin\Catalog\Helper\BreadcrumbPlugin" />
+    </type>
 </config>

--- a/src/module-elasticsuite-virtual-category/etc/frontend/di.xml
+++ b/src/module-elasticsuite-virtual-category/etc/frontend/di.xml
@@ -38,4 +38,20 @@
                 type="Smile\ElasticsuiteVirtualCategory\Plugin\Catalog\Category\FlatPlugin" />
     </type>
 
+    <type name="Magento\Catalog\Model\Product">
+        <plugin name="smile_elasticsuite_virtual_categories_product"
+                type="Smile\ElasticsuiteVirtualCategory\Plugin\Catalog\ProductPlugin" />
+    </type>
+
+    <type name="Magento\Framework\App\RouterList">
+        <arguments>
+            <argument name="routerList" xsi:type="array">
+                <item name="smile_elasticsuite_virtualcategory" xsi:type="array">
+                    <item name="class" xsi:type="string">Smile\ElasticsuiteVirtualCategory\Controller\Router</item>
+                    <item name="disable" xsi:type="boolean">false</item>
+                    <item name="sortOrder" xsi:type="string">50</item>
+                </item>
+            </argument>
+        </arguments>
+    </type>
 </config>

--- a/src/module-elasticsuite-virtual-category/etc/frontend/di.xml
+++ b/src/module-elasticsuite-virtual-category/etc/frontend/di.xml
@@ -72,4 +72,9 @@
         <plugin name="smile_elasticsuite_virtual_categories_breadcrumb"
                 type="Smile\ElasticsuiteVirtualCategory\Plugin\Catalog\Helper\BreadcrumbPlugin" />
     </type>
+
+    <type name="Magento\Catalog\Model\Design">
+        <plugin name="smile_elasticsuite_virtual_categories_design"
+                type="Smile\ElasticsuiteVirtualCategory\Plugin\Catalog\DesignPlugin" />
+    </type>
 </config>

--- a/src/module-elasticsuite-virtual-category/etc/frontend/events.xml
+++ b/src/module-elasticsuite-virtual-category/etc/frontend/events.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Smile_ElasticsuiteVirtualCategory frontend event manager configuration.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\ElasticsuiteVirtualCategory
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2016 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+ -->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
+    <event name="page_block_html_topmenu_gethtml_before">
+        <observer name="fix-category-has-active" instance="Smile\ElasticsuiteVirtualCategory\Observer\Topmenu"/>
+    </event>
+</config>

--- a/src/module-elasticsuite-virtual-category/etc/frontend/events.xml
+++ b/src/module-elasticsuite-virtual-category/etc/frontend/events.xml
@@ -19,4 +19,8 @@
     <event name="page_block_html_topmenu_gethtml_before">
         <observer name="fix-category-has-active" instance="Smile\ElasticsuiteVirtualCategory\Observer\Topmenu"/>
     </event>
+
+    <event name="catalog_controller_category_init_after">
+        <observer name="fix-category-subtree-display-mode" instance="Smile\ElasticsuiteVirtualCategory\Observer\DisplaySubtreeCategoryAsProductOnly"/>
+    </event>
 </config>

--- a/src/module-elasticsuite-virtual-category/etc/module.xml
+++ b/src/module-elasticsuite-virtual-category/etc/module.xml
@@ -17,7 +17,7 @@
  */
  -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Smile_ElasticsuiteVirtualCategory" setup_version="1.1.0">
+    <module name="Smile_ElasticsuiteVirtualCategory" setup_version="1.2.0">
         <sequence>
             <module name="Smile_ElasticsuiteCatalogRule" />
             <module name="Magento_Rule" />

--- a/src/module-elasticsuite-virtual-category/view/adminhtml/ui_component/category_form.xml
+++ b/src/module-elasticsuite-virtual-category/view/adminhtml/ui_component/category_form.xml
@@ -107,7 +107,32 @@
                     </item>
                 </argument>
             </field>
-            
+
+            <field name="generate_root_category_subtree">
+                <argument name="data" xsi:type="array">
+                    <item name="config" xsi:type="array">
+                        <item name="label" xsi:type="string" translate="true">Generate Virtual Category Root Subtree</item>
+                        <item name="dataType" xsi:type="string">boolean</item>
+                        <item name="formElement" xsi:type="string">checkbox</item>
+                        <item name="source" xsi:type="string">category</item>
+                        <item name="prefer" xsi:type="string">toggle</item>
+                        <item name="sortOrder" xsi:type="number">15</item>
+                        <item name="required" xsi:type="boolean">false</item>
+                        <item name="valueMap" xsi:type="array">
+                            <item name="true" xsi:type="string">1</item>
+                            <item name="false" xsi:type="string">0</item>
+                        </item>
+                        <item name="validation" xsi:type="array">
+                            <item name="required-entry" xsi:type="boolean">false</item>
+                        </item>
+                        <item name="default" xsi:type="string">0</item>
+                        <item name="imports" xsi:type="array">
+                            <item name="visible" xsi:type="string">category_form.category_form.assign_products.is_virtual_category:checked</item>
+                        </item>
+                    </item>
+                </argument>
+            </field>
+
             <htmlContent name="virtual_rule">
                 <argument name="block" xsi:type="object">Smile\ElasticsuiteVirtualCategory\Block\Adminhtml\Catalog\Category\VirtualRule</argument>
                 <argument name="data" xsi:type="array">


### PR DESCRIPTION
This is a PR for #49 

This is partially based on PR #227 so it may need to be refactored if we chose to not integrate this feature at all.

Working : 

- navigating through subtree of a virtual category root on the catalog.
- this is not implemented on search results, since I "lost" the initial virtual category root while drilling through category filter : may be hard to do.
- products URLs are also properly displayed (if configured to be displayed with category path) under category root subtree. 

Feel free to test and let met know.