### PR TITLE
Do not arbitrary cap the size of the collection to 20 items if no pag…

### DIFF
--- a/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Fulltext/Collection.php
+++ b/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Fulltext/Collection.php
@@ -465,7 +465,7 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Product\Collection
         $searchRequestName = $this->searchRequestName;
 
         // Pagination params.
-        $size = $this->_pageSize ? $this->_pageSize : 20;
+        $size = $this->_pageSize ? $this->_pageSize : min($this->getSize(), 1000);
         $from = $size * (max(1, $this->_curPage) - 1);
 
         // Query text.


### PR DESCRIPTION
…e size is defined. Append a soft limit of 1000 items anyway.

This PR will fix #247 where the absence of _pageSize does cap the request size to 20 items.

It's hard to manage the 'all' parameter since Magento simply does not apply it when it's set, which results in the non-presence of the pageSize in the collection : 

See the Magento's toolbar block
```
        $limit = (int)$this->getLimit();
        if ($limit) {
            $this->_collection->setPageSize($limit);
        }
```