### PR TITLE
Fix compatibility with Magento 2.1.3

### DIFF
--- a/src/module-elasticsuite-core/etc/di.xml
+++ b/src/module-elasticsuite-core/etc/di.xml
@@ -154,7 +154,7 @@
         </arguments>
     </virtualType>
 
-    <virtualType name="Smile\ElasticsuiteCore\Model\Search\Request\RelevanceConfig\ReaderPool" type="Magento\Store\Model\Config\Reader\ReaderPool">
+    <virtualType name="Smile\ElasticsuiteCore\Model\Search\Request\RelevanceConfig\ReaderPool" type="Magento\Framework\App\Config\Scope\ReaderPoolInterface">
         <arguments>
             <argument name="readers" xsi:type="array">
                 <item name="default" xsi:type="object">Smile\ElasticsuiteCore\Model\Search\Request\RelevanceConfig\Reader\DefaultReader</item>


### PR DESCRIPTION
Fix reflection exception about class "Magento\Store\Model\Config\Reader\ReaderPool" not exists. See https://github.com/magento/magento2/commit/11149f8144444d0442022fd91ce5ff98c803fc7a#diff-3fbbbd1a4273b6fc4feac789d0412b71