### PR TITLE
Feature refactoring relevance configuration (2.1.3 compatibility)

### DIFF
--- a/src/module-elasticsuite-core/Block/Adminhtml/Search/Request/RelevanceConfig/Form.php
+++ b/src/module-elasticsuite-core/Block/Adminhtml/Search/Request/RelevanceConfig/Form.php
@@ -19,6 +19,7 @@ use Magento\Config\Model\Config\Structure\Element\Field;
 use Magento\Framework\Data\FormFactory;
 use Magento\Framework\Registry;
 use Smile\ElasticsuiteCore\Api\Search\Request\ContainerScopeInterface;
+use Smile\ElasticsuiteCore\Search\Request\RelevanceConfig\App\Config as RelevanceConfig;
 
 /**
  * Relevance configuration edit form
@@ -30,6 +31,11 @@ use Smile\ElasticsuiteCore\Api\Search\Request\ContainerScopeInterface;
 class Form extends \Magento\Config\Block\System\Config\Form
 {
     /**
+     * @var RelevanceConfig
+     */
+    private $relevanceConfig;
+
+    /**
      * Form constructor.
      *
      * @param \Magento\Backend\Block\Template\Context                   $context         Application Context
@@ -39,6 +45,7 @@ class Form extends \Magento\Config\Block\System\Config\Form
      * @param Structure                                                 $configStructure Configuration Structure
      * @param \Magento\Config\Block\System\Config\Form\Fieldset\Factory $fieldsetFactory Fieldset Factory
      * @param \Magento\Config\Block\System\Config\Form\Field\Factory    $fieldFactory    Field Factory
+     * @param RelevanceConfig                                           $relevanceConfig Relevance Configuration
      * @param array                                                     $data            Object Data
      */
     public function __construct(
@@ -49,6 +56,7 @@ class Form extends \Magento\Config\Block\System\Config\Form
         Structure $configStructure,
         \Magento\Config\Block\System\Config\Form\Fieldset\Factory $fieldsetFactory,
         \Magento\Config\Block\System\Config\Form\Field\Factory $fieldFactory,
+        RelevanceConfig $relevanceConfig,
         array $data = []
     ) {
 
@@ -63,6 +71,7 @@ class Form extends \Magento\Config\Block\System\Config\Form
             $data
         );
 
+        $this->relevanceConfig = $relevanceConfig;
         $this->_scopeLabels = [
             ContainerScopeInterface::SCOPE_DEFAULT          => __('[GLOBAL]'),
             ContainerScopeInterface::SCOPE_CONTAINERS       => __('[CONTAINER]'),
@@ -147,7 +156,7 @@ class Form extends \Magento\Config\Block\System\Config\Form
      */
     public function getConfigValue($path)
     {
-        return $this->_scopeConfig->getValue($path, $this->getScope(), $this->getScopeCode());
+        return $this->relevanceConfig->getValue($path, $this->getScope(), $this->getScopeCode());
     }
 
     /**

--- a/src/module-elasticsuite-core/Model/Search/Request/RelevanceConfig.php
+++ b/src/module-elasticsuite-core/Model/Search/Request/RelevanceConfig.php
@@ -182,5 +182,6 @@ class RelevanceConfig extends \Magento\Config\Model\Config
 
         $this->setScope($scope);
         $this->setScopeCode($scopeCode);
+        $this->setScopeId($scopeCode);
     }
 }

--- a/src/module-elasticsuite-core/Model/Search/Request/RelevanceConfig/ReaderPool.php
+++ b/src/module-elasticsuite-core/Model/Search/Request/RelevanceConfig/ReaderPool.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\ElasticsuiteCore
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2016 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\ElasticsuiteCore\Model\Search\Request\RelevanceConfig;
+
+/**
+ * Relevance Configuration Reader Pool.
+ *
+ * @category Smile
+ * @package  Smile\ElasticsuiteCore
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class ReaderPool implements \Magento\Framework\App\Config\Scope\ReaderPoolInterface
+{
+    /**
+     * List of readers
+     *
+     * @var array
+     */
+    private $readers = [];
+
+    /**
+     * @param \Magento\Framework\App\Config\Scope\ReaderInterface[] $readers The readers
+     */
+    public function __construct(array $readers)
+    {
+        $this->readers = $readers;
+    }
+
+    /**
+     * Retrieve reader by scope type
+     *
+     * @param string $scopeType The scope
+     *
+     * @return mixed
+     */
+    public function getReader($scopeType)
+    {
+        return $this->readers[$scopeType];
+    }
+}

--- a/src/module-elasticsuite-core/Search/Request/RelevanceConfig/App/Config.php
+++ b/src/module-elasticsuite-core/Search/Request/RelevanceConfig/App/Config.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\ElasticsuiteCore
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2016 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\ElasticsuiteCore\Search\Request\RelevanceConfig\App;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+
+/**
+ * Relevance configuration implementation.
+ *
+ * @category Smile
+ * @package  Smile\ElasticSuiteCore
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class Config extends \Magento\Framework\App\Config
+{
+    /**
+     * Retrieve config value by path and scope
+     *
+     * @param string      $path      The path to retrieve config for
+     * @param string      $scope     The scope
+     * @param null|string $scopeCode The scope code, if any
+     *
+     * @return mixed
+     */
+    public function getValue(
+        $path = null,
+        $scope = ScopeConfigInterface::SCOPE_TYPE_DEFAULT,
+        $scopeCode = null
+    ) {
+        return $this->_scopePool->getScope($scope, $scopeCode)->getValue($path);
+    }
+}

--- a/src/module-elasticsuite-core/etc/di.xml
+++ b/src/module-elasticsuite-core/etc/di.xml
@@ -141,11 +141,11 @@
         </arguments>
     </virtualType>
 
-    <virtualType name="Smile\ElasticsuiteCore\Search\Request\RelevanceConfig\App\Config" type="Magento\Framework\App\Config">
+    <type name="Smile\ElasticsuiteCore\Search\Request\RelevanceConfig\App\Config">
         <arguments>
             <argument name="scopePool" xsi:type="object">Smile\ElasticsuiteCore\Model\Search\Request\RelevanceConfig\ScopePool</argument>
         </arguments>
-    </virtualType>
+    </type>
 
     <virtualType name="Smile\ElasticsuiteCore\Model\Search\Request\RelevanceConfig\ScopePool" type="Magento\Framework\App\Config\ScopePool">
         <arguments>
@@ -153,7 +153,7 @@
         </arguments>
     </virtualType>
 
-    <virtualType name="Smile\ElasticsuiteCore\Model\Search\Request\RelevanceConfig\ReaderPool" type="Magento\Store\Model\Config\Reader\ReaderPool">
+    <virtualType name="Smile\ElasticsuiteCore\Model\Search\Request\RelevanceConfig\ReaderPool" type="Magento\Framework\Config\ReaderPool">
         <arguments>
             <argument name="readers" xsi:type="array">
                 <item name="default" xsi:type="object">Smile\ElasticsuiteCore\Model\Search\Request\RelevanceConfig\Reader\DefaultReader</item>

--- a/src/module-elasticsuite-core/etc/di.xml
+++ b/src/module-elasticsuite-core/etc/di.xml
@@ -153,7 +153,7 @@
         </arguments>
     </virtualType>
 
-    <virtualType name="Smile\ElasticsuiteCore\Model\Search\Request\RelevanceConfig\ReaderPool" type="Magento\Framework\Config\ReaderPool">
+    <type name="Smile\ElasticsuiteCore\Model\Search\Request\RelevanceConfig\ReaderPool">
         <arguments>
             <argument name="readers" xsi:type="array">
                 <item name="default" xsi:type="object">Smile\ElasticsuiteCore\Model\Search\Request\RelevanceConfig\Reader\DefaultReader</item>
@@ -163,7 +163,7 @@
                 <item name="container_store" xsi:type="object">Smile\ElasticsuiteCore\Model\Search\Request\RelevanceConfig\Reader\ContainerStore</item>
             </argument>
         </arguments>
-    </virtualType>
+    </type>
 
     <virtualType name="Smile\ElasticsuiteCore\Search\Request\RelevanceConfig\Structure\Reader" type="Magento\Config\Model\Config\Structure\Reader">
         <arguments>
@@ -222,12 +222,6 @@
         </arguments>
     </type>
 
-    <virtualType name="Smile\ElasticsuiteCore\Block\Backend\Template\Context" type="Magento\Backend\Block\Template\Context">
-        <arguments>
-            <argument name="scopeConfig" xsi:type="object">Smile\ElasticsuiteCore\Search\Request\RelevanceConfig\App\Config</argument>
-        </arguments>
-    </virtualType>
-
     <virtualType name="Smile\ElasticsuiteCore\Block\Adminhtml\Search\Request\RelevanceConfig\Form\FieldFactory" type="Magento\Config\Block\System\Config\Form\Field\Factory">
         <arguments>
             <argument name="instanceName" xsi:type="string">Smile\ElasticsuiteCore\Block\Adminhtml\Search\Request\RelevanceConfig\Form\Field</argument>
@@ -239,21 +233,19 @@
             <argument name="configStructure" xsi:type="object">Smile\ElasticsuiteCore\Model\Search\Request\RelevanceConfig\Structure</argument>
             <argument name="configFactory" xsi:type="object">Smile\ElasticsuiteCore\Model\Search\Request\RelevanceConfig\Factory</argument>
             <argument name="fieldFactory" xsi:type="object">Smile\ElasticsuiteCore\Block\Adminhtml\Search\Request\RelevanceConfig\Form\Field\Factory</argument>
-            <argument name="context" xsi:type="object">Smile\ElasticsuiteCore\Block\Backend\Template\Context</argument>
+            <argument name="relevanceConfig" xsi:type="object">Smile\ElasticsuiteCore\Search\Request\RelevanceConfig\App\Config</argument>
         </arguments>
     </type>
 
     <type name="Smile\ElasticsuiteCore\Block\Adminhtml\Search\Request\RelevanceConfig\Edit">
         <arguments>
             <argument name="configStructure" xsi:type="object">Smile\ElasticsuiteCore\Model\Search\Request\RelevanceConfig\Structure</argument>
-            <argument name="context" xsi:type="object">Smile\ElasticsuiteCore\Block\Backend\Template\Context</argument>
         </arguments>
     </type>
 
     <virtualType name="Smile\ElasticsuiteCore\Block\Adminhtml\Search\Request\RelevanceConfig\Tabs" type="Magento\Config\Block\System\Config\Tabs">
         <arguments>
             <argument name="configStructure" xsi:type="object">Smile\ElasticsuiteCore\Model\Search\Request\RelevanceConfig\Structure</argument>
-            <argument name="context" xsi:type="object">Smile\ElasticsuiteCore\Block\Backend\Template\Context</argument>
         </arguments>
     </virtualType>
 


### PR DESCRIPTION
This PR is intended to fix the backward incompatible changes made by Magento between 2.1.2 and 2.1.3 versions.

This is essentially occuring on objects inheriting or using the Magento\Framework\App\Config class (Reader, Scope pools, etc ...).

Some (slights) parts of Relevance Configuration have been refactored to be 2.1.3 compliant.

This piece of code has also been tested against a Magento 2.1.2 version and is working, which should prevent us from having to release several versions of the module in the future.

Let me know,

Best regards,