### PR TITLE
Adding a more specific "emptyText" when the product sorted is used in…

### DIFF
--- a/src/module-elasticsuite-catalog/view/adminhtml/web/template/form/element/product-sorter.html
+++ b/src/module-elasticsuite-catalog/view/adminhtml/web/template/form/element/product-sorter.html
@@ -12,7 +12,7 @@
     
     <div class="elasticsuite-admin-product-sorter-empty" data-bind="if: !hasProducts()">
         <div class="message message-info">
-            <div data-bind="text: messages.emptyText"></div>
+            <div data-bind="html: messages.emptyText"></div>
         </div>
     </div>
     

--- a/src/module-elasticsuite-virtual-category/i18n/en_US.csv
+++ b/src/module-elasticsuite-virtual-category/i18n/en_US.csv
@@ -7,3 +7,4 @@
 "Select category ...","Select category ..."
 Merchandising,Merchandising
 "Cannot move the category : '%2' is using '%1' as virtual root category.","Cannot move the category : '%2' is using '%1' as virtual root category."
+"Your product selection is empty for the selected Store View. If you are running a multi-store setup, please check this <a href='https://github.com/Smile-SA/elasticsuite/wiki/VirtualCategories#previewing-virtual-categories-on-a-multi-store-setup'>manual page</a> for more informations.","Your product selection is empty for the selected Store View. If you are running a multi-store setup, please check this <a href='https://github.com/Smile-SA/elasticsuite/wiki/VirtualCategories#previewing-virtual-categories-on-a-multi-store-setup'>manual page</a> for more informations."

--- a/src/module-elasticsuite-virtual-category/i18n/fr_FR.csv
+++ b/src/module-elasticsuite-virtual-category/i18n/fr_FR.csv
@@ -7,3 +7,4 @@
 "Select category ...","Choisissez une catégorie ..."
 Merchandising,Merchandising
 "Cannot move the category : '%2' is using '%1' as virtual root category.","Impossible de déplacer la catégorie : '%2' utilise actuellement '%1' comme racine."
+"Your product selection is empty for the selected Store View. If you are running a multi-store setup, please check this <a href='https://github.com/Smile-SA/elasticsuite/wiki/VirtualCategories#previewing-virtual-categories-on-a-multi-store-setup'>manual page</a> for more informations.","Votre sélection de produits est vide pour la vue magasin actuellement sélectionnée. Si votre site comporte plusieurs vues magasin, consultez cette <a href='https://github.com/Smile-SA/elasticsuite/wiki/VirtualCategories#previewing-virtual-categories-on-a-multi-store-setup'>page du manuel</a> pour plus d'informations."

--- a/src/module-elasticsuite-virtual-category/view/adminhtml/ui_component/category_form.xml
+++ b/src/module-elasticsuite-virtual-category/view/adminhtml/ui_component/category_form.xml
@@ -142,6 +142,9 @@
                         <item name="label" xsi:type="string" translate="true">Products List Preview and Sorting</item>
                         <item name="dataScope" xsi:type="string">sorted_products</item>
                         <item name="pageSize" xsi:type="string">20</item>
+                        <item name="messages" xsi:type="array">
+                            <item name="emptyText" xsi:type="string" translate="true"><![CDATA[Your product selection is empty for the selected Store View. If you are running a multi-store setup, please check this <a href='https://github.com/Smile-SA/elasticsuite/wiki/VirtualCategories#previewing-virtual-categories-on-a-multi-store-setup'>manual page</a> for more informations.]]></item>
+                        </item>
                         <item name="refreshFields" xsi:type="array">
                             <item name="is_virtual_category" xsi:type="string">is_virtual_category</item>
                             <item name="virtual_rule" xsi:type="string">virtual_rule</item>


### PR DESCRIPTION
…to virtualCategories context.

This is a fix for #246 (just adding a more explicit message).

Linking to the Wiki page here : https://github.com/Smile-SA/elasticsuite/wiki/VirtualCategories#previewing-virtual-categories-on-a-multi-store-setup