### PR TITLE
Adding a additional attributes parameters into autocomplete product c…

### DIFF
--- a/src/module-elasticsuite-catalog/Model/Autocomplete/Product/DataProvider.php
+++ b/src/module-elasticsuite-catalog/Model/Autocomplete/Product/DataProvider.php
@@ -69,14 +69,22 @@ class DataProvider implements DataProviderInterface
     private $productCollection;
 
     /**
+     * Additional product attributes required.
+     *
+     * @var array
+     */
+    private $additionalAttributes;
+
+    /**
      * Constructor.
      *
-     * @param ItemFactory         $itemFactory         Suggest item factory.
-     * @param QueryFactory        $queryFactory        Search query factory.
-     * @param TermDataProvider    $termDataProvider    Search terms suggester.
-     * @param ProductCollection   $productCollection   Product collection.
-     * @param ConfigurationHelper $configurationHelper Autocomplete configuration helper.
-     * @param string              $type                Autocomplete provider type.
+     * @param ItemFactory         $itemFactory          Suggest item factory.
+     * @param QueryFactory        $queryFactory         Search query factory.
+     * @param TermDataProvider    $termDataProvider     Search terms suggester.
+     * @param ProductCollection   $productCollection    Product collection.
+     * @param ConfigurationHelper $configurationHelper  Autocomplete configuration helper.
+     * @param string              $type                 Autocomplete provider type.
+     * @param array               $additionalAttributes Additional product attributes required.
      */
     public function __construct(
         ItemFactory $itemFactory,
@@ -84,7 +92,8 @@ class DataProvider implements DataProviderInterface
         TermDataProvider $termDataProvider,
         ProductCollection $productCollection,
         ConfigurationHelper $configurationHelper,
-        $type = self::AUTOCOMPLETE_TYPE
+        $type = self::AUTOCOMPLETE_TYPE,
+        array $additionalAttributes = []
     ) {
         $this->itemFactory              = $itemFactory;
         $this->queryFactory             = $queryFactory;
@@ -92,6 +101,7 @@ class DataProvider implements DataProviderInterface
         $this->productCollection        = $productCollection;
         $this->configurationHelper      = $configurationHelper;
         $this->type                     = $type;
+        $this->additionalAttributes     = $additionalAttributes;
 
         $this->prepareProductCollection();
     }
@@ -112,7 +122,11 @@ class DataProvider implements DataProviderInterface
         $result = [];
 
         foreach ($this->productCollection as $product) {
-            $result[] = $this->itemFactory->create(['product' => $product, 'type' => $this->getType()]);
+            $result[] = $this->itemFactory->create([
+                'product'               => $product,
+                'type'                  => $this->getType(),
+                'additional_attributes' => $this->additionalAttributes,
+            ]);
         }
 
         return $result;
@@ -133,6 +147,10 @@ class DataProvider implements DataProviderInterface
             ->addAttributeToSelect('thumbnail')
             ->setVisibility([Visibility::VISIBILITY_IN_SEARCH, Visibility::VISIBILITY_BOTH])
             ->addPriceData();
+
+        if ($this->additionalAttributes) {
+            $this->productCollection->addAttributeToSelect($this->additionalAttributes);
+        }
 
         if (!$this->configurationHelper->isShowOutOfStock()) {
             $this->productCollection->addIsInStockFilter();

--- a/src/module-elasticsuite-catalog/Model/Autocomplete/Product/ItemFactory.php
+++ b/src/module-elasticsuite-catalog/Model/Autocomplete/Product/ItemFactory.php
@@ -70,7 +70,7 @@ class ItemFactory extends \Magento\Search\Model\Autocomplete\ItemFactory
     public function create(array $data)
     {
         $data = $this->addProductData($data);
-        unset($data['product']);
+        unset($data['product'], $data['additional_attributes']);
 
         return parent::create($data);
     }
@@ -92,6 +92,10 @@ class ItemFactory extends \Magento\Search\Model\Autocomplete\ItemFactory
             'url'         => $product->getProductUrl(),
             'price'       => $this->renderProductPrice($product, \Magento\Catalog\Pricing\Price\FinalPrice::PRICE_CODE),
         ];
+        $additionalAttributes = $data['additional_attributes'];
+        foreach ($additionalAttributes as $additionalAttributeKey => $additionalAttribute) {
+            $productData[$additionalAttributeKey] = $product->getData($additionalAttribute);
+        }
 
         $data = array_merge($data, $productData);
 


### PR DESCRIPTION
…lasses for load product data additional to change display.

Use di.xml for adding your custom attributes : 
```xml
<type name="Smile\ElasticsuiteCatalog\Model\Autocomplete\Product\DataProvider">
        <arguments>
            <argument name="additionalAttributes" xsi:type="array">
                <item name="my_custom_attribute" xsi:type="string">custom_attribute</item>
            </argument>
        </arguments>
</type>
```
and use `my_custom_attribute` key into template file to display it.
