### PR TITLE
Implements the saveConfig method to use correct "scope_code" field.

### DIFF
--- a/src/module-elasticsuite-core/Model/ResourceModel/Search/Request/RelevanceConfig.php
+++ b/src/module-elasticsuite-core/Model/ResourceModel/Search/Request/RelevanceConfig.php
@@ -1,7 +1,6 @@
 <?php
 /**
  * DISCLAIMER
- *
  * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
  * versions in the future.
  *
@@ -23,8 +22,72 @@ namespace Smile\ElasticsuiteCore\Model\ResourceModel\Search\Request;
 class RelevanceConfig extends \Magento\Config\Model\ResourceModel\Config
 {
     /**
-     * Define main table.
+     * Save config value
      *
+     * @param string $path      The config path
+     * @param string $value     The config value
+     * @param string $scope     The scope
+     * @param string $scopeCode The scope Code
+     *
+     * @return $this
+     */
+    public function saveConfig($path, $value, $scope, $scopeCode = 'default')
+    {
+        $connection = $this->getConnection();
+        $select = $connection->select()->from(
+            $this->getMainTable()
+        )->where(
+            'path = ?',
+            $path
+        )->where(
+            'scope = ?',
+            $scope
+        )->where(
+            'scope_code = ?',
+            $scopeCode
+        );
+        $row = $connection->fetchRow($select);
+
+        $newData = ['scope' => $scope, 'scope_code' => $scopeCode, 'path' => $path, 'value' => $value];
+
+        if ($row) {
+            $whereCondition = [$this->getIdFieldName() . '=?' => $row[$this->getIdFieldName()]];
+            $connection->update($this->getMainTable(), $newData, $whereCondition);
+
+            return $this;
+        }
+
+        $connection->insert($this->getMainTable(), $newData);
+
+        return $this;
+    }
+
+    /**
+     * Delete config value
+     *
+     * @param string $path      The config path
+     * @param string $scope     The scope
+     * @param string $scopeCode The scope Code
+     *
+     * @return $this
+     */
+    public function deleteConfig($path, $scope, $scopeCode)
+    {
+        $connection = $this->getConnection();
+        $connection->delete(
+            $this->getMainTable(),
+            [
+                $connection->quoteInto('path = ?', $path),
+                $connection->quoteInto('scope = ?', $scope),
+                $connection->quoteInto('scope_code = ?', $scopeCode),
+            ]
+        );
+
+        return $this;
+    }
+
+    /**
+     * Define main table.
      * @SuppressWarnings(PHPMD.CamelCaseMethodName)
      *
      * @return void


### PR DESCRIPTION
Will fix the latent issue described on #288 

Low impact since the bug can occurs only when calling explicitely the ```saveConfig``` or ```deleteConfig``` method, which is not the case when editing the configuration in the Back-Office.

This could only happen on specific code written to use this functions.