### PR TITLE
Remove the "is_used_in_autocomplete" field.

### DIFF
--- a/src/module-elasticsuite-catalog/Block/Plugin/Adminhtml/Product/Attribute/Edit/Tab/FrontPlugin.php
+++ b/src/module-elasticsuite-catalog/Block/Plugin/Adminhtml/Product/Attribute/Edit/Tab/FrontPlugin.php
@@ -92,8 +92,6 @@ class FrontPlugin
 
         if ($this->getAttribute()->getAttributeCode() == 'name') {
             $form->getElement('is_searchable')->setDisabled(1);
-            $form->getElement('is_used_in_autocomplete')->setDisabled(1);
-            $form->getElement('is_used_in_autocomplete')->setValue(1);
         }
 
         return $block;
@@ -164,17 +162,6 @@ class FrontPlugin
     private function addAutocompleteFields(Fieldset $fieldset)
     {
         $fieldset->addField(
-            'is_used_in_autocomplete',
-            'select',
-            [
-                'name'   => 'is_used_in_autocomplete',
-                'label'  => __('Used in autocomplete'),
-                'values' => $this->booleanSource->toOptionArray(),
-            ],
-            'is_used_in_spellcheck'
-        );
-
-        $fieldset->addField(
             'is_displayed_in_autocomplete',
             'select',
             [
@@ -182,7 +169,7 @@ class FrontPlugin
                 'label'  => __('Display in autocomplete'),
                 'values' => $this->booleanSource->toOptionArray(),
             ],
-            'is_used_in_autocomplete'
+            'is_used_in_spellcheck'
         );
 
         return $this;

--- a/src/module-elasticsuite-catalog/Helper/Attribute.php
+++ b/src/module-elasticsuite-catalog/Helper/Attribute.php
@@ -107,10 +107,6 @@ class Attribute extends Mapping
             $options['is_used_in_spellcheck'] = true;
         }
 
-        if ($attribute->getIsUsedInAutocomplete()) {
-            $options['is_used_in_autocomplete'] = true;
-        }
-
         if ($attribute->getIsDisplayedInAutocomplete()) {
             $options['is_filterable'] = true;
         }

--- a/src/module-elasticsuite-catalog/Model/Eav/Indexer/Fulltext/Datasource/AbstractAttributeData.php
+++ b/src/module-elasticsuite-catalog/Model/Eav/Indexer/Fulltext/Datasource/AbstractAttributeData.php
@@ -182,7 +182,6 @@ class AbstractAttributeData
 
             // Reset parent field values : only the option text field should be used for spellcheck and autocomplete.
             $fieldConfig['is_used_in_spellcheck'] = false;
-            $fieldConfig['is_used_in_autocomplete'] = false;
             $fieldConfig['is_searchable'] = false;
         }
 

--- a/src/module-elasticsuite-catalog/Setup/UpgradeSchema.php
+++ b/src/module-elasticsuite-catalog/Setup/UpgradeSchema.php
@@ -43,6 +43,10 @@ class UpgradeSchema implements UpgradeSchemaInterface
             $this->appendDecimalDisplayConfiguration($setup);
         }
 
+        if (version_compare($context->getVersion(), '1.2.2', '<')) {
+            $this->removeIsUsedInAutocompleteField($setup);
+        }
+
         $setup->endSetup();
     }
 
@@ -80,5 +84,18 @@ class UpgradeSchema implements UpgradeSchemaInterface
                 'comment'  => 'Attribute decimal precision for display',
             ]
         );
+    }
+
+    /**
+     * Remove the "is_used_in_autocomplete"
+     *
+     * @param \Magento\Framework\Setup\SchemaSetupInterface $setup The setup instance
+     */
+    private function removeIsUsedInAutocompleteField(SchemaSetupInterface $setup)
+    {
+        $connection = $setup->getConnection();
+        $table      = $setup->getTable('catalog_eav_attribute');
+
+        $connection->dropColumn($table, 'is_used_in_autocomplete');
     }
 }

--- a/src/module-elasticsuite-catalog/etc/module.xml
+++ b/src/module-elasticsuite-catalog/etc/module.xml
@@ -17,7 +17,7 @@
  */
  -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Smile_ElasticsuiteCatalog" setup_version="1.2.1">
+    <module name="Smile_ElasticsuiteCatalog" setup_version="1.2.2">
         <sequence>
             <module name="Smile_ElasticsuiteCore" />
             <module name="Magento_Search" />

--- a/src/module-elasticsuite-core/Api/Index/Mapping/FieldInterface.php
+++ b/src/module-elasticsuite-core/Api/Index/Mapping/FieldInterface.php
@@ -90,13 +90,6 @@ interface FieldInterface
     public function isUsedInSpellcheck();
 
     /**
-     * Is the field used for autocomplete.
-     *
-     * @return boolean
-     */
-    public function isUsedInAutocomplete();
-
-    /**
      * Weight of the fields in search.
      *
      * @return integer

--- a/src/module-elasticsuite-core/Index/Mapping.php
+++ b/src/module-elasticsuite-core/Index/Mapping.php
@@ -72,7 +72,6 @@ class Mapping implements MappingInterface
     private $copyFieldMap = [
         'isSearchable'         => self::DEFAULT_SEARCH_FIELD,
         'isUsedInSpellcheck'   => self::DEFAULT_SPELLING_FIELD,
-        'isUsedInAutocomplete' => self::DEFAULT_AUTOCOMPLETE_FIELD,
     ];
 
     /**

--- a/src/module-elasticsuite-core/Index/Mapping/Field.php
+++ b/src/module-elasticsuite-core/Index/Mapping/Field.php
@@ -60,7 +60,6 @@ class Field implements FieldInterface
         'is_filterable'           => true,
         'is_used_for_sort_by'     => false,
         'is_used_in_spellcheck'   => false,
-        'is_used_in_autocomplete' => false,
         'search_weight'           => 1,
         'default_search_analyzer' => self::ANALYZER_STANDARD,
     ];
@@ -132,14 +131,6 @@ class Field implements FieldInterface
     public function isUsedInSpellcheck()
     {
         return (bool) $this->config['is_used_in_spellcheck'];
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function isUsedInAutocomplete()
-    {
-        return (bool) $this->config['is_used_in_autocomplete'];
     }
 
     /**

--- a/src/module-elasticsuite-core/Test/Unit/Index/Mapping/FieldTest.php
+++ b/src/module-elasticsuite-core/Test/Unit/Index/Mapping/FieldTest.php
@@ -42,7 +42,6 @@ class FieldTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(true, $field->isFilterable());
         $this->assertEquals(false, $field->isUsedForSortBy());
         $this->assertEquals(false, $field->isUsedInSpellcheck());
-        $this->assertEquals(false, $field->isUsedInAutocomplete());
         $this->assertEquals(false, $field->isNested());
         $this->assertEquals(null, $field->getNestedFieldName());
         $this->assertEquals(null, $field->getNestedPath());


### PR DESCRIPTION
Proposal for removing this unused field.

Maybe we should not, since this was exposed publicly by the Field interface, I let you choose.