### PR TITLE
Better attribute configuration screen

### DIFF
--- a/src/module-elasticsuite-catalog/Block/Plugin/Adminhtml/Product/Attribute/Edit/Tab/FrontPlugin.php
+++ b/src/module-elasticsuite-catalog/Block/Plugin/Adminhtml/Product/Attribute/Edit/Tab/FrontPlugin.php
@@ -96,6 +96,8 @@ class FrontPlugin
             $form->getElement('is_used_in_autocomplete')->setValue(1);
         }
 
+        $this->appendFieldsDependency($form, $subject);
+
         return $block;
     }
 
@@ -349,6 +351,28 @@ class FrontPlugin
         if ($isAttributeDecimal && ($attribute->getFrontendInput() !== 'price')) {
             $displayFieldset = $this->createDisplayFieldset($form, $subject);
             $this->addDisplayFields($displayFieldset);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Manage dependency between fields.
+     *
+     * @param Front $subject The StoreFront tab
+     *
+     * @return FrontPlugin
+     */
+    private function appendFieldsDependency($subject)
+    {
+        /** @var \Magento\Backend\Block\Widget\Form\Element\Dependence $dependencyBlock */
+        $dependencyBlock = $subject->getChildBlock('form_after');
+
+        if ($dependencyBlock) {
+            $dependencyBlock
+                ->addFieldMap('is_displayed_in_autocomplete', 'is_displayed_in_autocomplete')
+                ->addFieldMap('is_filterable_in_search', 'is_filterable_in_search')
+                ->addFieldDependence('is_displayed_in_autocomplete', 'is_filterable_in_search', '1');
         }
 
         return $this;

--- a/src/module-elasticsuite-catalog/view/adminhtml/templates/catalog/product/attribute/js.phtml
+++ b/src/module-elasticsuite-catalog/view/adminhtml/templates/catalog/product/attribute/js.phtml
@@ -62,7 +62,13 @@
         {
             checkOptionsPanelVisibility();
             switchDefaultValueField();
-            if($('frontend_input') && ($('frontend_input').value=='select' || $('frontend_input').value=='multiselect' || $('frontend_input').value=='price' || $('frontend_input').value=='text')) {
+            if($('frontend_input') &&
+                ($('frontend_input').value == 'select'
+                || $('frontend_input').value == 'multiselect'
+                || $('frontend_input').value == 'price'
+                || $('frontend_input').value == 'text')
+                || $('frontend_input').value == 'boolean')
+            ) {
                 if($('is_filterable') && !$('is_filterable').getAttribute('readonly')){
                     $('is_filterable').disabled = false;
                 }

--- a/src/module-elasticsuite-swatches/view/adminhtml/templates/catalog/product/attribute/js.phtml
+++ b/src/module-elasticsuite-swatches/view/adminhtml/templates/catalog/product/attribute/js.phtml
@@ -104,7 +104,7 @@
             checkOptionsPanelVisibility();
             switchDefaultValueField();
             if (frontendInput
-                && (jQuery.inArray(frontendInput.value, selectFields) >= 0 || (frontendInput.value == "text"))
+                && (jQuery.inArray(frontendInput.value, selectFields) >= 0 || (frontendInput.value == "text") || frontendInput.value == "boolean")
             ) {
                 if (isFilterable && !isFilterable.getAttribute('readonly')) {
                     isFilterable.disabled = false;


### PR DESCRIPTION
Ensure booleans can be set as filterable / filterable in search

Also ensure to hide the "is_displayed_in_autocomplete" for attributes which are not "filterable in search" => since they are used as a facet on the search result page, they need to be filterable in search.