### PR TITLE
Index all prices data for each product.

### DIFF
--- a/src/module-elasticsuite-catalog/Model/Product/Indexer/Fulltext/Datasource/PriceData.php
+++ b/src/module-elasticsuite-catalog/Model/Product/Indexer/Fulltext/Datasource/PriceData.php
@@ -78,7 +78,11 @@ class PriceData implements DatasourceInterface
                 'price'             => $finalPrice,
                 'original_price'    => $originalPrice,
                 'is_discount'       => $finalPrice < $originalPrice,
-                'customer_group_id' => $priceDataRow['customer_group_id'],
+                'customer_group_id' => (int) $priceDataRow['customer_group_id'],
+                'tax_class_id'      => (int) $priceDataRow['tax_class_id'],
+                'final_price'       => $priceDataRow['final_price'],
+                'min_price'         => $priceDataRow['min_price'],
+                'max_price'         => $priceDataRow['max_price'],
             ];
         }
 

--- a/src/module-elasticsuite-catalog/etc/elasticsuite_indices.xml
+++ b/src/module-elasticsuite-catalog/etc/elasticsuite_indices.xml
@@ -49,6 +49,10 @@
                 <field name="price.original_price" type="double" nestedPath="price" />
                 <field name="price.is_discount" type="boolean" nestedPath="price" />
                 <field name="price.customer_group_id" type="integer" nestedPath="price" />
+                <field name="price.tax_class_id" type="integer" nestedPath="price" />
+                <field name="price.final_price" type="double" nestedPath="price" />
+                <field name="price.min_price" type="double" nestedPath="price" />
+                <field name="price.max_price" type="double" nestedPath="price" />
 
                 <!-- Static fields handled by the "stock" datasource -->
                 <field name="stock.is_in_stock" type="boolean" />


### PR DESCRIPTION
This one allows to index all prices related data (with the min and max price).

This could allow later to build price facet to the min_price data if we want : for websites using configurable and bundle products which want to have the price slider values correlated to the way they chose to display prices, eg. using the "From 'min_price' $ " display.

This is also a prelude to the availability of loading prices and stock data directly from elasticsearch instead of doing it via the _applyProductLimitation method.

We can discuss this one together later.

Regards