### PR TITLE
Fix categories anchor related issues

### DIFF
--- a/src/module-elasticsuite-catalog/Plugin/Catalog/Category/SetIsAnchor.php
+++ b/src/module-elasticsuite-catalog/Plugin/Catalog/Category/SetIsAnchor.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\ElasticsuiteCatalog
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2017 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\ElasticsuiteCatalog\Plugin\Catalog\Category;
+
+/**
+ * Plugin on Category Resource model to ensure category is set to is_anchor=1 before saving.
+ *
+ * @category Smile
+ * @package  Smile\ElasticsuiteCatalog
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class SetIsAnchor
+{
+    /**
+     * Resource model save function plugin.
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     *
+     * @param \Magento\Catalog\Model\ResourceModel\Category $categoryResource Category original resource model.
+     * @param \Closure                                      $proceed          Original save method.
+     * @param \Magento\Framework\Model\AbstractModel        $category         Saved category.
+     *
+     * @return \Magento\Catalog\Model\ResourceModel\Category
+     * @throws \Exception
+     */
+    public function aroundSave(
+        \Magento\Catalog\Model\ResourceModel\Category $categoryResource,
+        \Closure $proceed,
+        \Magento\Framework\Model\AbstractModel $category
+    ) {
+        $category->setData('is_anchor', true);
+
+        return $proceed($category);
+    }
+}

--- a/src/module-elasticsuite-catalog/Plugin/Indexer/Category/Product/SetIsAnchorBeforeIndexing.php
+++ b/src/module-elasticsuite-catalog/Plugin/Indexer/Category/Product/SetIsAnchorBeforeIndexing.php
@@ -1,0 +1,179 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\ElasticsuiteCatalog
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2017 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\ElasticsuiteCatalog\Plugin\Indexer\Category\Product;
+
+use Magento\Catalog\Api\CategoryAttributeRepositoryInterface;
+use Magento\Catalog\Api\Data\CategoryInterface;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Framework\EntityManager\MetadataPool;
+
+/**
+ * Set Categories to is_anchor=1 before reindexing category/products associations.
+ *
+ * @category Smile
+ * @package  Smile\ElasticsuiteCatalog
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class SetIsAnchorBeforeIndexing
+{
+    /**
+     * @var \Magento\Catalog\Api\CategoryAttributeRepositoryInterface
+     */
+    private $attributeRepository;
+
+    /**
+     * @var \Magento\Framework\EntityManager\MetadataPool
+     */
+    private $metadataPool;
+
+    /**
+     * SetIsAnchorBeforeIndexing constructor.
+     *
+     * @param \Magento\Catalog\Api\CategoryAttributeRepositoryInterface $attributeRepositoryInterface Category Attributes Repository
+     * @param \Magento\Framework\EntityManager\MetadataPool             $metadataPool                 Metadata Pool
+     * @param \Magento\Framework\App\ResourceConnection                 $resource                     Resource Connection
+     */
+    public function __construct(
+        CategoryAttributeRepositoryInterface $attributeRepositoryInterface,
+        MetadataPool $metadataPool,
+        ResourceConnection $resource
+    ) {
+        $this->attributeRepository = $attributeRepositoryInterface;
+        $this->metadataPool        = $metadataPool;
+        $this->connection          = $resource->getConnection();
+    }
+
+    /**
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     * Set categories to is_anchor=true before indexing
+     *
+     * @param \Magento\Catalog\Model\Indexer\Category\Product $subject The Catalog/Product indexer
+     * @param \Closure                                        $proceed The ::execute() function of $subject
+     *
+     * @return void
+     */
+    public function aroundExecuteFull(
+        \Magento\Catalog\Model\Indexer\Category\Product $subject,
+        \Closure $proceed
+    ) {
+        $this->updateIsAnchorAttribute();
+        $proceed();
+
+        return;
+    }
+
+    /**
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     * Set categories to is_anchor=true before indexing
+     *
+     * @param \Magento\Catalog\Model\Indexer\Category\Product $subject     The Catalog/Product indexer
+     * @param \Closure                                        $proceed     The ::execute() function of $subject
+     * @param int[]                                           $categoryIds The category ids being reindexed
+     *
+     * @return void
+     */
+    public function aroundExecute(
+        \Magento\Catalog\Model\Indexer\Category\Product $subject,
+        \Closure $proceed,
+        $categoryIds
+    ) {
+        $this->updateIsAnchorAttribute($categoryIds);
+        $proceed($categoryIds);
+
+        return;
+    }
+
+    /**
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     * Set categories to is_anchor=true before indexing
+     *
+     * @param \Magento\Catalog\Model\Indexer\Category\Product $subject    The Catalog/Product indexer
+     * @param \Closure                                        $proceed    The ::executeRow() function of $subject
+     * @param int                                             $categoryId The category id being reindexed
+     *
+     * @return void
+     */
+    public function aroundExecuteRow(
+        \Magento\Catalog\Model\Indexer\Category\Product $subject,
+        \Closure $proceed,
+        $categoryId
+    ) {
+        $this->updateIsAnchorAttribute([$categoryId]);
+        $proceed($categoryId);
+
+        return;
+    }
+
+    /**
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     * Set categories to is_anchor=true before indexing
+     *
+     * @param \Magento\Catalog\Model\Indexer\Category\Product $subject     The Catalog/Product indexer
+     * @param \Closure                                        $proceed     The ::execute() function of $subject
+     * @param int[]                                           $categoryIds The category ids being reindexed
+     *
+     * @return void
+     */
+    public function aroundExecuteList(
+        \Magento\Catalog\Model\Indexer\Category\Product $subject,
+        \Closure $proceed,
+        array $categoryIds
+    ) {
+
+        $this->updateIsAnchorAttribute($categoryIds);
+        $proceed($categoryIds);
+
+        return;
+    }
+
+    /**
+     * Automatically set the categories being indexed as is_anchor = 1
+     *
+     * @param array $categoryIds The category Ids
+     *
+     * @throws \Exception
+     */
+    private function updateIsAnchorAttribute($categoryIds = [])
+    {
+        $attribute      = $this->attributeRepository->get('is_anchor');
+        $metaData       = $this->metadataPool->getMetadata(CategoryInterface::class);
+        $entityTable    = $metaData->getEntityTable();
+        $attributeId    = (int) $attribute->getAttributeId();
+        $attributeTable = $attribute->getBackendTable();
+        $linkField      = $metaData->getLinkField();
+
+        $entitySelect = $this->connection->select()->from(
+            ['cat' => $entityTable],
+            [new \Zend_Db_Expr("{$attributeId} as attribute_id"), $linkField, new \Zend_Db_Expr("1 as value")]
+        );
+
+        if (!empty($categoryIds)) {
+            $entitySelect->where("cat.entity_id IN(?)", array_map('intval', $categoryIds));
+        }
+        $entitySelect->where("cat.entity_id NOT IN(?)", [\Magento\Catalog\Model\Category::TREE_ROOT_ID]);
+
+        $joinConditions = ["cat.{$linkField} = attr.{$linkField}", "attr.attribute_id = {$attributeId}"];
+        $entitySelect->joinLeft(['attr' => $attributeTable], new \Zend_Db_Expr(implode(" AND ", $joinConditions)), []);
+        $entitySelect->where(new \Zend_Db_Expr('COALESCE(attr.value, 0) <> 1'));
+
+        $insertQuery = $this->connection->insertFromSelect(
+            $entitySelect,
+            $attributeTable,
+            ['attribute_id', $linkField, 'value'],
+            AdapterInterface::INSERT_ON_DUPLICATE
+        );
+
+        $this->connection->query($insertQuery);
+    }
+}

--- a/src/module-elasticsuite-catalog/Plugin/LayerPlugin.php
+++ b/src/module-elasticsuite-catalog/Plugin/LayerPlugin.php
@@ -53,7 +53,10 @@ class LayerPlugin extends \Magento\CatalogInventory\Model\Plugin\Layer
         \Magento\Catalog\Model\ResourceModel\Collection\AbstractCollection $collection
     ) {
         if ($this->_isEnabledShowOutOfStock() === false) {
-            $collection->addIsInStockFilter();
+            // This call cannot be processed on standard layer since it does not use CatalogSearch Result collection.
+            if (method_exists($collection, 'addIsInStockFilter')) {
+                $collection->addIsInStockFilter();
+            }
         }
 
         $this->setSortParams($layer, $collection);
@@ -75,7 +78,10 @@ class LayerPlugin extends \Magento\CatalogInventory\Model\Plugin\Layer
 
         if (!$searchQuery->getQueryText() && $layer->getCurrentCategory()) {
             $categoryId = $layer->getCurrentCategory()->getId();
-            $collection->addSortFilterParameters('position', 'category.position', 'category', ['category.category_id' => $categoryId]);
+            // This call cannot be processed on standard layer since it does not use CatalogSearch Result collection.
+            if (method_exists($collection, 'addSortFilterParameters')) {
+                $collection->addSortFilterParameters('position', 'category.position', 'category', ['category.category_id' => $categoryId]);
+            }
         }
 
         return $this;

--- a/src/module-elasticsuite-catalog/etc/di.xml
+++ b/src/module-elasticsuite-catalog/etc/di.xml
@@ -173,4 +173,8 @@
         </arguments>
     </virtualType>
 
+    <type name="\Magento\Catalog\Model\ResourceModel\Category">
+        <plugin name="smile_elasticsuite_prevent_wrong_is_anchor_value"
+                type="\Smile\ElasticsuiteCatalog\Plugin\Catalog\Category\SetIsAnchor" />
+    </type>
 </config>

--- a/src/module-elasticsuite-catalog/etc/di.xml
+++ b/src/module-elasticsuite-catalog/etc/di.xml
@@ -177,4 +177,9 @@
         <plugin name="smile_elasticsuite_prevent_wrong_is_anchor_value"
                 type="\Smile\ElasticsuiteCatalog\Plugin\Catalog\Category\SetIsAnchor" />
     </type>
+
+    <type name="\Magento\Catalog\Model\Indexer\Category\Product">
+        <plugin name="smile_elasticsuite_set_category_is_anchor_before_reindex"
+                type="\Smile\ElasticsuiteCatalog\Plugin\Indexer\Category\Product\SetIsAnchorBeforeIndexing" />
+    </type>
 </config>


### PR DESCRIPTION
- Ensure we can apply methods on the layer plugin : this will prevent fatal error when using a theme or custom code which is instantiating a layer anywhere (home page, etc...)

- Automatically set categories to is_anchor=1 when saving it.

- Automatically set categories to is_anchor=1 just before reindexing the category/products association.

This should get rid of any remaining confusion or mis-usage of the is_anchor and layer strange instanciations.

Let me know 