### PR TITLE
Prevent the getDefaultStoreView call to fail when browsing adminhtml …

### DIFF
--- a/src/module-elasticsuite-catalog-rule/Model/Rule/Condition/Product/AttributeList.php
+++ b/src/module-elasticsuite-catalog-rule/Model/Rule/Condition/Product/AttributeList.php
@@ -172,12 +172,28 @@ class AttributeList
     private function getMapping()
     {
         if ($this->mapping === null) {
-            $defaultStore = $this->storeManager->getDefaultStoreView();
+            $defaultStore = $this->getDefaultStoreView();
             $index        = $this->indexManager->getIndexByName($this->indexName, $defaultStore);
 
             $this->mapping = $index->getType($this->typeName)->getMapping();
         }
 
         return $this->mapping;
+    }
+
+    /**
+     * Retrieve default Store View
+     *
+     * @return \Magento\Store\Api\Data\StoreInterface
+     */
+    private function getDefaultStoreView()
+    {
+        $store = $this->storeManager->getDefaultStoreView();
+        if (null === $store) {
+            // Occurs when current user does not have access to default website (due to AdminGWS ACLS on Magento EE).
+            $store = current($this->storeManager->getWebsites())->getDefaultStore();
+        }
+
+        return $store;
     }
 }

--- a/src/module-elasticsuite-virtual-category/Plugin/Catalog/Category/DataProviderPlugin.php
+++ b/src/module-elasticsuite-virtual-category/Plugin/Catalog/Category/DataProviderPlugin.php
@@ -107,7 +107,7 @@ class DataProviderPlugin
         $storeId = $category->getStoreId();
 
         if ($storeId === 0) {
-            $defaultStoreId = $this->storeManager->getDefaultStoreView()->getId();
+            $defaultStoreId = $this->getDefaultStoreView()->getId();
             $storeId        = current(array_filter($category->getStoreIds()));
             if (in_array($defaultStoreId, $category->getStoreIds())) {
                 $storeId = $defaultStoreId;
@@ -135,5 +135,21 @@ class DataProviderPlugin
         }
 
         return json_encode($productPositions, JSON_FORCE_OBJECT);
+    }
+
+    /**
+     * Retrieve default Store View
+     *
+     * @return \Magento\Store\Api\Data\StoreInterface
+     */
+    private function getDefaultStoreView()
+    {
+        $store = $this->storeManager->getDefaultStoreView();
+        if (null === $store) {
+            // Occurs when current user does not have access to default website (due to AdminGWS ACLS on Magento EE).
+            $store = current($this->storeManager->getWebsites())->getDefaultStore();
+        }
+
+        return $store;
     }
 }


### PR DESCRIPTION
…with a restricted account.

This will fix #347 . This is due to ```module-admin-gws``` on Magento EE which is causing ```$storeManager->getDefaultStoreView``` to return ```null``` if the current admin user is not auhorized to view the application default store view.

In  this case we fallback to retrieving the default store view **of the website of this admin account**

