### PR TITLE
Virtual category optimization

### DIFF
--- a/src/module-elasticsuite-virtual-category/Model/Preview.php
+++ b/src/module-elasticsuite-virtual-category/Model/Preview.php
@@ -184,8 +184,6 @@ class Preview
     /**
      * Return the filter applied to the query.
      *
-     * @SuppressWarnings(PHPMD.ElseExpression)
-     *
      * @return QueryInterface
      */
     private function getQueryFilter()


### PR DESCRIPTION
- Reduce the recursion level for standard categories.
- Merge children categories into an unique should clause when possible