### PR TITLE
Remove position column

### DIFF
--- a/src/module-elasticsuite-virtual-category/Block/Adminhtml/Catalog/Category/Tab/Product.php
+++ b/src/module-elasticsuite-virtual-category/Block/Adminhtml/Catalog/Category/Tab/Product.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\ElasticsuiteVirtualCategory
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2017 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\ElasticsuiteVirtualCategory\Block\Adminhtml\Catalog\Category\Tab;
+
+/**
+ * Custom Category/Product Grid
+ *
+ * Overridden to remove "position" column
+ *
+ * @category Smile
+ * @package  Smile\ElasticsuiteVirtualCategory
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class Product extends \Magento\Catalog\Block\Adminhtml\Category\Tab\Product
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @SuppressWarnings(PHPMD.CamelCaseMethodName) This Method is inherited
+     */
+    public function _prepareColumns()
+    {
+        parent::_prepareColumns();
+
+        if ($this->getColumn('position')) {
+            $this->removeColumn('position');
+        }
+
+        return $this;
+    }
+}

--- a/src/module-elasticsuite-virtual-category/etc/adminhtml/di.xml
+++ b/src/module-elasticsuite-virtual-category/etc/adminhtml/di.xml
@@ -22,4 +22,8 @@
             <argument name="categoryCollectionFactory" xsi:type="object">Smile\ElasticsuiteVirtualCategory\Model\Category\Attribute\Source\VirtualCategoryRoot\CollectionFactory</argument>
         </arguments>
     </virtualType>
+
+    <!-- Overridden directly because this block is called via hardcoded calls -->
+    <preference for="\Magento\Catalog\Block\Adminhtml\Category\Tab\Product" type="Smile\ElasticsuiteVirtualCategory\Block\Adminhtml\Catalog\Category\Tab\Product"/>
+
 </config>

--- a/src/module-elasticsuite-virtual-category/view/adminhtml/requirejs-config.js
+++ b/src/module-elasticsuite-virtual-category/view/adminhtml/requirejs-config.js
@@ -1,0 +1,21 @@
+/**
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ *
+ * @category  Smile
+ * @package   Smile\ElasticsuiteVirtualCategories
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2016 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+
+var config = {
+    map: {
+        '*': {
+            'Magento_Catalog/catalog/category/assign-products': 'Smile_ElasticsuiteVirtualCategory/js/component/catalog/category/form/assign-products'
+        }
+    }
+};

--- a/src/module-elasticsuite-virtual-category/view/adminhtml/web/js/component/catalog/category/form/assign-products.js
+++ b/src/module-elasticsuite-virtual-category/view/adminhtml/web/js/component/catalog/category/form/assign-products.js
@@ -1,0 +1,129 @@
+/**
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ *
+ * @category  Smile
+ * @package   Smile\ElasticsuiteCore
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2016 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+
+/*jshint browser:true jquery:true*/
+/*global alert*/
+
+/**
+ * Overridden grid for category-product assignment.
+ * Since the "position" column is removed, we are not able to select a new product to add into a category.
+ * This is mostly due to @see line 45 : processing the categoryProducts.set only if a position field exists.
+ */
+define([
+    'mage/adminhtml/grid'
+], function () {
+    'use strict';
+
+    return function (config) {
+        var selectedProducts = config.selectedProducts,
+            categoryProducts = $H(selectedProducts),
+            gridJsObject = window[config.gridJsObjectName],
+            tabIndex = 1000;
+
+        $('in_category_products').value = Object.toJSON(categoryProducts);
+
+        /**
+         * Register Category Product
+         *
+         * @param {Object} grid
+         * @param {Object} element
+         * @param {Boolean} checked
+         */
+        function registerCategoryProduct(grid, element, checked) {
+            if (checked) {
+                if (element.positionElement) {
+                    element.positionElement.disabled = false;
+                    categoryProducts.set(element.value, element.positionElement.value);
+                } else {
+                    // Override is here. Add the product to categoryProducts even if it does not have position field
+                    categoryProducts.set(element.value, 0);
+                }
+            } else {
+                if (element.positionElement) {
+                    element.positionElement.disabled = true;
+                }
+                categoryProducts.unset(element.value);
+            }
+            $('in_category_products').value = Object.toJSON(categoryProducts);
+            grid.reloadParams = {
+                'selected_products[]': categoryProducts.keys()
+            };
+        }
+
+        /**
+         * Click on product row
+         *
+         * @param {Object} grid
+         * @param {String} event
+         */
+        function categoryProductRowClick(grid, event) {
+            var trElement = Event.findElement(event, 'tr'),
+                isInput = Event.element(event).tagName === 'INPUT',
+                checked = false,
+                checkbox = null;
+
+            if (trElement) {
+                checkbox = Element.getElementsBySelector(trElement, 'input');
+
+                if (checkbox[0]) {
+                    checked = isInput ? checkbox[0].checked : !checkbox[0].checked;
+                    gridJsObject.setCheckboxChecked(checkbox[0], checked);
+                }
+            }
+        }
+
+        /**
+         * Change product position
+         *
+         * @param {String} event
+         */
+        function positionChange(event) {
+            var element = Event.element(event);
+
+            if (element && element.checkboxElement && element.checkboxElement.checked) {
+                categoryProducts.set(element.checkboxElement.value, element.value);
+                $('in_category_products').value = Object.toJSON(categoryProducts);
+            }
+        }
+
+        /**
+         * Initialize category product row
+         *
+         * @param {Object} grid
+         * @param {String} row
+         */
+        function categoryProductRowInit(grid, row) {
+            var checkbox = $(row).getElementsByClassName('checkbox')[0],
+                position = $(row).getElementsByClassName('input-text')[0];
+
+            if (checkbox && position) {
+                checkbox.positionElement = position;
+                position.checkboxElement = checkbox;
+                position.disabled = !checkbox.checked;
+                position.tabIndex = tabIndex++;
+                Event.observe(position, 'keyup', positionChange);
+            }
+        }
+
+        gridJsObject.rowClickCallback = categoryProductRowClick;
+        gridJsObject.initRowCallback = categoryProductRowInit;
+        gridJsObject.checkboxCheckCallback = registerCategoryProduct;
+
+        if (gridJsObject.rows) {
+            gridJsObject.rows.each(function (row) {
+                categoryProductRowInit(gridJsObject, row);
+            });
+        }
+    };
+});


### PR DESCRIPTION
Removing the column was easy, except since the block name is hardcoded by Magento, I had to rewrite it.

But magento does not handle adding products to a category if the "position" field does not exists on the grid. I had to override also the Javascript component to manage this case.