### PR TITLE
Fixing direct usage of Layer to prepare a product collection which th…

### DIFF
--- a/src/module-elasticsuite-catalog/etc/di.xml
+++ b/src/module-elasticsuite-catalog/etc/di.xml
@@ -191,4 +191,20 @@
         </arguments>
     </type>
 
+    <!-- Ensure automatic instantiation of layer will properly use a fulltext product collection -->
+    <virtualType name="Smile\ElasticsuiteCatalog\Model\Layer\Category\Context" type="Magento\Catalog\Model\Layer\Context">
+        <arguments>
+            <!-- This provider uses the Magento\CatalogSearch\Model\ResourceModel\Fulltext\CollectionFactory as Collection Factory -->
+            <argument name="collectionProvider" xsi:type="object">Magento\CatalogSearch\Model\Layer\Category\ItemCollectionProvider</argument>
+            <argument name="stateKey" xsi:type="object">Magento\Catalog\Model\Layer\Category\StateKey</argument>
+            <argument name="collectionFilter" xsi:type="object">Magento\Catalog\Model\Layer\Category\CollectionFilter</argument>
+        </arguments>
+    </virtualType>
+
+    <type name="Magento\Catalog\Model\Layer\Category">
+        <arguments>
+            <argument name="context" xsi:type="object">Smile\ElasticsuiteCatalog\Model\Layer\Category\Context</argument>
+        </arguments>
+    </type>
+
 </config>

--- a/src/module-elasticsuite-catalog/etc/frontend/di.xml
+++ b/src/module-elasticsuite-catalog/etc/frontend/di.xml
@@ -154,4 +154,24 @@
     </virtualType>
     <!-- End of  compatibility with Staging for Layered Navigation -->
 
+    <!-- Ensure navigation block is using fulltext collection, to prevent error when it sends it through the Layer -->
+    <type name="Magento\Catalog\Block\Navigation">
+        <arguments>
+            <argument name="productCollectionFactory" xsi:type="object">Magento\CatalogSearch\Model\ResourceModel\Fulltext\CollectionFactory</argument>
+        </arguments>
+    </type>
+
+    <!-- Ensure standard promotion block is using fulltext collection, to prevent error when it sends it through the Layer -->
+    <type name="Magento\Catalog\Block\Product\ProductList\Promotion">
+        <arguments>
+            <argument name="productCollectionFactory" xsi:type="object">Magento\CatalogSearch\Model\ResourceModel\Fulltext\CollectionFactory</argument>
+        </arguments>
+    </type>
+
+    <!-- Ensure standard random products block is using fulltext collection, to prevent error when it sends it through the Layer -->
+    <type name="Magento\Catalog\Block\Product\ProductList\Random">
+        <arguments>
+            <argument name="productCollectionFactory" xsi:type="object">Magento\CatalogSearch\Model\ResourceModel\Fulltext\CollectionFactory</argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
…ey did not instantiate themselves.

This is mostly related to the ```Call to undefined method Magento\Catalog\Model\ResourceModel\Product\Collection\Interceptor::addSortFilterParameters()``` error.

This error occurs when Magento uses the Layer object as a filter, to prepare an external product collection.

This can be seen especially on ```Magento\Catalog\Block\Navigation``` : 

`       $productCollection = $this->_productCollectionFactory->create();
        $this->_catalogLayer->prepareProductCollection($productCollection);`

the `$productCollection` is created by the standard product collection factory. Therefore it is not possible to use ElasticSuite method on it when the layer calls the prepareProductCollection.

This can be fixed by switching the factory used to the CatalogSearch one, and will then work properly.

Imho, since we cannot ensure which type of collection is sent to the Layer, and since prepareProductCollection is a public method, we should go further on this one.

Let me know @afoucret 
