### PR TITLE
Adding elasticsuite internal nested attributes as reserved.

### DIFF
--- a/src/module-elasticsuite-catalog/etc/di.xml
+++ b/src/module-elasticsuite-catalog/etc/di.xml
@@ -181,4 +181,14 @@
         </arguments>
     </virtualType>
 
+    <!-- Set reserved nested fields of elasticsuite as reserved to prevent anyone creating an attribute with the same name. -->
+    <type name="Magento\Catalog\Model\Product\ReservedAttributeList">
+        <arguments>
+            <argument name="reservedAttributes" xsi:type="array">
+                <item name="stock" xsi:type="string">stock</item>
+                <item name="category" xsi:type="string">category</item>
+            </argument>
+        </arguments>
+    </type>
+
 </config>


### PR DESCRIPTION
Will prevent cases like #340 by disallowing attributes creation with attribute_code identical to elasticsuite custom fields such "stock" or "category"