### PR TITLE
Remove previous DI that was erratic for virtual categories and also u…

### DIFF
--- a/src/module-elasticsuite-catalog/etc/di.xml
+++ b/src/module-elasticsuite-catalog/etc/di.xml
@@ -191,20 +191,4 @@
         </arguments>
     </type>
 
-    <!-- Ensure automatic instantiation of layer will properly use a fulltext product collection -->
-    <virtualType name="Smile\ElasticsuiteCatalog\Model\Layer\Category\Context" type="Magento\Catalog\Model\Layer\Context">
-        <arguments>
-            <!-- This provider uses the Magento\CatalogSearch\Model\ResourceModel\Fulltext\CollectionFactory as Collection Factory -->
-            <argument name="collectionProvider" xsi:type="object">Magento\CatalogSearch\Model\Layer\Category\ItemCollectionProvider</argument>
-            <argument name="stateKey" xsi:type="object">Magento\Catalog\Model\Layer\Category\StateKey</argument>
-            <argument name="collectionFilter" xsi:type="object">Magento\Catalog\Model\Layer\Category\CollectionFilter</argument>
-        </arguments>
-    </virtualType>
-
-    <type name="Magento\Catalog\Model\Layer\Category">
-        <arguments>
-            <argument name="context" xsi:type="object">Smile\ElasticsuiteCatalog\Model\Layer\Category\Context</argument>
-        </arguments>
-    </type>
-
 </config>


### PR DESCRIPTION
…module to prevent explicit application of category filter.

This is related to #367 and #366 .

When enforcing the catalogsearch layer to be used on catalog navigation, we introduced a biasis causing to always apply the addCategoryFilter method on the product collection.

This causes all categories to include a "must category_id=XXX" which indeed works for standard categories but produces conditions like "must color=blue AND category_id=XXX" on virtual categories which is not reliable.

It also causes a double appliance of "category_id=XXX" on standard category but does not fail since it does not change anything to the result.


=> This was NOT necessary since I tested again without this DI and here are my results : 

```
        $this->catalogLayer = $layerResolver->get();
        $collection = $this->catalogLayer->getProductCollection();
        $collection->addIsInStockFilter();

        $logger->info(" Class : " . get_class($collection));
```

Outputs no error and : 

```
Class : Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Fulltext\Collection\Interceptor
```

This is due to Magento behavioring good via the catalogsearch module DI : 

```
    <virtualType name="Magento\CatalogSearch\Model\Layer\Category\Context" type="Magento\Catalog\Model\Layer\Category\Context">
        <arguments>
            <argument name="collectionProvider" xsi:type="object">Magento\CatalogSearch\Model\Layer\Category\ItemCollectionProvider</argument>
        </arguments>
    </virtualType>

    <type name="Magento\Catalog\Model\Layer\Category">
        <arguments>
            <argument name="context" xsi:type="object">Magento\CatalogSearch\Model\Layer\Category\Context</argument>
        </arguments>
    </type>
```