### PR TITLE
Remove not used data parameter for category fulltext indexing.

### DIFF
--- a/src/module-elasticsuite-catalog/Model/Category/Indexer/Fulltext.php
+++ b/src/module-elasticsuite-catalog/Model/Category/Indexer/Fulltext.php
@@ -31,9 +31,6 @@ class Fulltext implements \Magento\Framework\Indexer\ActionInterface, \Magento\F
      */
     const INDEXER_ID = 'elasticsuite_categories_fulltext';
 
-    /** @var array index structure */
-    protected $data;
-
     /**
      * @var IndexerInterface
      */
@@ -59,20 +56,17 @@ class Fulltext implements \Magento\Framework\Indexer\ActionInterface, \Magento\F
      * @param IndexerInterface      $indexerHandler   The index handler
      * @param StoreManagerInterface $storeManager     The Store Manager
      * @param DimensionFactory      $dimensionFactory The dimension factory
-     * @param array                 $data             The data
      */
     public function __construct(
         Full $fullAction,
         IndexerInterface $indexerHandler,
         StoreManagerInterface $storeManager,
-        DimensionFactory $dimensionFactory,
-        array $data
+        DimensionFactory $dimensionFactory
     ) {
         $this->fullAction = $fullAction;
         $this->indexerHandler = $indexerHandler;
         $this->storeManager = $storeManager;
         $this->dimensionFactory = $dimensionFactory;
-        $this->data = $data;
     }
 
     /**


### PR DESCRIPTION
This is a fix for #384 

I just removed the $data parameter which was not used and therefore useless.