### PR TITLE
Allow to index prices attributes.

### DIFF
--- a/src/module-elasticsuite-catalog/Model/Eav/Indexer/Fulltext/Datasource/AbstractAttributeData.php
+++ b/src/module-elasticsuite-catalog/Model/Eav/Indexer/Fulltext/Datasource/AbstractAttributeData.php
@@ -67,6 +67,7 @@ class AbstractAttributeData
         'Magento\Catalog\Model\Product\Attribute\Backend\Boolean',
         'Magento\Eav\Model\Entity\Attribute\Backend\DefaultBackend',
         'Magento\Catalog\Model\Product\Attribute\Backend\Weight',
+        'Magento\Catalog\Model\Product\Attribute\Backend\Price',
     ];
 
     /**
@@ -153,7 +154,8 @@ class AbstractAttributeData
      */
     private function canIndexAttribute(AttributeInterface $attribute)
     {
-        $canIndex = $attribute->getBackendType() != 'static';
+        // 'price' attribute is declared as nested field into the indices file.
+        $canIndex = $attribute->getBackendType() != 'static' && $attribute->getAttributeCode() !== 'price';
 
         if ($canIndex && $attribute->getBackendModel()) {
             $canIndex = in_array($attribute->getBackendModel(), $this->indexedBackendModels);


### PR DESCRIPTION
They were not indexed previously, which was preventing our fellow users to create custom "prices" attributes and setting them as filterable in front office.

This has been discussed on #341 : this issue occurs in fact not for special_price only, but for any attribute having a price backend.

Regards