### PR TITLE
Change prepareProductCollection scope of autocomplete DataProvider 

### DIFF
--- a/src/module-elasticsuite-catalog/Model/Autocomplete/Product/Attribute/DataProvider.php
+++ b/src/module-elasticsuite-catalog/Model/Autocomplete/Product/Attribute/DataProvider.php
@@ -94,7 +94,7 @@ class DataProvider implements DataProviderInterface
         $this->autocompleteHelper  = $autocompleteHelper;
 
         $this->loadAttributeCollection();
-        $this->prepareProductCollection();
+        $this->prepareProductCollection($productCollection);
     }
 
     /**
@@ -140,14 +140,18 @@ class DataProvider implements DataProviderInterface
     /**
      * Append facets used to select suggested attributes.
      *
+     * @param \Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Fulltext\Collection $collection Product Collection
+     *
      * @return \Smile\ElasticsuiteCatalog\Model\Autocomplete\Product\Attribute\DataProvider
      */
-    private function prepareProductCollection()
+    public function prepareProductCollection($collection)
     {
         foreach ($this->attributeCollection as $attribute) {
             $facetSize   = $this->getResultsPageSize();
             $filterField = $this->getFilterField($attribute);
-            $this->productCollection->addFacet($filterField, BucketInterface::TYPE_TERM, ['size' => $facetSize]);
+            $collection->addFacet($filterField, BucketInterface::TYPE_TERM, ['size' => $facetSize]);
+
+            $this->productCollection = $collection;
         }
 
         return $this;

--- a/src/module-elasticsuite-catalog/Model/Autocomplete/Product/DataProvider.php
+++ b/src/module-elasticsuite-catalog/Model/Autocomplete/Product/DataProvider.php
@@ -98,12 +98,12 @@ class DataProvider implements DataProviderInterface
         $this->itemFactory              = $itemFactory;
         $this->queryFactory             = $queryFactory;
         $this->termDataProvider         = $termDataProvider;
-        $this->productCollection        = $productCollection;
         $this->configurationHelper      = $configurationHelper;
         $this->type                     = $type;
         $this->additionalAttributes     = $additionalAttributes;
+        $this->productCollection        = $productCollection;
 
-        $this->prepareProductCollection();
+        $this->prepareProductCollection($productCollection);
     }
 
     /**
@@ -137,26 +137,30 @@ class DataProvider implements DataProviderInterface
     /**
      * Init suggested products collection.
      *
-     * @return \Smile\ElasticsuiteCatalog\Model\Autocomplete\Product\DataProvider
+     * @param \Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Fulltext\Collection $collection Product Collection
+     *
+     * @return DataProvider
      */
-    private function prepareProductCollection()
+    public function prepareProductCollection($collection)
     {
         $terms = $this->getQueryText();
-        $this->productCollection->addSearchFilter($terms);
-        $this->productCollection->setPageSize($this->getResultsPageSize());
-        $this->productCollection
-            ->addAttributeToSelect('name')
+        $collection->addSearchFilter($terms);
+        $collection->setPageSize($this->getResultsPageSize());
+
+        $collection->addAttributeToSelect('name')
             ->addAttributeToSelect('thumbnail')
             ->setVisibility([Visibility::VISIBILITY_IN_SEARCH, Visibility::VISIBILITY_BOTH])
             ->addPriceData();
 
         if ($this->additionalAttributes) {
-            $this->productCollection->addAttributeToSelect($this->additionalAttributes);
+            $collection->addAttributeToSelect($this->additionalAttributes);
         }
 
         if (!$this->configurationHelper->isShowOutOfStock()) {
-            $this->productCollection->addIsInStockFilter();
+            $collection->addIsInStockFilter();
         }
+
+        $this->productCollection = $collection;
 
         return $this;
     }


### PR DESCRIPTION
Change the scope to public : this will allow people to add plugins on it.

This is mandatory for being able to filter products based on offers for the ElasticSuite for Retailers module.