### PR TITLE
Ensure proper EAV Attributes cache cleaning after creating attributes.

### DIFF
--- a/src/module-elasticsuite-catalog/Setup/InstallData.php
+++ b/src/module-elasticsuite-catalog/Setup/InstallData.php
@@ -14,6 +14,7 @@
 namespace Smile\ElasticsuiteCatalog\Setup;
 
 use Magento\Catalog\Api\Data\CategoryInterface;
+use Magento\Eav\Model\Config;
 use Magento\Framework\DB\Adapter\AdapterInterface;
 use Magento\Catalog\Model\Category;
 use Magento\Eav\Setup\EavSetupFactory;
@@ -59,17 +60,28 @@ class InstallData implements InstallDataInterface
     private $indexerFactory;
 
     /**
+     * @var Config
+     */
+    private $eavConfig;
+
+    /**
      * Class Constructor
      *
      * @param EavSetupFactory         $eavSetupFactory Eav setup factory.
      * @param MetadataPool            $metadataPool    Metadata Pool.
      * @param IndexerInterfaceFactory $indexerFactory  Indexer Factory.
+     * @param Config                  $eavConfig       EAV Config.
      */
-    public function __construct(EavSetupFactory $eavSetupFactory, MetadataPool $metadataPool, IndexerInterfaceFactory $indexerFactory)
-    {
+    public function __construct(
+        EavSetupFactory $eavSetupFactory,
+        MetadataPool $metadataPool,
+        IndexerInterfaceFactory $indexerFactory,
+        Config $eavConfig
+    ) {
         $this->metadataPool    = $metadataPool;
         $this->eavSetupFactory = $eavSetupFactory;
         $this->indexerFactory  = $indexerFactory;
+        $this->eavConfig       = $eavConfig;
     }
 
     /**
@@ -125,6 +137,9 @@ class InstallData implements InstallDataInterface
 
         // Set the attribute value to 1 for all existing categories.
         $this->updateAttributeDefaultValue(Category::ENTITY, 'use_name_in_product_search', 1);
+
+        // Mandatory to ensure next installers will have proper EAV Attributes definitions.
+        $this->eavConfig->clear();
     }
 
     /**

--- a/src/module-elasticsuite-virtual-category/Setup/InstallData.php
+++ b/src/module-elasticsuite-virtual-category/Setup/InstallData.php
@@ -13,6 +13,7 @@
 namespace Smile\ElasticsuiteVirtualCategory\Setup;
 
 use Magento\Catalog\Model\Category;
+use Magento\Eav\Model\Config;
 use Magento\Eav\Setup\EavSetupFactory;
 use Magento\Framework\Setup\InstallDataInterface;
 use Magento\Framework\Setup\ModuleContextInterface;
@@ -35,13 +36,20 @@ class InstallData implements InstallDataInterface
     private $eavSetupFactory;
 
     /**
+     * @var \Magento\Eav\Model\Config
+     */
+    private $eavConfig;
+
+    /**
      * Class Constructor
      *
      * @param EavSetupFactory $eavSetupFactory Eav setup factory.
+     * @param Config          $eavConfig       EAV Config.
      */
-    public function __construct(EavSetupFactory $eavSetupFactory)
+    public function __construct(EavSetupFactory $eavSetupFactory, Config $eavConfig)
     {
         $this->eavSetupFactory = $eavSetupFactory;
+        $this->eavConfig       = $eavConfig;
     }
 
     /**
@@ -116,6 +124,9 @@ class InstallData implements InstallDataInterface
         $eavSetup->updateAttribute(Category::ENTITY, 'is_virtual_category', 'frontend_input', null);
         $eavSetup->updateAttribute(Category::ENTITY, 'virtual_category_root', 'frontend_input', null);
         $eavSetup->updateAttribute(Category::ENTITY, 'virtual_rule', 'frontend_input', null);
+
+        // Mandatory to ensure next installers will have proper EAV Attributes definitions.
+        $this->eavConfig->clear();
 
         $setup->endSetup();
     }


### PR DESCRIPTION
This one is easy to reproduce on a completely fresh install : project sources but with an empty database.

- have a module which is creating categories.

Even if you add a dependency on Smile_ElasticsuiteCatalog or Smile_ElasticsuiteVirtualCategory, you will face the following error : 

```
Attribute with attributeCode "use_name_in_product_search" does not exist. 
```

**Even if the attribute was properly created before** by elasticsuite setups.

This is due to the fact that when using ```addAttribute```, Magento does not clear the EAV Cache properly. Therefore it does not find the attribute later when creating categories.

This one should be considered as **blocking to deploy project from scratch** on newly created environments (such as MECE or other PaaS platforms).

Regards