### PR TITLE
Ensure catalog requests have the proper type.

### DIFF
--- a/src/module-elasticsuite-catalog/etc/di.xml
+++ b/src/module-elasticsuite-catalog/etc/di.xml
@@ -99,10 +99,16 @@
     
     <virtualType name="Magento\CatalogSearch\Model\Layer\Category\Context" type="Magento\Catalog\Model\Layer\Category\Context">
         <arguments>
-            <argument name="collectionProvider" xsi:type="object">Magento\CatalogSearch\Model\Layer\Search\ItemCollectionProvider</argument>
+            <argument name="collectionProvider" xsi:type="object">Smile\ElasticsuiteCatalog\Model\Layer\Category\ItemCollectionProvider</argument>
         </arguments>
     </virtualType>
-    
+
+    <virtualType name="Smile\ElasticsuiteCatalog\Model\Layer\Category\ItemCollectionProvider" type="Magento\Catalog\Model\Layer\Search\ItemCollectionProvider">
+        <arguments>
+            <argument name="collectionFactory" xsi:type="object">Magento\CatalogSearch\Model\ResourceModel\Fulltext\CollectionFactory</argument>
+        </arguments>
+    </virtualType>
+
     <virtualType name="Magento\CatalogSearch\Model\Layer\Search\Context" type="Magento\Catalog\Model\Layer\Search\Context">
         <arguments>
             <argument name="collectionProvider" xsi:type="object">Magento\CatalogSearch\Model\Layer\Search\ItemCollectionProvider</argument>


### PR DESCRIPTION
This one fixes #392 

When using previously ```Magento\CatalogSearch\Model\Layer\Search\ItemCollectionProvider``` we were using a ```Magento\CatalogSearch\Model\ResourceModel\Fulltext\SearchCollectionFactory``` which was using a ```Magento\CatalogSearch\Model\ResourceModel\Fulltext\SearchCollection```.

This one always had the searchRequestName set to "quick_search_container", even when browsing the catalog.

I replaced it by direct usage of ElasticSuite Fulltext collection, allowing us to have the default value for catalog navigation which is ```catalog_view_container```