### PR TITLE
Fix swatches for Magento 2.1.6

### DIFF
--- a/src/module-elasticsuite-swatches/Helper/Swatches.php
+++ b/src/module-elasticsuite-swatches/Helper/Swatches.php
@@ -13,12 +13,15 @@
 namespace Smile\ElasticsuiteSwatches\Helper;
 
 use Magento\Catalog\Api\Data\ProductInterface as Product;
+use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\Catalog\Model\ResourceModel\Product\Collection as ProductCollection;
+use Magento\Eav\Model\Entity\Attribute;
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\Swatches\Model\SwatchAttributesProvider;
 
 /**
  * ElasticSuite swatches helper.
- *
- * Allow to load swatche images from a multivalued attribute filter.
+ * Allow to load swatches images from a multivalued attribute filter.
  *
  * @category Smile
  * @package  Smile\ElasticsuiteSwatches
@@ -35,39 +38,69 @@ class Swatches extends \Magento\Swatches\Helper\Data
         $variation = false;
 
         if ($this->isProductHasSwatch($parentProduct) && $parentProduct->getDocumentSource() !== null) {
-            $documentSource = $parentProduct->getDocumentSource();
-            $childrenIds = isset($documentSource['children_ids']) ? $documentSource['children_ids'] : [];
+            $variation = $this->loadVariationsFromSearchIndex($parentProduct, $attributes);
+        } else {
+            $productCollection = $this->productCollectionFactory->create();
+            $this->addFilterByParent($productCollection, $parentProduct->getId());
 
-            if (!empty($childrenIds)) {
-                $childrenIds = array_map('intval', $childrenIds);
+            $configurableAttributes = $this->getAttributesFromConfigurable($parentProduct);
+            $allAttributesArray     = [];
 
-                $productCollection = $this->productCollectionFactory->create();
-                $productCollection->addIdFilter($childrenIds);
-
-                $configurableAttributes = $this->getAttributesFromConfigurable($parentProduct);
-                $allAttributesArray = [];
-
-                foreach ($configurableAttributes as $attribute) {
-                    foreach ($attribute->getOptions() as $option) {
-                        $allAttributesArray[$attribute['attribute_code']][] = (int) $option->getValue();
+            foreach ($configurableAttributes as $attribute) {
+                $allAttributesArray[$attribute['attribute_code']] = $attribute['default_value'];
+                if ($attribute->usesSource() && isset($attributes[$attribute->getAttributeCode()])) {
+                    // If value is the attribute label, replace it by the optionId.
+                    $optionId = $attribute->getSource()->getOptionId($attributes[$attribute->getAttributeCode()]);
+                    if ($optionId) {
+                        $attributes[$attribute->getAttributeCode()] = $optionId;
                     }
                 }
-
-                $resultAttributesToFilter = array_merge($attributes, array_diff_key($allAttributesArray, $attributes));
-
-                $this->addFilterByAttributes($productCollection, $resultAttributesToFilter);
-
-                $variationProduct = $productCollection->getFirstItem();
-
-                if ($variationProduct && $variationProduct->getId()) {
-                    $variation = $this->productRepository->getById($variationProduct->getId());
-                }
             }
-        } else {
-            $variation = parent::loadVariationByFallback($parentProduct, $attributes);
+
+            $resultAttributesToFilter = array_merge(
+                $attributes,
+                array_diff_key($allAttributesArray, $attributes)
+            );
+
+            $this->addFilterByAttributes($productCollection, $resultAttributesToFilter);
+
+            $variationProduct = $productCollection->getFirstItem();
+
+            if ($variationProduct && $variationProduct->getId()) {
+                $variation = $this->productRepository->getById($variationProduct->getId());
+            }
         }
 
         return $variation;
+    }
+
+    /**
+     * Retrive options ids from a labels array.
+     *
+     * @param Attribute $attribute Attribute.
+     * @param string[]  $labels    Labels
+     *
+     * @return integer[]
+     */
+    public function getOptionIds(Attribute $attribute, $labels)
+    {
+        $optionIds = [];
+
+        if (!is_array($labels)) {
+            $labels = [$labels];
+        }
+
+        $options = $attribute->getSource()->getAllOptions();
+
+        foreach ($labels as $label) {
+            foreach ($options as $option) {
+                if ($option['label'] == $label) {
+                    $optionIds[] = (int) $option['value'];
+                }
+            }
+        }
+
+        return $optionIds;
     }
 
     /**
@@ -81,5 +114,66 @@ class Swatches extends \Magento\Swatches\Helper\Data
             }
             $productCollection->addAttributeToFilter($code, ['in' => $option]);
         }
+    }
+
+    /**
+     * Load variations for a given product with data coming from the search index.
+     *
+     * @param Product $parentProduct Parent Product
+     * @param array   $attributes    Attributes
+     *
+     * @return bool|\Magento\Catalog\Api\Data\ProductInterface
+     */
+    private function loadVariationsFromSearchIndex(Product $parentProduct, array $attributes)
+    {
+        $documentSource = $parentProduct->getDocumentSource();
+        $childrenIds    = isset($documentSource['children_ids']) ? $documentSource['children_ids'] : [];
+        $variation      = false;
+
+        if (!empty($childrenIds)) {
+            $childrenIds = array_map('intval', $childrenIds);
+
+            $productCollection = $this->productCollectionFactory->create();
+            $productCollection->addIdFilter($childrenIds);
+
+            $configurableAttributes = $this->getAttributesFromConfigurable($parentProduct);
+            $allAttributesArray     = [];
+
+            foreach ($configurableAttributes as $attribute) {
+                foreach ($attribute->getOptions() as $option) {
+                    $allAttributesArray[$attribute['attribute_code']][] = (int) $option->getValue();
+                }
+            }
+
+            $resultAttributesToFilter = array_merge($attributes, array_diff_key($allAttributesArray, $attributes));
+
+            $this->addFilterByAttributes($productCollection, $resultAttributesToFilter);
+
+            $variationProduct = $productCollection->getFirstItem();
+
+            if ($variationProduct && $variationProduct->getId()) {
+                $variation = $this->productRepository->getById($variationProduct->getId());
+            }
+        }
+
+        return $variation;
+    }
+
+    /**
+     * Filter a collection by its parent.
+     * Inherited method since it's private in the parent.
+     *
+     * @param ProductCollection $productCollection Product Collection
+     * @param integer           $parentId          Parent Product Id
+     *
+     * @return void
+     */
+    private function addFilterByParent(ProductCollection $productCollection, $parentId)
+    {
+        $tableProductRelation = $productCollection->getTable('catalog_product_relation');
+        $productCollection->getSelect()->join(
+            ['pr' => $tableProductRelation],
+            'e.entity_id = pr.child_id'
+        )->where('pr.parent_id = ?', $parentId);
     }
 }

--- a/src/module-elasticsuite-swatches/Model/Plugin/ProductImage.php
+++ b/src/module-elasticsuite-swatches/Model/Plugin/ProductImage.php
@@ -19,33 +19,21 @@ use Magento\Eav\Model\Entity\Attribute;
 /**
  * Plugin that allow to select the right product image when a filter is selected.
  *
- * @category Smile
- * @package  Smile\ElasticsuiteSwatches
- * @author   Aurelien FOUCRET <aurelien.foucret@smile.fr>
+ * @category   Smile
+ * @package    Smile\ElasticsuiteSwatches
+ * @author     Aurelien FOUCRET <aurelien.foucret@smile.fr>
+ * @deprecated since Magento 2.1.6
  */
 class ProductImage extends \Magento\Swatches\Model\Plugin\ProductImage
 {
     /**
-     * Constructor.
-     *
-     * @param \Smile\ElasticsuiteSwatches\Helper\Swatches $swatchesHelperData Swatch helper.
-     * @param \Magento\Eav\Model\Config                   $eavConfig          Product EAV configuration.
-     * @param \Magento\Framework\App\Request\Http         $request            HTTP Request.
-     */
-    public function __construct(
-        \Smile\ElasticsuiteSwatches\Helper\Swatches $swatchesHelperData,
-        \Magento\Eav\Model\Config $eavConfig,
-        \Magento\Framework\App\Request\Http $request
-    ) {
-        parent::__construct($swatchesHelperData, $eavConfig, $request);
-    }
-
-    /**
-     * {@inheritDoc}
+     * {@inheritdoc}
+     * @deprecated since Magento 2.1.6
      */
     protected function getFilterArray(array $request)
     {
         $filterArray = parent::getFilterArray($request);
+
         $attributeCodes = $this->eavConfig->getEntityAttributeCodes(\Magento\Catalog\Model\Product::ENTITY);
 
         foreach ($request as $code => $value) {
@@ -57,40 +45,11 @@ class ProductImage extends \Magento\Swatches\Model\Plugin\ProductImage
                 }
 
                 if ($attribute->getId() && $this->canReplaceImageWithSwatch($attribute)) {
-                    $filterArray[$code][] = $this->getOptionIds($attribute, $value);
+                    $filterArray[$code][] = $this->swatchHelperData->getOptionIds($attribute, $value);
                 }
             }
         }
 
         return $filterArray;
-    }
-
-    /**
-     * Retrive options ids from a labels array.
-     *
-     * @param Attribute $attribute Attribute.
-     * @param string[]  $labels    Labels
-     *
-     * @return integer[]
-     */
-    private function getOptionIds(Attribute $attribute, $labels)
-    {
-        $optionIds = [];
-
-        if (!is_array($labels)) {
-            $labels = [$labels];
-        }
-
-        $options = $attribute->getSource()->getAllOptions();
-
-        foreach ($labels as $label) {
-            foreach ($options as $option) {
-                if ($option['label'] == $label) {
-                    $optionIds[] = (int) $option['value'];
-                }
-            }
-        }
-
-        return $optionIds;
     }
 }

--- a/src/module-elasticsuite-swatches/Model/Plugin/ProductSubstitute.php
+++ b/src/module-elasticsuite-swatches/Model/Plugin/ProductSubstitute.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\ElasticSuiteSwatches
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2017 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\ElasticsuiteSwatches\Model\Plugin;
+
+use Smile\ElasticsuiteSwatches\Helper\Swatches;
+
+/**
+ * ProductSubstitute Plugin. Used to load Swatches variations.
+ *
+ * @category Smile
+ * @package  Smile\ElasticsuiteSwatches
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ * @since    Magento 2.1.6
+ */
+class ProductSubstitute
+{
+    /**
+     * @var \Magento\Eav\Model\Config
+     */
+    private $eavConfig;
+
+    /**
+     * @var \Smile\ElasticsuiteSwatches\Helper\Swatches
+     */
+    private $swatchHelper;
+
+    /**
+     * ProductSubstitute constructor.
+     *
+     * @param \Magento\Eav\Model\Config                   $config       EAV Config
+     * @param \Smile\ElasticsuiteSwatches\Helper\Swatches $swatchHelper Swatch Helper
+     */
+    public function __construct(\Magento\Eav\Model\Config $config, Swatches $swatchHelper)
+    {
+        $this->eavConfig    = $config;
+        $this->swatchHelper = $swatchHelper;
+    }
+
+    /**
+     * Build proper array for swatches rendering. Especially in product listing where values may come as label
+     * instead of option Ids.
+     *
+     * @param \Magento\Swatches\Model\ProductSubstitute $productSubstitute Original ProductSubstitute class
+     * @param \Closure                                  $proceed           ProductSubstitute::getFilterArray()
+     * @param array                                     $request           Request
+     *
+     * @return mixed
+     */
+    public function aroundGetFilterArray(
+        \Magento\Swatches\Model\ProductSubstitute $productSubstitute,
+        \Closure $proceed,
+        array $request
+    ) {
+        $filterArray = $proceed($request);
+
+        $attributeCodes = $this->eavConfig->getEntityAttributeCodes(\Magento\Catalog\Model\Product::ENTITY);
+
+        foreach ($request as $code => $value) {
+            if (in_array($code, $attributeCodes)) {
+                $attribute = $this->eavConfig->getAttribute(\Magento\Catalog\Model\Product::ENTITY, $code);
+
+                if (isset($filterArray[$code]) && !is_array($filterArray[$code])) {
+                    $filterArray[$code] = [$filterArray[$code]];
+                }
+
+                if ($attribute->getId() && $productSubstitute->canReplaceImageWithSwatch($attribute)) {
+                    $filterArray[$code][] = $this->swatchHelper->getOptionIds($attribute, $value);
+                }
+            }
+        }
+
+        return $filterArray;
+    }
+}

--- a/src/module-elasticsuite-swatches/etc/di.xml
+++ b/src/module-elasticsuite-swatches/etc/di.xml
@@ -21,4 +21,24 @@
         <plugin name="add_product_object_to_image_data_array" type="Smile\ElasticsuiteSwatches\Model\Plugin\ProductImage" />
     </type>
 
+    <type name="Smile\ElasticsuiteSwatches\Model\Plugin\ProductImage">
+        <arguments>
+            <argument name="swatchesHelperData" xsi:type="object">Smile\ElasticsuiteSwatches\Helper\Swatches</argument>
+        </arguments>
+    </type>
+
+    <type name="Magento\Swatches\Controller\Ajax\Media">
+        <arguments>
+            <argument name="swatchHelper" xsi:type="object">Smile\ElasticsuiteSwatches\Helper\Swatches</argument>
+        </arguments>
+    </type>
+
+    <!-- Since Magento 2.1.6 -->
+    <type name="Magento\Swatches\Model\ProductSubstitute">
+        <arguments>
+            <argument name="swatchesHelperData" xsi:type="object">Smile\ElasticsuiteSwatches\Helper\Swatches</argument>
+        </arguments>
+        <plugin name="fix_load_variations" type="Smile\ElasticsuiteSwatches\Model\Plugin\ProductSubstitute" />
+    </type>
+
 </config>


### PR DESCRIPTION
This will fix bugs for Magento 2.1.6 where swatches have ben refactored (our old plugin is not called anymore).

This refactoring have been tested against 2.1.5 and 2.1.6 and is working with full backward compatibility.

It also fixes #393 on both versions.