### PR TITLE
Adding Magento's EQP to build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ cache:
     - $HOME/.composer/cache
 
 script:
+    - vendor/bin/phpcs --config-set installed_paths vendor/magento/marketplace-eqp/
+    - vendor/bin/phpcs --standard=vendor/magento/marketplace-eqp/MEQP2 --severity=10 src/
     - vendor/bin/phpcs --standard=vendor/smile/magento2-smilelab-phpcs/phpcs-standards/SmileLab --extensions=php src/
     - vendor/bin/phpmd src text vendor/smile/magento2-smilelab-phpmd/phpmd-rulesets/rulset.xml
     - vendor/bin/phpunit -c Resources/tests/unit/phpunit.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ cache:
 
 script:
     - vendor/bin/phpcs --config-set installed_paths vendor/magento/marketplace-eqp/
-    - vendor/bin/phpcs --standard=vendor/magento/marketplace-eqp/MEQP2 --severity=10 src/
+    - vendor/bin/phpcs --standard=vendor/magento/marketplace-eqp/MEQP2 --severity=9 src/
     - vendor/bin/phpcs --standard=vendor/smile/magento2-smilelab-phpcs/phpcs-standards/SmileLab --extensions=php src/
     - vendor/bin/phpmd src text vendor/smile/magento2-smilelab-phpmd/phpmd-rulesets/rulset.xml
     - vendor/bin/phpunit -c Resources/tests/unit/phpunit.xml

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,8 @@
         "smile/module-elasticsuite-virtual-category": "self.version"
     },
     "require-dev": {
-        "smile/magento2-smilelab-quality-suite": "1.0.0"
+        "smile/magento2-smilelab-quality-suite": "1.0.0",
+        "magento/marketplace-eqp": "^1.0.0"
     },
     "autoload": {
         "files": [

--- a/src/module-elasticsuite-catalog-optimizer/Model/OptimizerRepository.php
+++ b/src/module-elasticsuite-catalog-optimizer/Model/OptimizerRepository.php
@@ -73,6 +73,9 @@ class OptimizerRepository implements OptimizerRepositoryInterface
     /**
      * Retrieve a optimizer by its ID
      *
+     * @SuppressWarnings(PHPMD.StaticAccess) Mandatory to throw the exception via static access to be compliant
+     * with Magento Extension Quality Program
+     *
      * @param int $optimizerId Id of the optimizer.
      *
      * @return \Smile\ElasticsuiteCatalogOptimizer\Api\Data\OptimizerInterface
@@ -84,8 +87,7 @@ class OptimizerRepository implements OptimizerRepositoryInterface
             $optimizerModel = $this->optimizerFactory->create();
             $optimizer = $this->entityManager->load($optimizerModel, $optimizerId);
             if (!$optimizer->getId()) {
-                $exception = new NoSuchEntityException();
-                throw $exception->singleField('optimizerId', $optimizerId);
+                throw NoSuchEntityException::singleField('optimizerId', $optimizerId);
             }
 
             $this->optimizerRepositoryById[$optimizerId] = $optimizer;

--- a/src/module-elasticsuite-thesaurus/Model/ThesaurusRepository.php
+++ b/src/module-elasticsuite-thesaurus/Model/ThesaurusRepository.php
@@ -88,6 +88,9 @@ class ThesaurusRepository implements ThesaurusRepositoryInterface
     /**
      * Retrieve a thesaurus by its ID
      *
+     * @SuppressWarnings(PHPMD.StaticAccess) Mandatory to throw the exception via static access to be compliant
+     * with Magento Extension Quality Program
+     *
      * @param int $thesaurusId id of the thesaurus
      *
      * @return \Smile\ElasticsuiteThesaurus\Api\Data\ThesaurusInterface
@@ -99,8 +102,7 @@ class ThesaurusRepository implements ThesaurusRepositoryInterface
             /** @var ThesaurusInterface $thesaurus */
             $thesaurus = $this->thesaurusFactory->create()->load($thesaurusId);
             if (!$thesaurus->getThesaurusId()) {
-                $exception = new NoSuchEntityException();
-                throw $exception->singleField('thesaurusId', $thesaurusId);
+                throw NoSuchEntityException::singleField('thesaurusId', $thesaurusId);
             }
 
             $this->thesaurusRepositoryById[$thesaurusId] = $thesaurus;


### PR DESCRIPTION
This PR embeds the Magento's marketplace EQP check (https://github.com/magento/marketplace-eqp) to the build.

It also contains two fixes to perform the build without error with a severity level of 10 (the minimum level to be published on the marketplace).

We could consider fixing all the other warnings shown for lower severity level later. Let me know.