### PR TITLE
Fixing autocomplete refactoring.

### DIFF
--- a/src/module-elasticsuite-catalog/Model/Autocomplete/Product/Attribute/DataProvider.php
+++ b/src/module-elasticsuite-catalog/Model/Autocomplete/Product/Attribute/DataProvider.php
@@ -16,6 +16,7 @@ namespace Smile\ElasticsuiteCatalog\Model\Autocomplete\Product\Attribute;
 use Magento\Search\Model\Autocomplete\DataProviderInterface;
 use Magento\Search\Model\Autocomplete\Item as AutocompleteItem;
 use Smile\ElasticsuiteCatalog\Model\Autocomplete\Product\AttributeConfig;
+use Smile\ElasticsuiteCatalog\Model\Autocomplete\Product\Collection\Provider;
 use Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Fulltext\Collection as ProductCollection;
 use Smile\ElasticsuiteCatalog\Helper\Autocomplete as AutocompleteHelper;
 
@@ -49,6 +50,7 @@ class DataProvider implements DataProviderInterface
      * @var AttributeConfig
      */
     private $attributeConfig;
+
     /**
      * @var ProductCollection
      */
@@ -62,23 +64,23 @@ class DataProvider implements DataProviderInterface
     /**
      * Constructor.
      *
-     * @param ItemFactory        $itemFactory        Autocomplete item factory.
-     * @param AttributeConfig    $attributeConfig    Autocomplete attribute config.
-     * @param ProductCollection  $productCollection  Autocomplete product collection.
-     * @param AutocompleteHelper $autocompleteHelper Autocomplete configuration helper.
-     * @param string             $type               Autocomplete type code.
+     * @param ItemFactory        $itemFactory               Autocomplete item factory.
+     * @param AttributeConfig    $attributeConfig           Autocomplete attribute config.
+     * @param Provider           $productCollectionProvider Autocomplete product collection provider.
+     * @param AutocompleteHelper $autocompleteHelper        Autocomplete configuration helper.
+     * @param string             $type                      Autocomplete type code.
      */
     public function __construct(
         ItemFactory $itemFactory,
         AttributeConfig $attributeConfig,
-        ProductCollection $productCollection,
+        Provider $productCollectionProvider,
         AutocompleteHelper $autocompleteHelper,
         $type = self::AUTOCOMPLETE_TYPE
     ) {
         $this->itemFactory         = $itemFactory;
         $this->type                = $type;
         $this->attributeConfig     = $attributeConfig;
-        $this->productCollection   = $productCollection;
+        $this->productCollection   = $productCollectionProvider->getProductCollection();
         $this->autocompleteHelper  = $autocompleteHelper;
     }
 

--- a/src/module-elasticsuite-catalog/Model/Autocomplete/Product/Collection/Filter.php
+++ b/src/module-elasticsuite-catalog/Model/Autocomplete/Product/Collection/Filter.php
@@ -82,7 +82,7 @@ class Filter implements PreProcessorInterface
             ->addSearchFilter($terms);
 
         if (!$this->stockConfiguration->isShowOutOfStock()) {
-            $this->productCollection->addIsInStockFilter();
+            $collection->addIsInStockFilter();
         }
 
         return $collection;

--- a/src/module-elasticsuite-catalog/etc/frontend/di.xml
+++ b/src/module-elasticsuite-catalog/etc/frontend/di.xml
@@ -110,7 +110,7 @@
     
     <type name="Smile\ElasticsuiteCatalog\Model\Autocomplete\Product\Collection\Provider">
         <arguments>
-            <argument name="productCollection" xsi:type="object">Smile\ElasticsuiteCatalog\Model\Autocomplete\Product\Collection</argument>
+            <argument name="collection" xsi:type="object">Smile\ElasticsuiteCatalog\Model\Autocomplete\Product\Collection</argument>
             <argument name="collectionProcessors" xsi:type="array">
                 <item name="filters" xsi:type="object">Smile\ElasticsuiteCatalog\Model\Autocomplete\Product\Collection\Filter</item>
                 <item name="attributeSelect" xsi:type="object">Smile\ElasticsuiteCatalog\Model\Autocomplete\Product\Collection\AttributeSelector</item>

--- a/src/module-elasticsuite-catalog/etc/frontend/di.xml
+++ b/src/module-elasticsuite-catalog/etc/frontend/di.xml
@@ -108,7 +108,7 @@
         </arguments>
     </virtualType>
     
-    <type name="Smile\ElasticsuiteCatalog\Model\Autocomplete\Product\Collection\Provider">
+    <type name="Smile\ElasticsuiteCatalog\Model\Autocomplete\Product\Collection\Provider" shared="true">
         <arguments>
             <argument name="collection" xsi:type="object">Smile\ElasticsuiteCatalog\Model\Autocomplete\Product\Collection</argument>
             <argument name="collectionProcessors" xsi:type="array">


### PR DESCRIPTION
Your refactoring was causing a fatal error because of using a non existent variable.
