### PR TITLE
Fixing issue with virtual categories

### DIFF
--- a/src/module-elasticsuite-virtual-category/Model/Preview.php
+++ b/src/module-elasticsuite-virtual-category/Model/Preview.php
@@ -192,7 +192,7 @@ class Preview
 
         $this->category->setIsActive(true);
 
-        if ($this->category->getIsVirtualCategory() || $this->category->getId()) {
+        if ($this->category->getIsVirtualCategory()) {
             $query = $this->category->getVirtualRule()->getCategorySearchQuery($this->category);
         }
 


### PR DESCRIPTION
Categories will always have an id, when you go to pull the rule for a
category which is not virtual, the rule will be null which results in
an exception in loading the categories and breaks the admin page with an
eternal spinner. I'm not sure if this fix is correct or not, but it
fixed the page in the admin for us

Potential fix for #435