### PR TITLE
Add Magento_LayeredNavigationStaging as a dependency to fix blank filter 

### DIFF
--- a/src/module-elasticsuite-catalog/etc/module.xml
+++ b/src/module-elasticsuite-catalog/etc/module.xml
@@ -23,6 +23,7 @@
             <module name="Magento_Search" />
             <module name="Magento_CatalogSearch" />
             <module name="Magento_LayeredNavigation" />
+            <module name="Magento_LayeredNavigationStaging" />
             <module name="Magento_CatalogInventory" />
         </sequence>
     </module>


### PR DESCRIPTION
With certain config.php module sequence where Magento_LayeredNavigationStaging come before Smile_ElasticsuiteCatalog we got blank filter for product listing page and search result page