### PR TITLE
Search exact term but still get "No exact results found for: '<query>'. The displayed items are the closest matches."

### DIFF
--- a/src/module-elasticsuite-core/Search/Adapter/Elasticsuite/Spellchecker.php
+++ b/src/module-elasticsuite-core/Search/Adapter/Elasticsuite/Spellchecker.php
@@ -206,7 +206,7 @@ class Spellchecker implements SpellcheckerInterface
                         $positionKey = sprintf("%s_%s", $token['start_offset'], $token['end_offset']);
 
                         if (!isset($termStats['doc_freq'])) {
-                            $termStats['doc_freq'] = 0;
+                            $termStats['doc_freq'] = 1;
                         }
 
                         if (!isset($statByPosition[$positionKey])) {


### PR DESCRIPTION
If doc_freq doesn't exist in term stats, the default value should be 1, because min_doc_freq is default to 1 if omitted in the query param.
See https://www.elastic.co/guide/en/elasticsearch/reference/2.4/docs-termvectors.html#_terms_filtering
for more detail