### PR TITLE
Prevent undefined offset error on deleted categories.

### DIFF
--- a/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Indexer/Fulltext/Datasource/CategoryData.php
+++ b/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Indexer/Fulltext/Datasource/CategoryData.php
@@ -90,7 +90,10 @@ class CategoryData extends Indexer
         $storeCategoryName = $this->loadCategoryNames(array_unique($categoryIds), $storeId);
 
         foreach ($categoryData as &$categoryDataRow) {
-            $categoryDataRow['name'] = $storeCategoryName[(int) $categoryDataRow['category_id']];
+            $categoryDataRow['name'] = '';
+            if (isset($storeCategoryName[(int) $categoryDataRow['category_id']])) {
+                $categoryDataRow['name'] = $storeCategoryName[(int) $categoryDataRow['category_id']];
+            }
         }
 
         return $categoryData;


### PR DESCRIPTION
This one is a workaround for this issue : https://github.com/magento/magento2/issues/10421

This could lead to several errors, since we rely on this table when reindexing products, and provoke failures when trying to index category names into products.

To reproduce : 

- Have the indexers in "Update on Save" mode.
- Delete the category YYY where the product XXX is affected.
- Try to execute an action which triggers a reindex of this product (save it in the BO, or event **order it in front-office**)
- The action will fail, due to "Undefined index: YYY on module-elasticsuite-catalog/Model/ResourceModel/Product/Indexer/Fulltext/Datasource/CategoryData
.php on line 93"

This is due to the fact we rely on a table where old rows concerning a deleted category are still present.

Regards,