### PR TITLE
Enforce reindexing when category is set to virtual.

### DIFF
--- a/src/module-elasticsuite-virtual-category/Plugin/Catalog/Category/ReindexOnChange.php
+++ b/src/module-elasticsuite-virtual-category/Plugin/Catalog/Category/ReindexOnChange.php
@@ -46,10 +46,13 @@ class ReindexOnChange
     {
         $proceed();
 
-        if ($category->dataHasChangedFor('is_virtual_category')) {
+        // Reindex only if attached product list has changed.
+        // This prevent reindexing if the category is just created and set to virtual.
+        if ($category->dataHasChangedFor('is_virtual_category') && ($category->getIsChangedProductList() === true)) {
             if (((bool) $category->getIsVirtualCategory() === true) && ($category->getId())) {
                 if (!$this->getIndexer()->isScheduled()) {
-                    $this->getIndexer()->reindexList($category->getPathIds());
+                    // Remove default root category (1) and Store Root.
+                    $this->getIndexer()->reindexList(array_slice($category->getPathIds(), 2));
                 }
             }
         }

--- a/src/module-elasticsuite-virtual-category/Plugin/Catalog/Category/ReindexOnChange.php
+++ b/src/module-elasticsuite-virtual-category/Plugin/Catalog/Category/ReindexOnChange.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\ElasticsuiteVirtualCategory
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2017 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\ElasticsuiteVirtualCategory\Plugin\Catalog\Category;
+
+/**
+ * Trigger reindexing for category when switched from Standard to "Virtual Category"
+ *
+ * @category Smile
+ * @package  Smile\ElasticsuiteVirtualCategory
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class ReindexOnChange
+{
+    /**
+     * @var \Magento\Framework\Indexer\IndexerRegistry
+     */
+    private $indexerRegistry;
+
+    /**
+     * ReindexOnChange constructor.
+     *
+     * @param \Magento\Framework\Indexer\IndexerRegistry $indexerRegistry Indexer Registry
+     */
+    public function __construct(\Magento\Framework\Indexer\IndexerRegistry $indexerRegistry)
+    {
+        $this->indexerRegistry = $indexerRegistry;
+    }
+
+    /**
+     * Enforce reindexing of path ids if the category has just been set to 'is_virtual_category' = true.
+     *
+     * @param \Magento\Catalog\Model\Category $category The category
+     * @param \Closure                        $proceed  The Category::reindex() method
+     */
+    public function aroundReindex(\Magento\Catalog\Model\Category $category, \Closure $proceed)
+    {
+        $proceed();
+
+        if ($category->dataHasChangedFor('is_virtual_category')) {
+            if (((bool) $category->getIsVirtualCategory() === true) && ($category->getId())) {
+                if (!$this->getIndexer()->isScheduled()) {
+                    $this->getIndexer()->reindexList($category->getPathIds());
+                }
+            }
+        }
+    }
+
+    /**
+     * Retrieve Category/Product indexer.
+     *
+     * @return \Magento\Framework\Indexer\IndexerInterface
+     */
+    private function getIndexer()
+    {
+        return $this->indexerRegistry->get(\Magento\Catalog\Model\Indexer\Category\Product::INDEXER_ID);
+    }
+}

--- a/src/module-elasticsuite-virtual-category/etc/di.xml
+++ b/src/module-elasticsuite-virtual-category/etc/di.xml
@@ -57,6 +57,11 @@
         <plugin name="smile_elasticsuite_virtual_categories_save_products_positions" 
                 type="\Smile\ElasticsuiteVirtualCategory\Plugin\Catalog\Category\SaveProductsPositions" />
     </type>
+
+    <type name="\Magento\Catalog\Model\Category">
+        <plugin name="smile_elasticsuite_virtual_categories_reindex_on_change"
+                type="\Smile\ElasticsuiteVirtualCategory\Plugin\Catalog\Category\ReindexOnChange" />
+    </type>
     
     <type name="Smile\ElasticsuiteCatalog\Model\Product\Indexer\Fulltext\Datasource\CategoryData">
         <arguments>


### PR DESCRIPTION
This is a fix for #465 

Enforce reindexing (if set to Update on Save) when switching a category from normal mode to virtual mode.

Nothing done for mview, since this is actually working properly (due to the SQL trigger).

