### PR TITLE
Fix term vector usage to use also default search field.

### DIFF
--- a/src/module-elasticsuite-core/Search/Adapter/Elasticsuite/Spellchecker.php
+++ b/src/module-elasticsuite-core/Search/Adapter/Elasticsuite/Spellchecker.php
@@ -141,9 +141,13 @@ class Spellchecker implements SpellcheckerInterface
             'type'            => $request->getType(),
             'id'              => '',
             'term_statistics' => true,
+            'dfs'             => true,
         ];
 
-        $termVectorsQuery['body']['doc'] = [MappingInterface::DEFAULT_SPELLING_FIELD => $request->getQueryText()];
+        $termVectorsQuery['body']['doc'] = [
+            MappingInterface::DEFAULT_SEARCH_FIELD   => $request->getQueryText(),
+            MappingInterface::DEFAULT_SPELLING_FIELD => $request->getQueryText(),
+        ];
 
         return $this->client->termvectors($termVectorsQuery);
     }

--- a/src/module-elasticsuite-core/Search/Adapter/Elasticsuite/Spellchecker.php
+++ b/src/module-elasticsuite-core/Search/Adapter/Elasticsuite/Spellchecker.php
@@ -144,10 +144,7 @@ class Spellchecker implements SpellcheckerInterface
             'dfs'             => true,
         ];
 
-        $termVectorsQuery['body']['doc'] = [
-            MappingInterface::DEFAULT_SEARCH_FIELD   => $request->getQueryText(),
-            MappingInterface::DEFAULT_SPELLING_FIELD => $request->getQueryText(),
-        ];
+        $termVectorsQuery['body']['doc'] = [MappingInterface::DEFAULT_SPELLING_FIELD => $request->getQueryText()];
 
         return $this->client->termvectors($termVectorsQuery);
     }


### PR DESCRIPTION
Potential fix for #412 

Two points here : 

- The detection of spelling type (exact or fuzzy) was based on the "spelling" analyzer. It cannot work for fields which are not used for spellcheck.

=> For this one, I have a question, why using "spelling" analyzer for term vectors ? Changing it for both 'search' and 'spelling' gives me better results for fields which are not used for spellchecking.

- The term vector query did not use "dfs" : this implies it is ran to a random shard. By doing this way, a query can be exact one time (matches document in the randomized shard) but fuzzy next time (not matching document in the new randomized shard).

=> About this one, I can understand this may be due to performances issues when using 'dfs'. Let me know where the cursor should be put between exact spelling calculation or less response time. (But the term vector result is cached for later usage, so I would say that using 'dfs' is fine and will give better relevancy).

Let me know !