### PR TITLE
Remove configurable delay for autocomplete debounce.

### DIFF
--- a/src/module-elasticsuite-core/view/frontend/web/js/form-mini.js
+++ b/src/module-elasticsuite-core/view/frontend/web/js/form-mini.js
@@ -35,8 +35,7 @@ define([
             responseFieldElements: 'dl dd',
             selectClass: 'selected',
             submitBtn: 'button[type="submit"]',
-            searchLabel: '[data-role=minisearch-label]',
-            debounceTimer: 500
+            searchLabel: '[data-role=minisearch-label]'
         },
 
         /**
@@ -309,7 +308,7 @@ define([
                 this._updateAriaHasPopup(false);
                 this.element.removeAttr('aria-activedescendant');
             }
-        }, this.debounceTimer),
+        }, 250),
 
         /**
          * Executes when keys are pressed in the search input field. Performs specific actions


### PR DESCRIPTION
Previous version (the #489) is bugged, it is throwing JS error. I did not notice it probably because I had a cached version with hardcoded value of 250 for testing which did not get expired properly.

It does not seem to be possible to access this.options.debounceTimer when launching the _.debounce function as far as I saw. Imho it's not a killer feature to allow a such configuration. For now we can go with arbitrary defined value.

Please merge this one to ensure the bug is fixed.