### PR TITLE
Compute correctly attributes option values from products, when used i…

### DIFF
--- a/src/module-elasticsuite-catalog/Model/Autocomplete/Product/ItemFactory.php
+++ b/src/module-elasticsuite-catalog/Model/Autocomplete/Product/ItemFactory.php
@@ -106,6 +106,9 @@ class ItemFactory extends \Magento\Search\Model\Autocomplete\ItemFactory
         foreach ($this->attributes as $attributeCode) {
             if ($product->hasData($attributeCode)) {
                 $productData[$attributeCode] = $product->getData($attributeCode);
+                if ($product->getResource()->getAttribute($attributeCode)->usesSource()) {
+                    $productData[$attributeCode] = $product->getAttributeText($attributeCode);
+                }
             }
         }
 


### PR DESCRIPTION
…n autocomplete.

For now, if you inject an option based attribute (let's say "manufacturer") and try to display the data in the html template, you will see the option_id.

This is due to the fact we just use $product->getData($attributeCode) which is not rendering properly the attribute value.

$product->getAttributeText($attributeCode) should be used with option based attributes.

regards