### PR TITLE
Handle store codes with upper case characters

### DIFF
--- a/src/module-elasticsuite-core/Helper/IndexSettings.php
+++ b/src/module-elasticsuite-core/Helper/IndexSettings.php
@@ -107,7 +107,7 @@ class IndexSettings extends AbstractConfiguration
      */
     public function getIndexAliasFromIdentifier($indexIdentifier, $store)
     {
-        $store = $this->getStoreCode($store);
+        $store = strtolower($this->getStoreCode($store));
 
         return sprintf('%s_%s_%s', $this->getIndexAlias(), $store, $indexIdentifier);
     }


### PR DESCRIPTION
While Magento allows upper case characters in store codes, elasticsearch does not allow upper case characters in index names. Therefore we have to transform the store code before using it as part of the index name.

larasearch had the same problem which was fixed in [issue 43](https://github.com/iverberk/larasearch/issues/43).