### PR TITLE
Fix synonyms handling when query does not contains any words.

### DIFF
--- a/src/module-elasticsuite-thesaurus/Model/Index.php
+++ b/src/module-elasticsuite-thesaurus/Model/Index.php
@@ -205,9 +205,13 @@ class Index
     {
         $indexName = $this->getIndexAlias($storeId);
 
-        $analysis = $this->client->indices()->analyze(
-            ['index' => $indexName, 'text' => $queryText, 'analyzer' => $type]
-        );
+        try {
+            $analysis = $this->client->indices()->analyze(
+                ['index' => $indexName, 'text' => $queryText, 'analyzer' => $type]
+            );
+        } catch (\Exception $e) {
+            $analysis = ['tokens' => []];
+        }
 
         $synonymByPositions = [];
 


### PR DESCRIPTION
Fix for #529 