### PR TITLE
Fix not existing object into VirtualCategories Install.

### DIFF
--- a/src/module-elasticsuite-virtual-category/Setup/InstallData.php
+++ b/src/module-elasticsuite-virtual-category/Setup/InstallData.php
@@ -71,9 +71,6 @@ class InstallData implements InstallDataInterface
 
         $this->virtualCategorySetup->createVirtualCategoriesAttributes($eavSetup);
 
-        // Mandatory to ensure next installers will have proper EAV Attributes definitions.
-        $this->eavConfig->clear();
-
         $setup->endSetup();
     }
 }


### PR DESCRIPTION
This piece of code was already moved to the dedicated VirtualCategorySetup class during the setup refactoring, it should be removed from the InstallData, especially since $this->eavConfig is not defined anymore.