### PR TITLE
Compute spellcheck apart for fields not using default search analyzer.

### DIFF
--- a/src/module-elasticsuite-catalog-optimizer/Model/Optimizer/Preview/SearchQuery.php
+++ b/src/module-elasticsuite-catalog-optimizer/Model/Optimizer/Preview/SearchQuery.php
@@ -144,6 +144,7 @@ class SearchQuery
             'type'            => $containerConfig->getTypeName(),
             'queryText'       => $queryText,
             'cutoffFrequency' => $containerConfig->getRelevanceConfig()->getCutOffFrequency(),
+            'fields'          => $containerConfig->getMapping()->getNonDefaultAnalyzerFields(),
         ];
 
         $spellcheckRequest = $this->spellcheckRequestFactory->create($spellcheckRequestParams);

--- a/src/module-elasticsuite-core/Api/Index/MappingInterface.php
+++ b/src/module-elasticsuite-core/Api/Index/MappingInterface.php
@@ -84,4 +84,11 @@ interface MappingInterface
         $boost = 1,
         FieldFilterInterface $fieldFilter = null
     );
+
+    /**
+     * Retrieve all fields which are not using the default search analyzer.
+     *
+     * @return FieldInterface[]
+     */
+    public function getNonDefaultAnalyzerFields();
 }

--- a/src/module-elasticsuite-core/Api/Search/Spellchecker/RequestInterface.php
+++ b/src/module-elasticsuite-core/Api/Search/Spellchecker/RequestInterface.php
@@ -14,6 +14,8 @@
 
 namespace Smile\ElasticsuiteCore\Api\Search\Spellchecker;
 
+use Smile\ElasticsuiteCore\Api\Index\Mapping\FieldInterface;
+
 /**
  * Spellchecking request interface.
  *
@@ -36,6 +38,13 @@ interface RequestInterface
      * @return string
      */
     public function getType();
+
+    /**
+     * Spellcheck request document type.
+     *
+     * @return FieldInterface[]
+     */
+    public function getFields();
 
     /**
      * Spellcheck fulltext query.

--- a/src/module-elasticsuite-core/Index/Mapping.php
+++ b/src/module-elasticsuite-core/Index/Mapping.php
@@ -186,6 +186,22 @@ class Mapping implements MappingInterface
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function getNonDefaultAnalyzerFields()
+    {
+        $nonDefaultFields = [];
+
+        foreach ($this->getFields() as $field) {
+            if ($field->isSearchable() && ($field->getDefaultSearchAnalyzer() !== FieldInterface::ANALYZER_STANDARD)) {
+                $nonDefaultFields[] = $field;
+            }
+        }
+
+        return $nonDefaultFields;
+    }
+
+    /**
      * Return the search property for a field present in defaultMappingFields.
      *
      * @throws \InvalidArgument If the field / analyzer does not exists.

--- a/src/module-elasticsuite-core/Search/Adapter/Elasticsuite/Spellchecker.php
+++ b/src/module-elasticsuite-core/Search/Adapter/Elasticsuite/Spellchecker.php
@@ -144,7 +144,15 @@ class Spellchecker implements SpellcheckerInterface
             'dfs'             => true,
         ];
 
-        $termVectorsQuery['body']['doc'] = [MappingInterface::DEFAULT_SPELLING_FIELD => $request->getQueryText()];
+        $termVectorsParams = [MappingInterface::DEFAULT_SPELLING_FIELD => $request->getQueryText()];
+
+        foreach ($request->getFields() as $field) {
+            if ($field->getType() === 'string') { // Non-string fields cannot work with term vectors.
+                $termVectorsParams[$field->getName()] = $request->getQueryText();
+            }
+        }
+
+        $termVectorsQuery['body']['doc'] = $termVectorsParams;
 
         return $this->client->termvectors($termVectorsQuery);
     }

--- a/src/module-elasticsuite-core/Search/Request/Builder.php
+++ b/src/module-elasticsuite-core/Search/Request/Builder.php
@@ -15,6 +15,7 @@
 namespace Smile\ElasticsuiteCore\Search\Request;
 
 use Magento\Framework\Search\Request\DimensionFactory;
+use Smile\ElasticsuiteCore\Api\Index\Mapping\FieldInterface;
 use Smile\ElasticsuiteCore\Search\Request\Query\Builder as QueryBuilder;
 use Smile\ElasticsuiteCore\Search\Request\SortOrder\SortOrderBuilder;
 use Smile\ElasticsuiteCore\Search\Request\Aggregation\AggregationBuilder;
@@ -186,6 +187,7 @@ class Builder
             'type'            => $containerConfig->getTypeName(),
             'queryText'       => $queryText,
             'cutoffFrequency' => $containerConfig->getRelevanceConfig()->getCutOffFrequency(),
+            'fields'          => $containerConfig->getMapping()->getNonDefaultAnalyzerFields(),
         ];
 
         $spellcheckRequest = $this->spellcheckRequestFactory->create($spellcheckRequestParams);

--- a/src/module-elasticsuite-core/Search/Spellchecker/Request.php
+++ b/src/module-elasticsuite-core/Search/Spellchecker/Request.php
@@ -14,6 +14,7 @@
 
 namespace Smile\ElasticsuiteCore\Search\Spellchecker;
 
+use Smile\ElasticsuiteCore\Api\Index\Mapping\FieldInterface;
 use Smile\ElasticsuiteCore\Api\Search\Spellchecker\RequestInterface;
 
 /**
@@ -48,19 +49,26 @@ class Request implements RequestInterface
     private $cufoffFrequency;
 
     /**
+     * @var FieldInterface[]
+     */
+    private $fields;
+
+    /**
      * Constructor.
      *
      * @param string $index           Spellcheck request index name.
      * @param string $type            Spellcheck request document type.
      * @param string $queryText       Spellcheck fulltext query.
      * @param float  $cutoffFrequency Spellcheck cutoff frequency (used to detect stopwords).
+     * @param array  $fields          The fields to check against spellcheck.
      */
-    public function __construct($index, $type, $queryText, $cutoffFrequency)
+    public function __construct($index, $type, $queryText, $cutoffFrequency, $fields = [])
     {
         $this->index           = $index;
         $this->type            = $type;
         $this->queryText       = $queryText;
         $this->cufoffFrequency = $cutoffFrequency;
+        $this->fields          = $fields;
     }
 
     /**
@@ -77,6 +85,14 @@ class Request implements RequestInterface
     public function getType()
     {
         return $this->type;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getFields()
+    {
+        return $this->fields;
     }
 
     /**


### PR DESCRIPTION
This one is meant to enhance "search by sku" but could theorically work with any field which is using a custom "defaultSearchAnalyzer". I choose to split the spellcheck request, which was previously performed only on "spelling" field, to "spelling" + "the fields which are using a custom search analyzer".

This has been tested working OK with several patterns of SKU : 

- mix of letters and number : 101177BLG
- full letters : HEWPUTRABC
- full numbers : 11610018
- mixed with dash : ABC-V1P80
- overly complicated sku : HEW-V1P80UTR#ABA

So this should gladly address #412 and #524 

However, this actually does NOT work with "partial searches", eg searching for just "ABC" or "V1P80" or BLG will not match against my examples.

So let me know if you want me to enhance more this PR by adding support of partial searches, which seems a little bit more tricky to do.

Regards