### PR TITLE
Feature missing sort

### DIFF
--- a/src/module-elasticsuite-catalog/Block/Plugin/Adminhtml/Product/Attribute/Edit/Tab/FrontPlugin.php
+++ b/src/module-elasticsuite-catalog/Block/Plugin/Adminhtml/Product/Attribute/Edit/Tab/FrontPlugin.php
@@ -99,7 +99,7 @@ class FrontPlugin
         $this->addSearchFields($fieldset);
         $this->addAutocompleteFields($fieldset);
         $this->addFacetFields($fieldset);
-
+        $this->addSortFields($fieldset);
         $this->appendSliderDisplayRelatedFields($form, $subject);
 
         if ($this->getAttribute()->getAttributeCode() == 'name') {
@@ -273,6 +273,47 @@ class FrontPlugin
     }
 
     /**
+     * Append sorting related fields.
+     *
+     * @param Fieldset $fieldset Target fieldset
+     *
+     * @return FrontPlugin
+     */
+    private function addSortFields(Fieldset $fieldset)
+    {
+        $sortFieldsOptions = [
+            ['value' => '_first', 'label' => __("First")],
+            ['value' => '_last',  'label' => __("Last")],
+        ];
+
+        $fieldset->addField(
+            'sort_order_asc_missing',
+            'select',
+            [
+                'name'   => 'sort_order_asc_missing',
+                'label'  => __('Sort products without value when sorting ASC'),
+                'values' => $sortFieldsOptions,
+                'note'   => __('How the products which are missing values for this attribute should be treated when using it to sort.'),
+            ],
+            'used_for_sortby'
+        );
+
+        $fieldset->addField(
+            'sort_order_desc_missing',
+            'select',
+            [
+                'name'   => 'sort_order_desc_missing',
+                'label'  => __('Sort products without value when sorting DESC'),
+                'values' => $sortFieldsOptions,
+                'note'   => __('How the products which are missing values for this attribute should be treated when using it to sort.'),
+            ],
+            'sort_order_asc_missing'
+        );
+
+        return $this;
+    }
+
+    /**
      * Append the "Slider Display Configuration" fieldset to the tab.
      *
      * @param Form  $form    Target form.
@@ -368,8 +409,13 @@ class FrontPlugin
                 ->addFieldMap('is_filterable_in_search', 'is_filterable_in_search')
                 ->addFieldMap('is_searchable', 'is_searchable')
                 ->addFieldMap('is_used_in_spellcheck', 'is_used_in_spellcheck')
+                ->addFieldMap('used_for_sort_by', 'used_for_sort_by')
+                ->addFieldMap('sort_order_asc_missing', 'sort_order_asc_missing')
+                ->addFieldMap('sort_order_desc_missing', 'sort_order_desc_missing')
                 ->addFieldDependence('is_displayed_in_autocomplete', 'is_filterable_in_search', '1')
-                ->addFieldDependence('is_used_in_spellcheck', 'is_searchable', '1');
+                ->addFieldDependence('is_used_in_spellcheck', 'is_searchable', '1')
+                ->addFieldDependence('sort_order_asc_missing', 'used_for_sort_by', '1')
+                ->addFieldDependence('sort_order_desc_missing', 'used_for_sort_by', '1');
         }
 
         return $this;

--- a/src/module-elasticsuite-catalog/Helper/AbstractAttribute.php
+++ b/src/module-elasticsuite-catalog/Helper/AbstractAttribute.php
@@ -99,6 +99,11 @@ abstract class AbstractAttribute extends Mapping
             $options['is_filterable'] = true;
         }
 
+        if ($attribute->getUsedForSortBy()) {
+            $options['sort_order_asc_missing']  = $attribute->getSortOrderAscMissing();
+            $options['sort_order_desc_missing'] = $attribute->getSortOrderDescMissing();
+        }
+
         return $options;
     }
 

--- a/src/module-elasticsuite-catalog/Setup/CatalogSetup.php
+++ b/src/module-elasticsuite-catalog/Setup/CatalogSetup.php
@@ -513,6 +513,43 @@ class CatalogSetup
     }
 
     /**
+     * Add "sort_order_asc_missing" and "sort_order_desc_missing" fields to catalog_eav_attribute table.
+     *
+     * @param \Magento\Framework\Setup\SchemaSetupInterface $setup Schema Setup
+     */
+    public function addSortOrderMissingFields(SchemaSetupInterface $setup)
+    {
+        $connection = $setup->getConnection();
+        $table      = $setup->getTable('catalog_eav_attribute');
+
+        // Append a column 'sort_order_asc_missing' into the db.
+        $connection->addColumn(
+            $table,
+            'sort_order_asc_missing',
+            [
+                'type'     => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
+                'nullable' => false,
+                'default'  => \Smile\ElasticsuiteCore\Search\Request\SortOrderInterface::MISSING_LAST,
+                'length'   => 10,
+                'comment'  => 'Sort products without value when sorting ASC',
+            ]
+        );
+
+        // Append a column 'sort_order_desc_missing' into the db.
+        $connection->addColumn(
+            $table,
+            'sort_order_desc_missing',
+            [
+                'type'     => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
+                'nullable' => false,
+                'default'  => \Smile\ElasticsuiteCore\Search\Request\SortOrderInterface::MISSING_FIRST,
+                'length'   => 10,
+                'comment'  => 'Sort products without value when sorting DESC',
+            ]
+        );
+    }
+
+    /**
      * Update attribute value for an entity with a default value.
      * All existing values are erased by the new value.
      *

--- a/src/module-elasticsuite-catalog/Setup/InstallSchema.php
+++ b/src/module-elasticsuite-catalog/Setup/InstallSchema.php
@@ -68,6 +68,9 @@ class InstallSchema implements InstallSchemaInterface
         // Introduced in version 1.4.0.
         $this->catalogSetup->createSearchPositionTable($setup);
 
+        // Introduced in version 1.5.1.
+        $this->catalogSetup->addSortOrderMissingFields($setup);
+
         $setup->endSetup();
     }
 }

--- a/src/module-elasticsuite-catalog/Setup/UpgradeSchema.php
+++ b/src/module-elasticsuite-catalog/Setup/UpgradeSchema.php
@@ -75,6 +75,10 @@ class UpgradeSchema implements UpgradeSchemaInterface
             $this->catalogSetup->setNullablePositionColumn($setup);
         }
 
+        if (version_compare($context->getVersion(), '1.5.1', '<')) {
+            $this->catalogSetup->addSortOrderMissingFields($setup);
+        }
+
         $setup->endSetup();
     }
 }

--- a/src/module-elasticsuite-catalog/etc/module.xml
+++ b/src/module-elasticsuite-catalog/etc/module.xml
@@ -17,7 +17,7 @@
  */
  -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Smile_ElasticsuiteCatalog" setup_version="1.5.0">
+    <module name="Smile_ElasticsuiteCatalog" setup_version="1.5.1">
         <sequence>
             <module name="Smile_ElasticsuiteCore" />
             <module name="Magento_Search" />

--- a/src/module-elasticsuite-catalog/i18n/en_US.csv
+++ b/src/module-elasticsuite-catalog/i18n/en_US.csv
@@ -77,3 +77,9 @@ Pinned,Pinned
 Products,Products
 Categories,Categories
 Attributes,Attributes
+"No value matching the search <b>%1</b>.","No value matching the search <b>%1</b>."
+"Sort products without value when sorting ASC","Sort products without value when sorting ASC"
+"Sort products without value when sorting DESC","Sort products without value when sorting DESC"
+"How the products which are missing values for this attribute should be treated when using it to sort.","How the products which are missing values for this attribute should be treated when using it to sort."
+"First","First"
+"Last","Last"

--- a/src/module-elasticsuite-catalog/i18n/fr_FR.csv
+++ b/src/module-elasticsuite-catalog/i18n/fr_FR.csv
@@ -77,3 +77,9 @@ No,Non
 Products,Produits
 Categories,Catégories
 Attributes,Attributs
+"No value matching the search <b>%1</b>.","Aucun résultat pour la recherche <b>%s</b>."
+"Sort products without value when sorting ASC","Trier les produits sans valeurs lors d'un tri ASC"
+"Sort products without value when sorting DESC","Trier les produits sans valeurs lors d'un tri DESC"
+"How the products which are missing values for this attribute should be treated when using it to sort.","Comment sont traités les produits sans valeur lorsque cet attribut est utilisé pour trier."
+"First","En premier"
+"Last","En dernier"

--- a/src/module-elasticsuite-core/Api/Index/Mapping/FieldInterface.php
+++ b/src/module-elasticsuite-core/Api/Index/Mapping/FieldInterface.php
@@ -14,6 +14,8 @@
 
 namespace Smile\ElasticsuiteCore\Api\Index\Mapping;
 
+use Smile\ElasticsuiteCore\Search\Request\SortOrderInterface;
+
 /**
  * Representation of a Elasticsearch field (abstraction of mapping properties).
  *
@@ -132,7 +134,6 @@ interface FieldInterface
      */
     public function getMappingProperty($analyzer = self::ANALYZER_UNTOUCHED);
 
-
     /**
      * Return the search analyzer used by default for fulltext searches.
      *
@@ -148,4 +149,13 @@ interface FieldInterface
      * @return \Smile\ElasticsuiteCore\Api\Index\Mapping\FieldInterface
      */
     public function mergeConfig(array $config = []);
+
+    /**
+     * Retrieve the directive to apply for "missing" when the field is used for sort by.
+     *
+     * @param string $direction The direction used to sort
+     *
+     * @return mixed
+     */
+    public function getSortMissing($direction = SortOrderInterface::SORT_ASC);
 }

--- a/src/module-elasticsuite-core/Index/Mapping/Field.php
+++ b/src/module-elasticsuite-core/Index/Mapping/Field.php
@@ -15,6 +15,7 @@
 namespace Smile\ElasticsuiteCore\Index\Mapping;
 
 use Smile\ElasticsuiteCore\Api\Index\Mapping\FieldInterface;
+use Smile\ElasticsuiteCore\Search\Request\SortOrderInterface;
 
 /**
  * Default implementation for ES mapping field (Smile\ElasticsuiteCore\Api\Index\Mapping\FieldInterface).
@@ -233,6 +234,24 @@ class Field implements FieldInterface
         $config = array_merge($this->config, $config);
 
         return new static($this->name, $this->type, $this->nestedPath, $config);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getSortMissing($direction = SortOrderInterface::SORT_ASC)
+    {
+        // @codingStandardsIgnoreStart
+        $missing = $direction === SortOrderInterface::SORT_ASC ? SortOrderInterface::MISSING_LAST : SortOrderInterface::MISSING_FIRST;
+        // @codingStandardsIgnoreEnd
+
+        if ($direction === SortOrderInterface::SORT_ASC && isset($this->config['sort_order_asc_missing'])) {
+            $missing = $this->config['sort_order_asc_missing'];
+        } elseif ($direction === SortOrderInterface::SORT_DESC && isset($this->config['sort_order_desc_missing'])) {
+            $missing = $this->config['sort_order_desc_missing'];
+        }
+
+        return $missing;
     }
 
     /**

--- a/src/module-elasticsuite-core/Search/Adapter/Elasticsuite/Request/SortOrder/Builder.php
+++ b/src/module-elasticsuite-core/Search/Adapter/Elasticsuite/Request/SortOrder/Builder.php
@@ -70,7 +70,7 @@ class Builder
         $sortOrderConfig = ['order' => $sortOrder->getDirection()];
 
         if ($sortField !== SortOrderInterface::DEFAULT_SORT_FIELD) {
-            $sortOrderConfig['missing']       = $sortOrder->getDirection() == SortOrderInterface::SORT_ASC ? '_last' : '_first';
+            $sortOrderConfig['missing']       = $sortOrder->getMissing();
             $sortOrderConfig['unmapped_type'] = FieldInterface::FIELD_TYPE_KEYWORD;
         }
 

--- a/src/module-elasticsuite-core/Search/Request/SortOrder/Nested.php
+++ b/src/module-elasticsuite-core/Search/Request/SortOrder/Nested.php
@@ -49,6 +49,7 @@ class Nested extends Standard
      * @param QueryInterface $nestedFilter The filter applied to the nested sort.
      * @param string         $scoreMode    Method used to aggregate the sort if there is many match for the filter.
      * @param string         $name         Sort order name.
+     * @param string         $missing      How to treat missing values.
      */
     public function __construct(
         $field,
@@ -56,9 +57,10 @@ class Nested extends Standard
         $nestedPath,
         QueryInterface $nestedFilter = null,
         $scoreMode = self::SCORE_MODE_MIN,
-        $name = null
+        $name = null,
+        $missing = null
     ) {
-        parent::__construct($field, $direction, $name);
+        parent::__construct($field, $direction, $name, $missing);
 
         $this->nestedFilter = $nestedFilter;
         $this->nestedPath   = $nestedPath;

--- a/src/module-elasticsuite-core/Search/Request/SortOrder/SortOrderBuilder.php
+++ b/src/module-elasticsuite-core/Search/Request/SortOrder/SortOrderBuilder.php
@@ -149,7 +149,8 @@ class SortOrderBuilder
      */
     private function getSortOrderParams(FieldInterface $field, array $sortOrderParams)
     {
-        $sortOrderParams['field'] = $field->getMappingProperty(FieldInterface::ANALYZER_SORTABLE);
+        $sortOrderParams['field']   = $field->getMappingProperty(FieldInterface::ANALYZER_SORTABLE);
+        $sortOrderParams['missing'] = $field->getSortMissing($sortOrderParams['direction']);
 
         if ($field->isNested() && !isset($sortOrderParams['nestedPath'])) {
             $sortOrderParams['nestedPath'] = $field->getNestedPath();

--- a/src/module-elasticsuite-core/Search/Request/SortOrder/Standard.php
+++ b/src/module-elasticsuite-core/Search/Request/SortOrder/Standard.php
@@ -41,17 +41,27 @@ class Standard implements SortOrderInterface
     private $direction;
 
     /**
+     * @var string
+     */
+    private $missing;
+
+    /**
      * Constructor.
      *
      * @param string $field     Sort order field.
      * @param string $direction Sort order direction.
      * @param string $name      Sort order name.
+     * @param string $missing   How to treat missing values.
      */
-    public function __construct($field, $direction = self::SORT_ASC, $name = null)
+    public function __construct($field, $direction = self::SORT_ASC, $name = null, $missing = null)
     {
         $this->field     = $field;
         $this->direction = $direction;
         $this->name      = $name;
+        $this->missing   = $missing;
+        if ($this->missing === null) {
+            $this->missing = $direction == self::SORT_ASC ? self::MISSING_LAST : self::MISSING_FIRST;
+        }
     }
 
     /**
@@ -84,5 +94,13 @@ class Standard implements SortOrderInterface
     public function getType()
     {
         return SortOrderInterface::TYPE_STANDARD;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getMissing()
+    {
+        return $this->missing;
     }
 }

--- a/src/module-elasticsuite-core/Search/Request/SortOrderInterface.php
+++ b/src/module-elasticsuite-core/Search/Request/SortOrderInterface.php
@@ -26,6 +26,9 @@ interface SortOrderInterface
     const SORT_ASC  = 'asc';
     const SORT_DESC = 'desc';
 
+    const MISSING_FIRST  = '_first';
+    const MISSING_LAST   = '_last';
+
     const TYPE_STANDARD = 'standardSortOrder';
     const TYPE_NESTED   = 'nestedSortOrder';
 
@@ -66,4 +69,11 @@ interface SortOrderInterface
      * @return string
      */
     public function getType();
+
+    /**
+     * Sort order 'missing' directive.
+     *
+     * @return string
+     */
+    public function getMissing();
 }

--- a/src/module-elasticsuite-core/Test/Unit/Index/Mapping/FieldTest.php
+++ b/src/module-elasticsuite-core/Test/Unit/Index/Mapping/FieldTest.php
@@ -16,6 +16,7 @@ namespace Smile\ElasticsuiteCore\Test\Unit\Index\Mapping;
 
 use Smile\ElasticsuiteCore\Index\Mapping\Field;
 use Smile\ElasticsuiteCore\Api\Index\Mapping\FieldInterface;
+use Smile\ElasticsuiteCore\Search\Request\SortOrderInterface;
 
 /**
  * Mapping field test case.
@@ -45,6 +46,9 @@ class FieldTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(false, $field->isNested());
         $this->assertEquals(null, $field->getNestedFieldName());
         $this->assertEquals(null, $field->getNestedPath());
+        $this->assertEquals('_last', $field->getSortMissing());
+        $this->assertEquals('_last', $field->getSortMissing(SortOrderInterface::SORT_ASC));
+        $this->assertEquals('_first', $field->getSortMissing(SortOrderInterface::SORT_DESC));
 
         $mappingPropertyConfig = $field->getMappingPropertyConfig();
         $this->assertEquals(FieldInterface::FIELD_TYPE_KEYWORD, $mappingPropertyConfig['type']);


### PR DESCRIPTION
This one allow to fix for each attribute (and both sorting direction) how we are supposed to set the "missing" parameter of the ES sort order.

Default values are equal to what was done previously (DESC => _last, ASC => _first) so it will be transparent after upgrade.

Will fix #560 and #362 by letting our fellow users to define how they want the sort order to behave.