### PR TITLE
Adding SKU to spellchecked field to allow exact matching on it.

### DIFF
--- a/src/module-elasticsuite-catalog/etc/elasticsuite_indices.xml
+++ b/src/module-elasticsuite-catalog/etc/elasticsuite_indices.xml
@@ -38,6 +38,7 @@
                 <field name="type_id" type="string" />
                 <field name="sku" type="string">
                     <isSearchable>1</isSearchable>
+                    <isUsedInSpellcheck>1</isUsedInSpellcheck>
                     <defaultSearchAnalyzer>whitespace</defaultSearchAnalyzer>
                 </field>
                 <field name="visibility" type="integer" />


### PR DESCRIPTION
You were right @afoucret (I know, you will say "as usual"), just putting the sku as "isUsedInSpellcheck" allow to obtain exact matching on it (as we discussed about the term vector query using only spellchecked field) .

Tested working OK with : 

- mix of letters and number : 101177BLG
- full letters : HEWPUTRABC
- full numbers : 11610018
- mixed with dash : ABC-V1P80
- overly complicated sku : HEW-V1P80UTR#ABA

So this should gladly fix #412 and fix #524 with a less intrusive implementation than #548 

