### PR TITLE
Refactoring "special attributes" to allow extending them easily.

### DIFF
--- a/src/module-elasticsuite-catalog-rule/Api/Rule/Condition/Product/SpecialAttributeInterface.php
+++ b/src/module-elasticsuite-catalog-rule/Api/Rule/Condition/Product/SpecialAttributeInterface.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * DISCLAIMER :
+ *
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile_Elasticsuite
+ * @package   Smile\ElasticsuiteCatalogRule
+ * @author    Aurelien FOUCRET <romain.ruaud@smile.fr>
+ * @copyright 2017 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+
+namespace Smile\ElasticsuiteCatalogRule\Api\Rule\Condition\Product;
+
+use Smile\ElasticsuiteCore\Search\Request\QueryInterface;
+
+/**
+ * Definition of "special attributes" that can be used for building rules with Elasticsuite.
+ *
+ * @category Smile_Elasticsuite
+ * @package  Smile\ElasticsuiteCatalogRule
+ * @author   Aurelien FOUCRET <aurelien.foucret@smile.fr>
+ */
+interface SpecialAttributeInterface
+{
+    /**
+     * @return string
+     */
+    public function getAttributeCode();
+
+    /**
+     * @return QueryInterface
+     */
+    public function getSearchQuery();
+
+    /**
+     * @return string
+     */
+    public function getOperatorName();
+
+    /**
+     * @return string
+     */
+    public function getInputType();
+
+    /**
+     * @return string
+     */
+    public function getValueElementType();
+
+    /**
+     * @return string
+     */
+    public function getValueName();
+
+    /**
+     * @return mixed
+     */
+    public function getValue();
+
+    /**
+     * @return array
+     */
+    public function getValueOptions();
+
+    /**
+     * @return string
+     */
+    public function getLabel();
+}

--- a/src/module-elasticsuite-catalog-rule/Model/Rule/Condition/Product/QueryBuilder.php
+++ b/src/module-elasticsuite-catalog-rule/Model/Rule/Condition/Product/QueryBuilder.php
@@ -1,10 +1,8 @@
 <?php
 /**
  * DISCLAIMER
- *
  * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
  * versions in the future.
- *
  *
  * @category  Smile
  * @package   Smile\ElasticsuiteCatalogRule
@@ -39,6 +37,11 @@ class QueryBuilder
     private $attributeList;
 
     /**
+     * @var SpecialAttributesProvider
+     */
+    private $specialAttributesProvider;
+
+    /**
      * @var NestedFilterInterface[]
      */
     private $nestedFilters;
@@ -46,15 +49,21 @@ class QueryBuilder
     /**
      * Constructor.
      *
-     * @param AttributeList           $attributeList Search rule product attributes list
-     * @param QueryFactory            $queryFactory  Search query factory.
-     * @param NestedFilterInterface[] $nestedFilters Filters applied to nested fields during query building.
+     * @param AttributeList             $attributeList             Search rule product attributes list
+     * @param QueryFactory              $queryFactory              Search query factory.
+     * @param SpecialAttributesProvider $specialAttributesProvider Special Attributes Provider.
+     * @param NestedFilterInterface[]   $nestedFilters             Filters applied to nested fields during query building.
      */
-    public function __construct(AttributeList $attributeList, QueryFactory $queryFactory, $nestedFilters = [])
-    {
-        $this->queryFactory  = $queryFactory;
-        $this->attributeList = $attributeList;
-        $this->nestedFilters = $nestedFilters;
+    public function __construct(
+        AttributeList $attributeList,
+        QueryFactory $queryFactory,
+        SpecialAttributesProvider $specialAttributesProvider,
+        $nestedFilters = []
+    ) {
+        $this->queryFactory              = $queryFactory;
+        $this->attributeList             = $attributeList;
+        $this->specialAttributesProvider = $specialAttributesProvider;
+        $this->nestedFilters             = $nestedFilters;
     }
 
     /**
@@ -77,10 +86,10 @@ class QueryBuilder
             $queryParams = $this->getTermsQueryParams($productCondition);
 
             if ($productCondition->getInputType() === 'string' && !in_array($productCondition->getOperator(), ['()', '!()'])) {
-                $queryType = QueryInterface::TYPE_MATCH;
+                $queryType   = QueryInterface::TYPE_MATCH;
                 $queryParams = $this->getMatchQueryParams($productCondition);
             } elseif (in_array($productCondition->getOperator(), ['>=', '>', '<=', '<'])) {
-                $queryType = QueryInterface::TYPE_RANGE;
+                $queryType   = QueryInterface::TYPE_RANGE;
                 $queryParams = $this->getRangeQueryParams($productCondition);
             }
 
@@ -93,11 +102,11 @@ class QueryBuilder
             $field = $this->getSearchField($productCondition);
 
             if ($field->isNested()) {
-                $nestedPath = $field->getNestedPath();
+                $nestedPath        = $field->getNestedPath();
                 $nestedQueryParams = ['query' => $query, 'path' => $nestedPath];
 
                 if (isset($this->nestedFilters[$nestedPath])) {
-                    $nestedFilterClauses = [];
+                    $nestedFilterClauses           = [];
                     $nestedFilterClauses['must'][] = $this->nestedFilters[$nestedPath]->getFilter();
                     $nestedFilterClauses['must'][] = $nestedQueryParams['query'];
 
@@ -124,23 +133,12 @@ class QueryBuilder
     {
         $query = null;
 
-        if ($productCondition->getAttribute() == 'has_image' && $productCondition->getValue()) {
-            $query = $this->getHasImageQuery();
+        if (in_array($productCondition->getAttribute(), array_keys($this->specialAttributesProvider->getList()))) {
+            $specialAttribute = $this->specialAttributesProvider->getAttribute($productCondition->getAttribute());
+            $query            = $specialAttribute->getSearchQuery();
         }
 
         return $query;
-    }
-
-    /**
-     * Has image query.
-     *
-     * @return \Smile\ElasticsuiteCore\Search\Request\QueryInterface
-     */
-    private function getHasImageQuery()
-    {
-        $query = $this->queryFactory->create(QueryInterface::TYPE_MISSING, ['field' => 'image']);
-
-        return $this->queryFactory->create(QueryInterface::TYPE_NOT, ['query' => $query]);
     }
 
     /**
@@ -248,7 +246,7 @@ class QueryBuilder
         return $field;
     }
 
-     /**
+    /**
      * Retrieve ES mapping field name used for the current condition (including analyzer).
      *
      * @param ProductCondition $productCondition Product condition.

--- a/src/module-elasticsuite-catalog-rule/Model/Rule/Condition/Product/SpecialAttribute/HasImage.php
+++ b/src/module-elasticsuite-catalog-rule/Model/Rule/Condition/Product/SpecialAttribute/HasImage.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\ElasticsuiteCatalogRule
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2017 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\ElasticsuiteCatalogRule\Model\Rule\Condition\Product\SpecialAttribute;
+
+use Smile\ElasticsuiteCatalogRule\Api\Rule\Condition\Product\SpecialAttributeInterface;
+use Smile\ElasticsuiteCore\Search\Request\Query\QueryFactory;
+use Smile\ElasticsuiteCore\Search\Request\QueryInterface;
+
+/**
+ * Special "has_image" attribute class.
+ *
+ * @category Smile
+ * @package  Smile\ElasticsuiteCatalogRule
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class HasImage implements SpecialAttributeInterface
+{
+    /**
+     * @var \Smile\ElasticsuiteCore\Search\Request\Query\QueryFactory
+     */
+    private $queryFactory;
+
+    /**
+     * @var \Magento\Config\Model\Config\Source\Yesno
+     */
+    private $booleanSource;
+
+    /**
+     * HasImage constructor.
+     *
+     * @param \Smile\ElasticsuiteCore\Search\Request\Query\QueryFactory $queryFactory  Query Factory
+     * @param \Magento\Config\Model\Config\Source\Yesno                 $booleanSource Boolean Source
+     */
+    public function __construct(QueryFactory $queryFactory, \Magento\Config\Model\Config\Source\Yesno $booleanSource)
+    {
+        $this->queryFactory  = $queryFactory;
+        $this->booleanSource = $booleanSource;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAttributeCode()
+    {
+        return 'has_image';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSearchQuery()
+    {
+        $query = $this->queryFactory->create(QueryInterface::TYPE_MISSING, ['field' => 'image']);
+
+        return $this->queryFactory->create(QueryInterface::TYPE_NOT, ['query' => $query]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getOperatorName()
+    {
+        return ' ';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getInputType()
+    {
+        return 'select';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getValueElementType()
+    {
+        return 'hidden';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getValueName()
+    {
+        return ' ';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getValue()
+    {
+        return 1;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getValueOptions()
+    {
+        return $this->booleanSource->toOptionArray();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLabel()
+    {
+        return __('Only products with image');
+    }
+}

--- a/src/module-elasticsuite-catalog-rule/Model/Rule/Condition/Product/SpecialAttribute/IsDiscount.php
+++ b/src/module-elasticsuite-catalog-rule/Model/Rule/Condition/Product/SpecialAttribute/IsDiscount.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\ElasticsuiteCatalogRule
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2017 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\ElasticsuiteCatalogRule\Model\Rule\Condition\Product\SpecialAttribute;
+
+use Smile\ElasticsuiteCatalogRule\Api\Rule\Condition\Product\SpecialAttributeInterface;
+
+/**
+ * Special "is_discount" attribute class.
+ *
+ * @category Smile
+ * @package  Smile\ElasticsuiteCatalogRule
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class IsDiscount implements SpecialAttributeInterface
+{
+    /**
+     * @var \Magento\Config\Model\Config\Source\Yesno
+     */
+    private $booleanSource;
+
+    /**
+     * IsDiscount constructor.
+     *
+     * @param \Magento\Config\Model\Config\Source\Yesno $booleanSource Boolean Source
+     */
+    public function __construct(\Magento\Config\Model\Config\Source\Yesno $booleanSource)
+    {
+        $this->booleanSource = $booleanSource;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAttributeCode()
+    {
+        return 'price.is_discount';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSearchQuery()
+    {
+        // Query can be computed directly with the attribute code and value. (price.is_discount = true).
+        return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getOperatorName()
+    {
+        return ' ';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getInputType()
+    {
+        return 'select';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getValueElementType()
+    {
+        return 'hidden';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getValueName()
+    {
+        return ' ';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getValue()
+    {
+        return 1;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getValueOptions()
+    {
+        return $this->booleanSource->toOptionArray();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLabel()
+    {
+        return __('Only discounted products');
+    }
+}

--- a/src/module-elasticsuite-catalog-rule/Model/Rule/Condition/Product/SpecialAttribute/IsInStock.php
+++ b/src/module-elasticsuite-catalog-rule/Model/Rule/Condition/Product/SpecialAttribute/IsInStock.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\ElasticsuiteCatalogRule
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2017 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\ElasticsuiteCatalogRule\Model\Rule\Condition\Product\SpecialAttribute;
+
+use Smile\ElasticsuiteCatalogRule\Api\Rule\Condition\Product\SpecialAttributeInterface;
+
+/**
+ * Special "is_in_stock" attribute class.
+ *
+ * @category Smile
+ * @package  Smile\ElasticsuiteCatalogRule
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class IsInStock implements SpecialAttributeInterface
+{
+    /**
+     * @var \Magento\Config\Model\Config\Source\Yesno
+     */
+    private $booleanSource;
+
+    /**
+     * IsInStock constructor.
+     *
+     * @param \Magento\Config\Model\Config\Source\Yesno $booleanSource Boolean Source
+     */
+    public function __construct(\Magento\Config\Model\Config\Source\Yesno $booleanSource)
+    {
+        $this->booleanSource = $booleanSource;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAttributeCode()
+    {
+        return 'stock.is_in_stock';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSearchQuery()
+    {
+        // Query can be computed directly with the attribute code and value. (stock.is_in_stock = true).
+        return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getOperatorName()
+    {
+        return ' ';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getInputType()
+    {
+        return 'select';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getValueElementType()
+    {
+        return 'hidden';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getValueName()
+    {
+        return ' ';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getValue()
+    {
+        return 1;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getValueOptions()
+    {
+        return $this->booleanSource->toOptionArray();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLabel()
+    {
+        return __('Only in stock products');
+    }
+}

--- a/src/module-elasticsuite-catalog-rule/Model/Rule/Condition/Product/SpecialAttributesProvider.php
+++ b/src/module-elasticsuite-catalog-rule/Model/Rule/Condition/Product/SpecialAttributesProvider.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\ElasticsuiteCatalogRule
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2017 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\ElasticsuiteCatalogRule\Model\Rule\Condition\Product;
+
+use Smile\ElasticsuiteCatalogRule\Api\Rule\Condition\Product\SpecialAttributeInterface;
+
+/**
+ * Special Attributes Provider.
+ *
+ * @category Smile
+ * @package  Smile\ElasticsuiteCatalogRule
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class SpecialAttributesProvider
+{
+    /**
+     * @var SpecialAttributeInterface[]
+     */
+    private $attributes = [];
+
+    /**
+     * SpecialAttributesProvider constructor.
+     *
+     * @param SpecialAttributeInterface[] $attributes Attributes
+     */
+    public function __construct($attributes = [])
+    {
+        $this->attributes = $attributes;
+    }
+
+    /**
+     * Retrieve Special Attributes list.
+     *
+     * @return SpecialAttributeInterface[]
+     */
+    public function getList()
+    {
+        return $this->attributes;
+    }
+
+    /**
+     * Retrieve a special attribute by code.
+     *
+     * @param string $attributeCode The attribute code to retrieve
+     *
+     * @return SpecialAttributeInterface
+     */
+    public function getAttribute($attributeCode)
+    {
+        return $this->attributes[$attributeCode];
+    }
+}

--- a/src/module-elasticsuite-catalog-rule/etc/di.xml
+++ b/src/module-elasticsuite-catalog-rule/etc/di.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Smile_ElasticsuiteCatalogRule dependency injection configuration.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\ElasticsuiteCatalogRule
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2017 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+ -->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+
+    <!-- Add the default Elasticsuite Special Attributes. -->
+    <type name="Smile\ElasticsuiteCatalogRule\Model\Rule\Condition\Product\SpecialAttributesProvider">
+        <arguments>
+            <argument name="attributes" xsi:type="array">
+                <item name="has_image" xsi:type="object">Smile\ElasticsuiteCatalogRule\Model\Rule\Condition\Product\SpecialAttribute\HasImage</item>
+                <item name="stock.is_in_stock" xsi:type="object">Smile\ElasticsuiteCatalogRule\Model\Rule\Condition\Product\SpecialAttribute\IsInStock</item>
+                <item name="price.is_discount" xsi:type="object">Smile\ElasticsuiteCatalogRule\Model\Rule\Condition\Product\SpecialAttribute\IsDiscount</item>
+            </argument>
+        </arguments>
+    </type>
+
+</config>

--- a/src/module-elasticsuite-virtual-category/Model/Rule/Condition/Product.php
+++ b/src/module-elasticsuite-virtual-category/Model/Rule/Condition/Product.php
@@ -1,10 +1,8 @@
 <?php
 /**
  * DISCLAIMER
- *
  * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
  * versions in the future.
- *
  *
  * @category  Smile
  * @package   Smile\ElasticsuiteVirtualCategory
@@ -14,11 +12,11 @@
  */
 namespace Smile\ElasticsuiteVirtualCategory\Model\Rule\Condition;
 
+use Smile\ElasticsuiteCatalogRule\Model\Rule\Condition\Product\SpecialAttributesProvider;
 use Smile\ElasticsuiteCore\Search\Request\QueryInterface;
 
 /**
  * Product search rule condition.
- *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  *
  * @category Smile
@@ -34,24 +32,24 @@ class Product extends \Smile\ElasticsuiteCatalogRule\Model\Rule\Condition\Produc
 
     /**
      * Constructor.
-     *
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      *
-     * @param \Magento\Rule\Model\Condition\Context                                     $context           Rule context.
-     * @param \Magento\Backend\Helper\Data                                              $backendData       Admin helper.
-     * @param \Magento\Eav\Model\Config                                                 $config            EAV config.
-     * @param \Smile\ElasticsuiteCatalogRule\Model\Rule\Condition\Product\AttributeList $attributeList     Product search rule
-     *                                                                                                     attribute list.
-     * @param \Smile\ElasticsuiteCatalogRule\Model\Rule\Condition\Product\QueryBuilder  $queryBuilder      Product search rule
-     *                                                                                                     query builder.
-     * @param \Magento\Catalog\Model\ProductFactory                                     $productFactory    Product factory.
-     * @param \Magento\Catalog\Api\ProductRepositoryInterface                           $productRepository Product repository.
-     * @param \Magento\Catalog\Model\ResourceModel\Product                              $productResource   Product resource model.
-     * @param \Magento\Eav\Model\ResourceModel\Entity\Attribute\Set\Collection          $attrSetCollection Attribute set collection.
-     * @param \Magento\Framework\Locale\FormatInterface                                 $localeFormat      Locale format.
-     * @param \Magento\Config\Model\Config\Source\Yesno                                 $booleanSource     Data source for boolean select.
-     * @param \Smile\ElasticsuiteCore\Search\Request\Query\QueryFactory                 $queryFactory      Search query factory.
-     * @param array                                                                     $data              Additional data.
+     * @param \Magento\Rule\Model\Condition\Context                                     $context                   Rule context.
+     * @param \Magento\Backend\Helper\Data                                              $backendData               Admin helper.
+     * @param \Magento\Eav\Model\Config                                                 $config                    EAV config.
+     * @param \Smile\ElasticsuiteCatalogRule\Model\Rule\Condition\Product\AttributeList $attributeList             Product search rule
+     *                                                                                                             attribute list.
+     * @param \Smile\ElasticsuiteCatalogRule\Model\Rule\Condition\Product\QueryBuilder  $queryBuilder              Product search rule
+     *                                                                                                             query builder.
+     * @param \Magento\Catalog\Model\ProductFactory                                     $productFactory            Product factory.
+     * @param \Magento\Catalog\Api\ProductRepositoryInterface                           $productRepository         Product repository.
+     * @param \Magento\Catalog\Model\ResourceModel\Product                              $productResource           Product resource model.
+     * @param \Magento\Eav\Model\ResourceModel\Entity\Attribute\Set\Collection          $attrSetCollection         Attribute set collection.
+     * @param \Magento\Framework\Locale\FormatInterface                                 $localeFormat              Locale format.
+     * @param SpecialAttributesProvider                                                 $specialAttributesProvider Special attributes
+     *                                                                                                             provider.
+     * @param \Smile\ElasticsuiteCore\Search\Request\Query\QueryFactory                 $queryFactory              Search query factory.
+     * @param array                                                                     $data                      Additional data.
      */
     public function __construct(
         \Magento\Rule\Model\Condition\Context $context,
@@ -64,7 +62,7 @@ class Product extends \Smile\ElasticsuiteCatalogRule\Model\Rule\Condition\Produc
         \Magento\Catalog\Model\ResourceModel\Product $productResource,
         \Magento\Eav\Model\ResourceModel\Entity\Attribute\Set\Collection $attrSetCollection,
         \Magento\Framework\Locale\FormatInterface $localeFormat,
-        \Magento\Config\Model\Config\Source\Yesno $booleanSource,
+        SpecialAttributesProvider $specialAttributesProvider,
         \Smile\ElasticsuiteCore\Search\Request\Query\QueryFactory $queryFactory,
         array $data = []
     ) {
@@ -79,7 +77,7 @@ class Product extends \Smile\ElasticsuiteCatalogRule\Model\Rule\Condition\Produc
             $productResource,
             $attrSetCollection,
             $localeFormat,
-            $booleanSource,
+            $specialAttributesProvider,
             $data
         );
         $this->queryFactory = $queryFactory;


### PR DESCRIPTION
Moving all hardcoded reference to "special attributes" (is_in_stock, price.is_discount, has_image) to a SpecialAttributeProvider extendable via the DI.

Here is also a proposal to implement a special attribute "is_new" injectable via DI : 

di.xml : 

```
    <type name="Smile\ElasticsuiteCatalogRule\Model\Rule\Condition\Product\SpecialAttributesProvider">
        <arguments>
            <argument name="attributes" xsi:type="array">
                <item name="is_product_new" xsi:type="object">Smile\ElasticsuiteCatalogRule\Model\Rule\Condition\Product\SpecialAttribute\IsNew</item>
            </argument>
        </arguments>
    </type>
```

"IsNew" class : 

```
<?php
/**
 * DISCLAIMER
 * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
 * versions in the future.
 *
 * @category  Smile
 * @package   Smile\ElasticsuiteCatalogRule
 * @author    Romain Ruaud <romain.ruaud@smile.fr>
 * @copyright 2017 Smile
 * @license   Open Software License ("OSL") v. 3.0
 */
namespace Smile\ElasticsuiteCatalogRule\Model\Rule\Condition\Product\SpecialAttribute;

use Smile\ElasticsuiteCatalogRule\Api\Rule\Condition\Product\SpecialAttributeInterface;
use Smile\ElasticsuiteCore\Search\Request\Query\QueryFactory;
use Smile\ElasticsuiteCore\Search\Request\QueryInterface;

/**
 * "Is New" special attribute class
 *
 * @category Smile
 * @package  Smile\ElasticsuiteCatalogRule
 * @author   Romain Ruaud <romain.ruaud@smile.fr>
 */
class IsNew implements SpecialAttributeInterface
{
    /**
     * @var \Smile\ElasticsuiteCore\Search\Request\Query\QueryFactory
     */
    private $queryFactory;

    /**
     * @var \Magento\Config\Model\Config\Source\Yesno
     */
    private $booleanSource;

    /**
     * Image constructor.
     *
     * @param \Smile\ElasticsuiteCore\Search\Request\Query\QueryFactory $queryFactory  Query Factory
     * @param \Magento\Config\Model\Config\Source\Yesno                 $booleanSource Boolean Source
     */
    public function __construct(QueryFactory $queryFactory, \Magento\Config\Model\Config\Source\Yesno $booleanSource)
    {
        $this->queryFactory  = $queryFactory;
        $this->booleanSource = $booleanSource;
    }

    /**
     * {@inheritdoc}
     */
    public function getAttributeCode()
    {
        return 'is_product_new';
    }

    /**
     * {@inheritdoc}
     */
    public function getSearchQuery()
    {
        $now = (new \DateTime())->format(\Magento\Framework\Stdlib\DateTime::DATETIME_PHP_FORMAT);

        $clauses = [];

        $newFromDateEarlier = $this->queryFactory->create(
            QueryInterface::TYPE_RANGE,
            ['field' => 'news_from_date', 'bounds' => ['lte' => $now]]
        );

        $newsToDateLater = $this->queryFactory->create(
            QueryInterface::TYPE_RANGE,
            ['field' => 'news_to_date', 'bounds' => ['gte' => $now]]
        );

        $missingNewsFromDate = $this->queryFactory->create(QueryInterface::TYPE_MISSING, ['field' => 'news_from_date']);
        $missingNewsToDate   = $this->queryFactory->create(QueryInterface::TYPE_MISSING, ['field' => 'news_to_date']);

        // Product is new if "news_from_date" is earlier than now and he has no "news_to_date".
        $clauses[] = $this->queryFactory->create(
            QueryInterface::TYPE_BOOL,
            ['must' => [$newFromDateEarlier, $missingNewsToDate]]
        );

        // Product is new if "news_to_date" is later than now and he has no "news_from_date".
        $clauses[] = $this->queryFactory->create(
            QueryInterface::TYPE_BOOL,
            ['must' => [$missingNewsFromDate, $newsToDateLater]]
        );

        // Product is new if now is between "news_from_date" and "news_to_date".
        $clauses[] = $this->queryFactory->create(
            QueryInterface::TYPE_BOOL,
            ['must' => [$newFromDateEarlier, $newsToDateLater]]
        );

        // Product is new if one of previously built queries match.
        return $this->queryFactory->create(QueryInterface::TYPE_BOOL, ['should' => $clauses]);
    }

    /**
     * {@inheritdoc}
     */
    public function getOperatorName()
    {
        return ' ';
    }

    /**
     * {@inheritdoc}
     */
    public function getInputType()
    {
        return 'select';
    }

    /**
     * {@inheritdoc}
     */
    public function getValueElementType()
    {
        return 'hidden';
    }

    /**
     * {@inheritdoc}
     */
    public function getValueName()
    {
        return ' ';
    }

    /**
     * {@inheritdoc}
     */
    public function getValue()
    {
        return 1;
    }

    /**
     * {@inheritdoc}
     */
    public function getValueOptions()
    {
        return $this->booleanSource->toOptionArray();
    }

    /**
     * {@inheritdoc}
     */
    public function getLabel()
    {
        return __('Only new products');
    }
}

```