### PR TITLE
Do not display navigation block on content mode categories.

### DIFF
--- a/src/module-elasticsuite-catalog/Block/Navigation.php
+++ b/src/module-elasticsuite-catalog/Block/Navigation.php
@@ -87,6 +87,11 @@ class Navigation extends \Magento\LayeredNavigation\Block\Navigation
             }
         }
 
+        if ($this->getLayer() instanceof \Magento\Catalog\Model\Layer\Category &&
+            $this->getLayer()->getCurrentCategory()->getDisplayMode() === \Magento\Catalog\Model\Category::DM_PAGE) {
+            return false;
+        }
+
         return parent::canShowBlock();
     }
 


### PR DESCRIPTION
Proposal of fix for #593 

```$this->getLayer()->getCurrentCategory()->getDisplayMode() === \Magento\Catalog\Model\Category::DM_PAGE``` is not enough because this can cause the filters to disappear on search if the root category is configured with Content Mode.

I did not found something better to test if we are on catalog than testing if current layer is an instance of ```\Magento\Catalog\Model\Layer\Category```. This could cause some bugs when people override this class without inheriting it... but should we manage such a mistake ?