### PR TITLE
Process parent product when reindexing with a list of product ids

### DIFF
--- a/src/module-elasticsuite-catalog/Model/Product/Indexer/Fulltext/Action/Full.php
+++ b/src/module-elasticsuite-catalog/Model/Product/Indexer/Fulltext/Action/Full.php
@@ -53,6 +53,11 @@ class Full
     {
         $productId = 0;
 
+        // Magento is only sending children ids here. Ensure to reindex also the parents product ids, if any.
+        if (!empty($productIds)) {
+            $productIds = array_unique(array_merge($productIds, $this->resourceModel->getRelationsByChild($productIds)));
+        }
+
         do {
             $products = $this->getSearchableProducts($storeId, $productIds, $productId);
 


### PR DESCRIPTION
This is a fix for #610 and has been tested OK on customer environment.

@afoucret I think once we are done merging this one, I'll publish minor 2.4.1