### PR TITLE
Refactoring product collection coverage.

### DIFF
--- a/src/module-elasticsuite-catalog/Block/Navigation.php
+++ b/src/module-elasticsuite-catalog/Block/Navigation.php
@@ -156,23 +156,8 @@ class Navigation extends \Magento\LayeredNavigation\Block\Navigation
      */
     private function addFacets()
     {
-        $productCollection    = $this->getLayer()->getProductCollection();
-        $countByAttributeCode = $productCollection->getProductCountByAttributeCode();
-        $totalCount           = $productCollection->getSize();
-
         foreach ($this->filterList->getFilters($this->_catalogLayer) as $filter) {
-            try {
-                $attribute           = $filter->getAttributeModel();
-                $facetCoverageRate   = $attribute->getFacetMinCoverageRate();
-                $attributeCount      = $countByAttributeCode[$attribute->getAttributeCode()] ?? 0;
-                $currentCoverageRate = (int) $attributeCount / $totalCount * 100;
-
-                if ($facetCoverageRate < $currentCoverageRate) {
-                    $filter->addFacetToCollection();
-                }
-            } catch (\Exception $e) {
-                $filter->addFacetToCollection();
-            }
+            $filter->addFacetToCollection();
         }
     }
 }

--- a/src/module-elasticsuite-catalog/Block/Navigation.php
+++ b/src/module-elasticsuite-catalog/Block/Navigation.php
@@ -156,16 +156,16 @@ class Navigation extends \Magento\LayeredNavigation\Block\Navigation
      */
     private function addFacets()
     {
-        $productCollection = $this->getLayer()->getProductCollection();
-        $countBySetId      = $productCollection->getProductCountByAttributeSetId();
-        $totalCount        = $productCollection->getSize();
+        $productCollection    = $this->getLayer()->getProductCollection();
+        $countByAttributeCode = $productCollection->getProductCountByAttributeCode();
+        $totalCount           = $productCollection->getSize();
 
         foreach ($this->filterList->getFilters($this->_catalogLayer) as $filter) {
             try {
-                $attribute                = $filter->getAttributeModel();
-                $facetCoverageRate        = $attribute->getFacetMinCoverageRate();
-                $attributeCountCandidates = array_sum(array_intersect_key($countBySetId, $attribute->getAttributeSetInfo()));
-                $currentCoverageRate      = $attributeCountCandidates / $totalCount * 100;
+                $attribute           = $filter->getAttributeModel();
+                $facetCoverageRate   = $attribute->getFacetMinCoverageRate();
+                $attributeCount      = $countByAttributeCode[$attribute->getAttributeCode()] ?? 0;
+                $currentCoverageRate = (int) $attributeCount / $totalCount * 100;
 
                 if ($facetCoverageRate < $currentCoverageRate) {
                     $filter->addFacetToCollection();

--- a/src/module-elasticsuite-catalog/Model/Product/Attribute/CoverageRateProvider.php
+++ b/src/module-elasticsuite-catalog/Model/Product/Attribute/CoverageRateProvider.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\ElasticsuiteCatalog
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2017 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\ElasticsuiteCatalog\Model\Product\Attribute;
+
+/**
+ * Coverage Rate provider for product collection.
+ *
+ * @category Smile
+ * @package  Smile\ElasticsuiteCatalog
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class CoverageRateProvider
+{
+    /**
+     * Retrieve Attributes coverage rate for a given product collection.
+     *
+     * @param \Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Fulltext\Collection $collection Product Collection
+     *
+     * @return array
+     */
+    public function getCoverageRates(\Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Fulltext\Collection $collection)
+    {
+        $totalCount    = $collection->getSize();
+        $coverageRates = [];
+
+        foreach ($collection->getProductCountByAttributeCode() as $attributeCode => $attributeCount) {
+            $coverageRates[$attributeCode] = (int) $attributeCount / $totalCount * 100;
+        }
+
+        return $coverageRates;
+    }
+}

--- a/src/module-elasticsuite-catalog/Model/Product/Indexer/Fulltext/Datasource/AttributeData.php
+++ b/src/module-elasticsuite-catalog/Model/Product/Indexer/Fulltext/Datasource/AttributeData.php
@@ -93,6 +93,11 @@ class AttributeData extends AbstractAttributeData implements DatasourceInterface
                 }
 
                 $indexData[$productId] += $indexValues;
+
+                if (!isset($indexData[$productId]['indexed_attributes'])) {
+                    $indexData[$productId]['indexed_attributes'] = [];
+                }
+                $indexData[$productId]['indexed_attributes'][] = $attribute->getAttributeCode();
             }
         }
 
@@ -142,7 +147,7 @@ class AttributeData extends AbstractAttributeData implements DatasourceInterface
         $parentAttributeCodes = array_keys($parentData);
 
         if (!isset($parentData['children_attributes'])) {
-            $parentData['children_attributes'] = [];
+            $parentData['children_attributes'] = ['indexed_attributes'];
         }
 
         $childrenAttributes = array_merge(

--- a/src/module-elasticsuite-catalog/Model/Product/Indexer/Fulltext/Datasource/PriceData.php
+++ b/src/module-elasticsuite-catalog/Model/Product/Indexer/Fulltext/Datasource/PriceData.php
@@ -14,6 +14,7 @@
 
 namespace Smile\ElasticsuiteCatalog\Model\Product\Indexer\Fulltext\Datasource;
 
+use Smile\ElasticsuiteCatalog\Model\CoverageRateProvider;
 use Smile\ElasticsuiteCore\Api\Index\DatasourceInterface;
 use Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Indexer\Fulltext\Datasource\PriceData as ResourceModel;
 use Magento\Catalog\Model\Product\TypeFactory as ProductTypeFactory;
@@ -80,6 +81,13 @@ class PriceData implements DatasourceInterface
                 'is_discount'       => $finalPrice < $originalPrice,
                 'customer_group_id' => $priceDataRow['customer_group_id'],
             ];
+
+            if (!isset($indexData[$productId]['indexed_attributes'])) {
+                $indexData[$productId]['indexed_attributes'] = ['price'];
+            } elseif (!in_array('price', $indexData[$productId]['indexed_attributes'])) {
+                // Add price only one time.
+                $indexData[$productId]['indexed_attributes'][] = 'price';
+            }
         }
 
         return $indexData;

--- a/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Fulltext/Collection.php
+++ b/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Fulltext/Collection.php
@@ -352,6 +352,8 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Product\Collection
     /**
      * Load the product count by attribute code.
      *
+     * @deprecated To be refactored later.
+     *
      * @return array
      */
     public function getProductCountByAttributeCode()

--- a/src/module-elasticsuite-catalog/etc/elasticsuite_indices.xml
+++ b/src/module-elasticsuite-catalog/etc/elasticsuite_indices.xml
@@ -44,6 +44,7 @@
                 <field name="visibility" type="integer" />
                 <field name="children_ids" type="integer" />
                 <field name="configurable_attributes" type="string" />
+                <field name="indexed_attributes" type="string" />
 
                 <!-- Static fields handled by the "prices" datasource -->
                 <field name="price.price" type="double" nestedPath="price" />


### PR DESCRIPTION
As we discussed together, I refactored the product collection coverage.

This time, no additional PHP classes, I simply put it at the same place of the "countByAttributeSetId".

I decided to let the count by attribute set id in place, and flag it as deprecated (since it was a public method). I just added a new bucket into the loadProductCount method, to be used when calculating coverage rate in the Navigation block.

This will also fix #645 btw