### PR TITLE
Moving the  filtering of filters according to their coverage in anoth…

### DIFF
--- a/src/module-elasticsuite-catalog/Block/Navigation.php
+++ b/src/module-elasticsuite-catalog/Block/Navigation.php
@@ -156,7 +156,7 @@ class Navigation extends \Magento\LayeredNavigation\Block\Navigation
      */
     private function addFacets()
     {
-        foreach ($this->filterList->getFilters($this->_catalogLayer) as $filter) {
+        foreach ($this->filterList->getRelevantFilters($this->_catalogLayer) as $filter) {
             $filter->addFacetToCollection();
         }
     }


### PR DESCRIPTION
…er method.

I decided to create a new method in the FilterList object.

This is not possible to proceed post filtering of filters according to the coverage inside getFilters(), since the getFilters() method is called also before applying the filters : coverage is inconsistent when calculated at this step.

I'm not a big fan of having another method doing the post-filtering, but I do not see any other option here. But with this approach, this new method has only one purpose and is clear to understand.

Let me know