### PR TITLE
Cleanup thesaurus store ids management.

### DIFF
--- a/src/module-elasticsuite-thesaurus/Block/Adminhtml/Thesaurus/Edit/Form.php
+++ b/src/module-elasticsuite-thesaurus/Block/Adminhtml/Thesaurus/Edit/Form.php
@@ -104,7 +104,7 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
             $fieldset->addField('type', 'hidden', ['name' => 'type']);
         }
 
-        $this->initBaseFields($fieldset, $model);
+        $this->initBaseFields($fieldset);
         $this->initTypeFields($fieldset, $model);
 
         $form->setValues($model->getData());
@@ -120,15 +120,13 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
      *  - thesaurus name
      *  - store id
      *
-     * @param \Magento\Framework\Data\Form\Element\Fieldset     $fieldset The fieldset
-     * @param \Smile\ElasticsuiteThesaurus\Model\Thesaurus|null $model    Current Thesaurus
+     * @param \Magento\Framework\Data\Form\Element\Fieldset $fieldset The fieldset
      *
      * @throws \Magento\Framework\Exception\LocalizedException
-     * @SuppressWarnings(PHPMD.ElseExpression)
      *
      * @return \Smile\ElasticsuiteThesaurus\Block\Adminhtml\Thesaurus\Edit\Form
      */
-    private function initBaseFields($fieldset, $model)
+    private function initBaseFields($fieldset)
     {
         $fieldset->addField(
             'name',
@@ -169,9 +167,6 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
             );
 
             $field->setRenderer($renderer);
-        } else {
-            $fieldset->addField('store_id', 'hidden', ['name' => 'store_id']);
-            $model->setStoreIds([$this->_storeManager->getStore(true)->getId()]);
         }
 
         return $this;

--- a/src/module-elasticsuite-thesaurus/Controller/Adminhtml/Thesaurus/Save.php
+++ b/src/module-elasticsuite-thesaurus/Controller/Adminhtml/Thesaurus/Save.php
@@ -39,7 +39,7 @@ class Save extends ThesaurusController
 
         if ($data) {
             $identifier = $this->getRequest()->getParam('thesaurus_id');
-            $model = $this->thesaurusFactory->create();
+            $model      = $this->thesaurusFactory->create();
 
             if ($identifier) {
                 $model->load($identifier);
@@ -51,6 +51,10 @@ class Save extends ThesaurusController
             }
 
             $model->setData($data);
+            $storeIds = $this->getRequest()->getParam('stores', null);
+            if ($storeIds) {
+                $model->setStoreIds($storeIds);
+            }
 
             try {
                 $this->thesaurusRepository->save($model);

--- a/src/module-elasticsuite-thesaurus/Model/ResourceModel/Thesaurus.php
+++ b/src/module-elasticsuite-thesaurus/Model/ResourceModel/Thesaurus.php
@@ -123,8 +123,7 @@ class Thesaurus extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
     {
         if ($object->getId()) {
             $stores = $this->getStoreIdsFromThesaurusId($object->getId());
-            $object->setData('store_id', $stores);
-            $object->setData('stores', $stores);
+            $object->setStoreIds($stores);
         }
 
         return parent::_afterLoad($object);
@@ -149,15 +148,14 @@ class Thesaurus extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
             $storeLinks = [];
             $deleteCondition = [ThesaurusInterface::THESAURUS_ID . " = ?" => $object->getThesaurusId()];
 
-            foreach ($storeIds as $key => $storeId) {
+            foreach ($storeIds as $storeId) {
                 $storeLinks[] = [
                     ThesaurusInterface::THESAURUS_ID  => (int) $object->getThesaurusId(),
                     ThesaurusInterface::STORE_ID      => (int) $storeId,
                 ];
-                $storeIds[$key] = (int) $storeId;
             }
 
-            $deleteCondition[ThesaurusInterface::STORE_ID . " NOT IN (?)"] = array_keys($storeIds);
+            $deleteCondition[ThesaurusInterface::STORE_ID . " NOT IN (?)"] = $storeIds;
 
             $this->getConnection()->delete($this->getTable(ThesaurusInterface::STORE_TABLE_NAME), $deleteCondition);
             $this->getConnection()->insertOnDuplicate(

--- a/src/module-elasticsuite-thesaurus/Model/Thesaurus.php
+++ b/src/module-elasticsuite-thesaurus/Model/Thesaurus.php
@@ -12,6 +12,7 @@
  */
 namespace Smile\ElasticsuiteThesaurus\Model;
 
+use Magento\Store\Model\StoreManagerInterface;
 use Smile\ElasticsuiteThesaurus\Api\Data\ThesaurusInterface;
 use Smile\ElasticsuiteThesaurus\Model\Indexer\Thesaurus as ThesaurusIndexer;
 use Magento\Framework\Indexer\IndexerRegistry;
@@ -43,6 +44,11 @@ class Thesaurus extends \Magento\Framework\Model\AbstractModel implements Thesau
     protected $_eventObject = 'thesaurus';
 
     /**
+     * @var IndexerRegistry
+     */
+    protected $indexerRegistry;
+
+    /**
      * @var array The store ids of this thesaurus
      */
     private $storeIds = [];
@@ -53,9 +59,9 @@ class Thesaurus extends \Magento\Framework\Model\AbstractModel implements Thesau
     private $termsData;
 
     /**
-     * @var IndexerRegistry
+     * @var StoreManagerInterface
      */
-    protected $indexerRegistry;
+    private $storeManager;
 
     /**
      * PHP constructor
@@ -63,6 +69,7 @@ class Thesaurus extends \Magento\Framework\Model\AbstractModel implements Thesau
      * @param \Magento\Framework\Model\Context                        $context            Magento Context
      * @param \Magento\Framework\Registry                             $registry           Magento Registry
      * @param IndexerRegistry                                         $indexerRegistry    Indexers registry.
+     * @param \Magento\Store\Model\StoreManagerInterface              $storeManager       Store Manager.
      * @param \Magento\Framework\Model\ResourceModel\AbstractResource $resource           Magento Resource
      * @param \Magento\Framework\Data\Collection\AbstractDb           $resourceCollection Magento Collection
      * @param array                                                   $data               Magento Data
@@ -71,11 +78,13 @@ class Thesaurus extends \Magento\Framework\Model\AbstractModel implements Thesau
         \Magento\Framework\Model\Context $context,
         \Magento\Framework\Registry $registry,
         IndexerRegistry $indexerRegistry,
+        StoreManagerInterface $storeManager,
         \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
         \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
         array $data = []
     ) {
         $this->indexerRegistry = $indexerRegistry;
+        $this->storeManager    = $storeManager;
 
         parent::__construct($context, $registry, $resource, $resourceCollection, $data);
     }
@@ -181,8 +190,8 @@ class Thesaurus extends \Magento\Framework\Model\AbstractModel implements Thesau
      */
     public function getStoreIds()
     {
-        if ($this->getStores()) {
-            $this->setStoreIds($this->getStores());
+        if ($this->storeManager->isSingleStoreMode()) {
+            $this->storeIds = [$this->storeManager->getStore(true)->getId()];
         }
 
         if (empty($this->storeIds)) {
@@ -201,6 +210,7 @@ class Thesaurus extends \Magento\Framework\Model\AbstractModel implements Thesau
      */
     public function setStoreIds($storeIds)
     {
+        $this->setData('store_id', $storeIds);
         $this->storeIds = $storeIds;
 
         return $this;


### PR DESCRIPTION
To be merged in 2.4.x and cascaded to master.

Fix #674 

Note : We should consider a big refactoring of the way thesaurus are saved for next version, and move it to the EntityManager instead of deprecated save/load methods.