### PR TITLE
Fix integer indexing for very long values.

### DIFF
--- a/src/module-elasticsuite-catalog/Helper/AbstractAttribute.php
+++ b/src/module-elasticsuite-catalog/Helper/AbstractAttribute.php
@@ -115,8 +115,10 @@ abstract class AbstractAttribute extends Mapping
 
         if ($attribute->getSourceModel() == 'Magento\Eav\Model\Entity\Attribute\Source\Boolean') {
             $type = FieldInterface::FIELD_TYPE_BOOLEAN;
-        } elseif ($attribute->getBackendType() == 'int' || $attribute->getFrontendClass() == 'validate-digits') {
+        } elseif ($attribute->getBackendType() == 'int') {
             $type = FieldInterface::FIELD_TYPE_INTEGER;
+        } elseif ($attribute->getFrontendClass() == 'validate-digits') {
+            $type = FieldInterface::FIELD_TYPE_LONG;
         } elseif ($attribute->getBackendType() == 'decimal' || $attribute->getFrontendClass() == 'validate-number') {
             $type = FieldInterface::FIELD_TYPE_DOUBLE;
         } elseif ($attribute->getBackendType() == 'datetime') {

--- a/src/module-elasticsuite-catalog/Test/Unit/Helper/AbstractAttributeTest.php
+++ b/src/module-elasticsuite-catalog/Test/Unit/Helper/AbstractAttributeTest.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\ElasticsuiteCatalog
+ * @author    Aurelien FOUCRET <aurelien.foucret@smile.fr>
+ * @copyright 2016 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+
+namespace Smile\ElasticsuiteCatalog\Test\Unit\Helper;
+
+use Smile\ElasticsuiteCore\Api\Index\Mapping\FieldInterface;
+use Smile\ElasticsuiteCatalog\Helper\AbstractAttribute;
+
+/**
+ * Attribute helper unit test.
+ *
+ * @category Smile_Elasticsuite
+ * @package  Smile\ElasticsuiteCatalog
+ * @author   Aurelien FOUCRET <aurelien.foucret@smile.fr>
+ */
+class AbstractAttributeTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * Test automatic attribute ES field type detection.
+     *
+     * @dataProvider attributeTypeProvider
+     *
+     * @param string $backendType   Attribute backend type.
+     * @param bool   $usesSource    Does attribute uses source.
+     * @param string $sourceModel   Attribute source model
+     * @param string $frontendClass Attribute frontend class.
+     * @param string $expectedType  Expected ES field type.
+     *
+     * @return void
+     */
+    public function testFieldTypes($backendType, $usesSource, $sourceModel, $frontendClass, $expectedType)
+    {
+        $attributeMock = $this->createMock(\Magento\Catalog\Model\Entity\Attribute::class);
+        $attributeMock->expects($this->any())->method('getBackendType')->will($this->returnValue($backendType));
+        $attributeMock->method('usesSource')->will($this->returnValue($usesSource));
+        $attributeMock->method('getSourceModel')->will($this->returnValue($sourceModel));
+        $attributeMock->method('getFrontendClass')->will($this->returnValue($frontendClass));
+
+        $helperMock = $this->getMockForAbstractClass(AbstractAttribute::class, [], '', false);
+        $this->assertEquals($expectedType, $helperMock->getFieldType($attributeMock));
+    }
+
+    /**
+     * List of tested combination for the getFieldType method.
+     *
+     * @return array
+     */
+    public function attributeTypeProvider()
+    {
+        return [
+            ['int', true, 'Magento\Eav\Model\Entity\Attribute\Source\Boolean', null, FieldInterface::FIELD_TYPE_BOOLEAN],
+            ['int', false, null, null, FieldInterface::FIELD_TYPE_INTEGER],
+            ['varchar', false, null, 'validate-digits', FieldInterface::FIELD_TYPE_LONG],
+            ['decimal', false, null, null, FieldInterface::FIELD_TYPE_DOUBLE],
+            ['varchar', false, null, 'validate-number', FieldInterface::FIELD_TYPE_DOUBLE],
+            ['datetime', false, null, null, FieldInterface::FIELD_TYPE_DATE],
+            ['varchar', true, null, null, FieldInterface::FIELD_TYPE_INTEGER],
+            ['varchar', false, null, null, FieldInterface::FIELD_TYPE_STRING],
+        ];
+    }
+}

--- a/src/module-elasticsuite-core/Api/Index/Mapping/FieldInterface.php
+++ b/src/module-elasticsuite-core/Api/Index/Mapping/FieldInterface.php
@@ -31,6 +31,7 @@ interface FieldInterface
     const FIELD_TYPE_STRING  = 'string';
     const FIELD_TYPE_DOUBLE  = 'double';
     const FIELD_TYPE_INTEGER = 'integer';
+    const FIELD_TYPE_LONG    = 'long';
     const FIELD_TYPE_DATE    = 'date';
     const FIELD_TYPE_BOOLEAN = 'boolean';
     const FIELD_TYPE_NESTED  = 'nested';

--- a/src/module-elasticsuite-core/Test/Unit/Index/Mapping/FieldTest.php
+++ b/src/module-elasticsuite-core/Test/Unit/Index/Mapping/FieldTest.php
@@ -90,8 +90,11 @@ class FieldTest extends \PHPUnit\Framework\TestCase
     public function testBasicTypes()
     {
         $types = [
-            FieldInterface::FIELD_TYPE_INTEGER, FieldInterface::FIELD_TYPE_DOUBLE,
-            FieldInterface::FIELD_TYPE_BOOLEAN, FieldInterface::FIELD_TYPE_DATE,
+            FieldInterface::FIELD_TYPE_INTEGER,
+            FieldInterface::FIELD_TYPE_LONG,
+            FieldInterface::FIELD_TYPE_DOUBLE,
+            FieldInterface::FIELD_TYPE_BOOLEAN,
+            FieldInterface::FIELD_TYPE_DATE,
         ];
 
         foreach ($types as $type) {


### PR DESCRIPTION
Improvement related to #673
Now using long instead of integer for attribute created from the admin.