### PR TITLE
Fix autocomplete special price

### DIFF
--- a/src/module-elasticsuite-catalog/Model/Autocomplete/Product/AttributeConfig.php
+++ b/src/module-elasticsuite-catalog/Model/Autocomplete/Product/AttributeConfig.php
@@ -32,7 +32,7 @@ class AttributeConfig
     /**
      * @var string[]
      */
-    private $defaultSelectedAttributes = ['name', 'thumbnail'];
+    private $defaultSelectedAttributes = ['name', 'thumbnail', 'special_price'];
 
     /**
      * @var string[]

--- a/src/module-elasticsuite-catalog/Model/Autocomplete/Product/AttributeConfig.php
+++ b/src/module-elasticsuite-catalog/Model/Autocomplete/Product/AttributeConfig.php
@@ -32,7 +32,7 @@ class AttributeConfig
     /**
      * @var string[]
      */
-    private $defaultSelectedAttributes = ['name', 'thumbnail', 'special_price'];
+    private $defaultSelectedAttributes = ['name', 'thumbnail', 'special_price', 'special_from_date', 'special_to_date'];
 
     /**
      * @var string[]

--- a/src/module-elasticsuite-catalog/Model/Autocomplete/Product/ItemFactory.php
+++ b/src/module-elasticsuite-catalog/Model/Autocomplete/Product/ItemFactory.php
@@ -41,7 +41,7 @@ class ItemFactory extends \Magento\Search\Model\Autocomplete\ItemFactory
     /**
      * @var \Magento\Framework\Pricing\Render
      */
-    private $priceRenderer;
+    private $priceRenderer = null;
 
     /**
      * @var ObjectManagerInterface
@@ -58,19 +58,16 @@ class ItemFactory extends \Magento\Search\Model\Autocomplete\ItemFactory
      *
      * @param ObjectManagerInterface $objectManager   Object manager used to instantiate new item.
      * @param ImageHelper            $imageHelper     Catalog product image helper.
-     * @param Render                 $priceRenderer   Catalog product price renderer.
      * @param AttributeConfig        $attributeConfig Autocomplete attribute config.
      */
     public function __construct(
         ObjectManagerInterface $objectManager,
         ImageHelper $imageHelper,
-        Render $priceRenderer,
         AttributeConfig $attributeConfig
     ) {
         parent::__construct($objectManager);
         $this->attributes    = $attributeConfig->getAdditionalSelectedAttributes();
         $this->imageHelper   = $imageHelper;
-        $this->priceRenderer = $priceRenderer;
         $this->objectManager = $objectManager;
     }
 
@@ -169,19 +166,23 @@ class ItemFactory extends \Magento\Search\Model\Autocomplete\ItemFactory
      */
     private function getPriceRenderer()
     {
-        /** @var \Magento\Framework\View\LayoutInterface $layout */
-        $layout = $this->objectManager->get('\Magento\Framework\View\LayoutInterface');
-        $layout->getUpdate()->addHandle('default');
-        $priceRenderer = $layout->getBlock('product.price.render.default');
+        if (null === $this->priceRenderer) {
+            /** @var \Magento\Framework\View\LayoutInterface $layout */
+            $layout = $this->objectManager->get('\Magento\Framework\View\LayoutInterface');
+            $layout->getUpdate()->addHandle('default');
+            $priceRenderer = $layout->getBlock('product.price.render.default');
 
-        if (!$priceRenderer) {
-            $priceRenderer = $layout->createBlock(
-                'Magento\Framework\Pricing\Render',
-                'product.price.render.default',
-                ['data' => ['price_render_handle' => 'catalog_product_prices']]
-            );
+            if (!$priceRenderer) {
+                $priceRenderer = $layout->createBlock(
+                    'Magento\Framework\Pricing\Render',
+                    'product.price.render.default',
+                    ['data' => ['price_render_handle' => 'catalog_product_prices']]
+                );
+            }
+
+            $this->priceRenderer = $priceRenderer;
         }
 
-        return $priceRenderer;
+        return $this->priceRenderer;
     }
 }


### PR DESCRIPTION
This one fix #682 

Main problem is due to the fact that "special_price" is not selected in autocomplete. I thought `addPriceData()` would do this, but it's not the case.

The only reason the same bug is not appearing on catalog listing is that special_price is set to `used_in_product_listing=1` and get automatically loaded by the layer.

I did not want to load all attributes `used_in_product_listing=1` in the autocomplete (for performances concern, however, this would have fixed the issue easily), so I added only 'special_price' to the list of default selected attributes.

I intentionally omitted to add "special_from_date" and "special_to_date".

This is due to the fact that they are used only with Magento CE and this could cause errors when these attributes are missing (if they were deleted, or when using Magento EE).

To allow proper handling of the special price when using these attributes, one will have to add them manually via DI like this : 

```
    <type name="Smile\ElasticsuiteCatalog\Model\Autocomplete\Product\AttributeConfig">
        <arguments>
            <argument name="additionalSelectedAttributes" xsi:type="array">
                <item name="special_from_date" xsi:type="string">special_from_date</item>
                <item name="special_to_date" xsi:type="string">special_to_date</item>
            </argument>
        </arguments>
    </type>
```

Let me know if this solution is acceptable for you, or if we should do it another way ?