### PR TITLE
Ensure proper retrieval of parent entity_id 

### DIFF
--- a/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Indexer/Fulltext/Action/Full.php
+++ b/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Indexer/Fulltext/Action/Full.php
@@ -62,9 +62,15 @@ class Full extends Indexer
      */
     public function getRelationsByChild($childrenIds)
     {
+        $metadata      = $this->getEntityMetaData(\Magento\Catalog\Api\Data\ProductInterface::class);
+        $entityTable   = $this->getTable($metadata->getEntityTable());
+        $relationTable = $this->getTable('catalog_product_relation');
+        $joinCondition = sprintf('relation.parent_id = entity.%s', $metadata->getLinkField());
+
         $select = $this->getConnection()->select()
-            ->from($this->resource->getTableName('catalog_product_relation'), 'parent_id')
-            ->where('child_id IN(?)', $childrenIds);
+            ->from(['relation' => $relationTable], [])
+            ->join(['entity' => $entityTable], $joinCondition, [$metadata->getIdentifierField()])
+            ->where('child_id IN(?)', array_map('intval', $childrenIds));
 
         return $this->getConnection()->fetchCol($select);
     }


### PR DESCRIPTION
There may be inconsistency issues when retrieving relations by child when using Magento Commerce (EE).

This is due to the fact that on Magento EE, `catalog_product_relation` is built like this : 

```
CREATE TABLE `catalog_product_relation` (
  `parent_id` int(10) unsigned NOT NULL COMMENT 'Parent ID',
  `child_id` int(10) unsigned NOT NULL COMMENT 'Child ID',
  PRIMARY KEY (`parent_id`,`child_id`),
  KEY `CATALOG_PRODUCT_RELATION_CHILD_ID` (`child_id`),
  CONSTRAINT `CAT_PRD_RELATION_CHILD_ID_SEQUENCE_PRD_SEQUENCE_VAL` FOREIGN KEY (`child_id`) REFERENCES `sequence_product` (`sequence_value`) ON DELETE CASCADE,
  CONSTRAINT `CAT_PRD_RELATION_PARENT_ID_CAT_PRD_ENTT_ENTT_ID` FOREIGN KEY (`parent_id`) REFERENCES `catalog_product_entity` (`row_id`) ON DELETE CASCADE
) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Catalog Product Relation Table' 
```

Notice the **reference between parent_id and row_id**.

This would lead to inconsistency when retrieving parent_id.

Regards