### PR TITLE
Add ES server configuration options to Magento setup:install command

### DIFF
--- a/src/module-elasticsuite-core/Helper/ClientConfiguration.php
+++ b/src/module-elasticsuite-core/Helper/ClientConfiguration.php
@@ -14,6 +14,7 @@
 
 namespace Smile\ElasticsuiteCore\Helper;
 
+use Magento\Framework\App\Helper\AbstractHelper;
 use Smile\ElasticsuiteCore\Api\Client\ClientConfigurationInterface;
 
 /**
@@ -23,21 +24,71 @@ use Smile\ElasticsuiteCore\Api\Client\ClientConfigurationInterface;
  * @package  Smile\ElasticsuiteCore
  * @author   Aurelien FOUCRET <aurelien.foucret@smile.fr>
  */
-class ClientConfiguration extends AbstractConfiguration implements ClientConfigurationInterface
+class ClientConfiguration extends AbstractHelper implements ClientConfigurationInterface
 {
     /**
      * Location of Elasticsearch client configuration.
      *
+     * @deprecated
      * @var string
      */
     const ES_CLIENT_CONFIG_XML_PREFIX = 'es_client';
+
+    /**
+     * Configuration path for client servers list.
+     *
+     * @var string
+     */
+    const CONFIG_PATH_CLIENT_SERVERS = 'smile_elasticsuite_core_base_settings/es_client/servers';
+
+    /**
+     * Configuration path for debug mode enabled.
+     *
+     * @var string
+     */
+    const CONFIG_PATH_DEBUG_MODE_ENABLED = 'smile_elasticsuite_core_base_settings/es_client/enable_debug_mode';
+
+    /**
+     * Configuration path for connection timeout.
+     *
+     * @var string
+     */
+    const CONFIG_PATH_CONNECTION_TIMEOUT = 'smile_elasticsuite_core_base_settings/es_client/connection_timeout';
+
+    /**
+     * Configuration path for HTTPS mode.
+     *
+     * @var string
+     */
+    const CONFIG_PATH_ENABLE_HTTPS_MODE = 'smile_elasticsuite_core_base_settings/es_client/enable_https_mode';
+
+    /**
+     * Configuration path for enable HTTP auth.
+     *
+     * @var string
+     */
+    const CONFIG_PATH_ENABLE_HTTP_AUTH = 'smile_elasticsuite_core_base_settings/es_client/enable_http_auth';
+
+    /**
+     * Configuration path for HTTP auth user.
+     *
+     * @var string
+     */
+    const CONFIG_PATH_HTTP_AUTH_USER = 'smile_elasticsuite_core_base_settings/es_client/http_auth_user';
+
+    /**
+     * Configuration path for HTTP auth user.
+     *
+     * @var string
+     */
+    const CONFIG_PATH_HTTP_AUTH_PWD = 'smile_elasticsuite_core_base_settings/es_client/http_auth_pwd';
 
     /**
      * {@inheritdoc}
      */
     public function getServerList()
     {
-        return explode(',', $this->getElasticsearchClientConfigParam('servers'));
+        return explode(',', $this->scopeConfig->getValue(self::CONFIG_PATH_CLIENT_SERVERS));
     }
 
     /**
@@ -45,7 +96,7 @@ class ClientConfiguration extends AbstractConfiguration implements ClientConfigu
      */
     public function isDebugModeEnabled()
     {
-        return (bool) $this->getElasticsearchClientConfigParam('enable_debug_mode');
+        return (bool) $this->scopeConfig->getValue(self::CONFIG_PATH_DEBUG_MODE_ENABLED);
     }
 
     /**
@@ -53,7 +104,7 @@ class ClientConfiguration extends AbstractConfiguration implements ClientConfigu
      */
     public function getConnectionTimeout()
     {
-        return (int) $this->getElasticsearchClientConfigParam('connection_timeout');
+        return (int) $this->scopeConfig->getValue(self::CONFIG_PATH_CONNECTION_TIMEOUT);
     }
 
     /**
@@ -61,7 +112,7 @@ class ClientConfiguration extends AbstractConfiguration implements ClientConfigu
      */
     public function getScheme()
     {
-        return (bool) $this->getElasticsearchClientConfigParam('enable_https_mode') ? 'https' : 'http';
+        return (bool) $this->scopeConfig->getValue(self::CONFIG_PATH_ENABLE_HTTPS_MODE) ? 'https' : 'http';
     }
 
     /**
@@ -69,7 +120,7 @@ class ClientConfiguration extends AbstractConfiguration implements ClientConfigu
      */
     public function isHttpAuthEnabled()
     {
-        $authEnabled = (bool) $this->getElasticsearchClientConfigParam('enable_http_auth');
+        $authEnabled = (bool) $this->scopeConfig->getValue(self::CONFIG_PATH_ENABLE_HTTP_AUTH);
 
         return $authEnabled && !empty($this->getHttpAuthUser()) && !empty($this->getHttpAuthPassword());
     }
@@ -79,7 +130,7 @@ class ClientConfiguration extends AbstractConfiguration implements ClientConfigu
      */
     public function getHttpAuthUser()
     {
-        return (string) $this->getElasticsearchClientConfigParam('http_auth_user');
+        return (string) $this->scopeConfig->getValue(self::CONFIG_PATH_HTTP_AUTH_USER);
     }
 
     /**
@@ -87,20 +138,6 @@ class ClientConfiguration extends AbstractConfiguration implements ClientConfigu
      */
     public function getHttpAuthPassword()
     {
-        return (string) $this->getElasticsearchClientConfigParam('http_auth_pwd');
-    }
-
-    /**
-     * Read config under the path smile_elasticsuite_core_base_settings/es_client.
-     *
-     * @param string $configField Field name.
-     *
-     * @return mixed
-     */
-    private function getElasticsearchClientConfigParam($configField)
-    {
-        $path = self::ES_CLIENT_CONFIG_XML_PREFIX . '/' . $configField;
-
-        return $this->getElasticSuiteConfigParam($path);
+        return (string) $this->scopeConfig->getValue(self::CONFIG_PATH_HTTP_AUTH_PWD);
     }
 }

--- a/src/module-elasticsuite-core/Setup/ClientConfiguration.php
+++ b/src/module-elasticsuite-core/Setup/ClientConfiguration.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\ElasticsuiteCore
+ * @author    Carey Sizer <carey@balanceinternet.com.au>
+ * @copyright 2018 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\ElasticsuiteCore\Setup;
+
+use Smile\ElasticsuiteCore\Api\Client\ClientConfigurationInterface;
+
+/**
+ * Client configuration implementation for use during Magento setup.
+ *
+ * @category Smile
+ * @package  Smile\ElasticsuiteCore
+ * @author   Carey Sizer <carey@balanceinternet.com.au>
+ */
+class ClientConfiguration implements ClientConfigurationInterface
+{
+    /**
+     * @var array
+     */
+    private $serverList;
+
+    /**
+     * @var boolean
+     */
+    private $isDebugModeEnabled;
+
+    /**
+     * @var integer
+     */
+    private $connectionTimeout;
+
+    /**
+     * @var string
+     */
+    private $scheme;
+
+    /**
+     * @var boolean
+     */
+    private $isHttpAuthEnabled;
+
+    /**
+     * @var string
+     */
+    private $httpAuthUser;
+
+    /**
+     * @var string
+     */
+    private $httpAuthPassword;
+
+    /**
+     * @inheritDoc
+     */
+    public function __construct(
+        $serverList = [],
+        $isDebugModeEnabled = false,
+        $connectionTimeout = 0,
+        $scheme = 'http',
+        $isHttpAuthEnabled = false,
+        $httpAuthUser = null,
+        $httpAuthPassword = null
+    ) {
+        $this->serverList = $serverList;
+        $this->isDebugModeEnabled = $isDebugModeEnabled;
+        $this->connectionTimeout = $connectionTimeout;
+        $this->scheme = $scheme;
+        $this->isHttpAuthEnabled = $isHttpAuthEnabled;
+        $this->httpAuthUser = $httpAuthUser;
+        $this->httpAuthPassword = $httpAuthPassword;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getServerList()
+    {
+        return (array) $this->serverList;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function isDebugModeEnabled()
+    {
+        return (bool) $this->isDebugModeEnabled;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getConnectionTimeout()
+    {
+        return (int) $this->connectionTimeout;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getScheme()
+    {
+        return $this->scheme;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function isHttpAuthEnabled()
+    {
+        return (bool) $this->isHttpAuthEnabled;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getHttpAuthUser()
+    {
+        return $this->httpAuthUser;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getHttpAuthPassword()
+    {
+        return $this->httpAuthPassword;
+    }
+}

--- a/src/module-elasticsuite-core/Setup/ClientConfiguration.php
+++ b/src/module-elasticsuite-core/Setup/ClientConfiguration.php
@@ -31,22 +31,17 @@ class ClientConfiguration implements ClientConfigurationInterface
     /**
      * @var boolean
      */
-    private $isDebugModeEnabled;
+    private $isDebugModeEnabled = false;
 
     /**
      * @var integer
      */
-    private $connectionTimeout;
+    private $connectionTimeout = 0;
 
     /**
      * @var string
      */
-    private $scheme;
-
-    /**
-     * @var boolean
-     */
-    private $isHttpAuthEnabled;
+    private $scheme = null;
 
     /**
      * @var string
@@ -59,28 +54,24 @@ class ClientConfiguration implements ClientConfigurationInterface
     private $httpAuthPassword;
 
     /**
-     * @inheritDoc
+     * ClientConfiguration constructor.
+     *
+     * @param array $serverList       Server list configuration.
+     * @param null  $httpAuthUser     HTTP auth user supplied (optional).
+     * @param null  $httpAuthPassword HTTP auth password supplied (optional).
      */
     public function __construct(
         $serverList = [],
-        $isDebugModeEnabled = false,
-        $connectionTimeout = 0,
-        $scheme = 'http',
-        $isHttpAuthEnabled = false,
         $httpAuthUser = null,
         $httpAuthPassword = null
     ) {
         $this->serverList = $serverList;
-        $this->isDebugModeEnabled = $isDebugModeEnabled;
-        $this->connectionTimeout = $connectionTimeout;
-        $this->scheme = $scheme;
-        $this->isHttpAuthEnabled = $isHttpAuthEnabled;
         $this->httpAuthUser = $httpAuthUser;
         $this->httpAuthPassword = $httpAuthPassword;
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function getServerList()
     {
@@ -88,7 +79,7 @@ class ClientConfiguration implements ClientConfigurationInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function isDebugModeEnabled()
     {
@@ -96,7 +87,7 @@ class ClientConfiguration implements ClientConfigurationInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function getConnectionTimeout()
     {
@@ -104,7 +95,7 @@ class ClientConfiguration implements ClientConfigurationInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function getScheme()
     {
@@ -112,15 +103,22 @@ class ClientConfiguration implements ClientConfigurationInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function isHttpAuthEnabled()
     {
-        return (bool) $this->isHttpAuthEnabled;
+        $authValues = [$this->getHttpAuthUser(), $this->getHttpAuthPassword()];
+        foreach ($authValues as $authValue) {
+            if ($authValue !== null && mb_strlen((string) $authValue) > 0) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function getHttpAuthUser()
     {
@@ -128,7 +126,7 @@ class ClientConfiguration implements ClientConfigurationInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function getHttpAuthPassword()
     {

--- a/src/module-elasticsuite-core/Setup/ConfigOptionsList.php
+++ b/src/module-elasticsuite-core/Setup/ConfigOptionsList.php
@@ -64,8 +64,8 @@ class ConfigOptionsList implements ConfigOptionsListInterface
     /**
      * ConfigOptionsList constructor.
      *
-     * @param ClientFactoryFactory $clientFactoryFactory
-     * @param ClientConfigurationFactory $clientConfigurationFactory
+     * @param ClientFactoryFactory       $clientFactoryFactory       Factory to generate the ClientFactory.
+     * @param ClientConfigurationFactory $clientConfigurationFactory Factory to generate the ClientConfiguration.
      */
     public function __construct(
         ClientFactoryFactory $clientFactoryFactory,
@@ -112,7 +112,7 @@ class ConfigOptionsList implements ConfigOptionsListInterface
         $configData = new ConfigData(ConfigFilePool::APP_ENV);
         $configPrefix = 'system/default/';
 
-        // Apply the provided server configuration if it is set and not an empty string
+        // Apply the provided server configuration if it is set and not an empty string.
         if (!$this->isDataEmpty($data, self::INPUT_KEY_ES_SERVER)) {
             $configData->set(
                 $configPrefix . ClientConfiguration::CONFIG_PATH_CLIENT_SERVERS,
@@ -120,7 +120,7 @@ class ConfigOptionsList implements ConfigOptionsListInterface
             );
         }
 
-        // If the user has supplied a username or password, assume they are using auth
+        // If the user has supplied a username or password, assume they are using auth.
         if (!$this->isDataEmpty($data, self::INPUT_KEY_ES_SERVER_HTTP_AUTH_USER) ||
             !$this->isDataEmpty($data, self::INPUT_KEY_ES_SERVER_HTTP_AUTH_PWD)) {
             $httpAuthConfig = [
@@ -129,7 +129,7 @@ class ConfigOptionsList implements ConfigOptionsListInterface
                 ClientConfiguration::CONFIG_PATH_HTTP_AUTH_PWD => $data[self::INPUT_KEY_ES_SERVER_HTTP_AUTH_PWD],
             ];
             foreach ($httpAuthConfig as $configKey => $configValue) {
-                $configData->set($configPrefix . $configKey, $configKey);
+                $configData->set($configPrefix . $configKey, $configValue);
             }
         }
 
@@ -138,6 +138,7 @@ class ConfigOptionsList implements ConfigOptionsListInterface
 
     /**
      * {@inheritdoc}
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function validate(array $options, DeploymentConfig $deploymentConfig)
     {
@@ -162,7 +163,10 @@ class ConfigOptionsList implements ConfigOptionsListInterface
     }
 
     /**
-     * @param array $options
+     * Create setup configuration for the client for purposes of validation.
+     *
+     * @param array $options The configuration options supplied by install.
+     *
      * @return \Smile\ElasticsuiteCore\Setup\ClientConfiguration
      */
     private function createClientConfiguration(array $options)
@@ -172,10 +176,9 @@ class ConfigOptionsList implements ConfigOptionsListInterface
             'serverList' => $options[self::INPUT_KEY_ES_SERVER],
         ];
 
-        // If HTTP Auth is enabled, add those configurations
+        // If HTTP Auth is enabled, add those configurations.
         if ($this->isHttpAuthEnabled($options)) {
             $configurationArgs = array_merge($configurationArgs, [
-                'isHttpAuthEnabled' => true,
                 'httpAuthUser'      => $options[self::INPUT_KEY_ES_SERVER_HTTP_AUTH_USER] ?? null,
                 'httpAuthPassword'  => $options[self::INPUT_KEY_ES_SERVER_HTTP_AUTH_PWD] ?? null,
             ]);
@@ -187,13 +190,14 @@ class ConfigOptionsList implements ConfigOptionsListInterface
     /**
      * Check if HTTP Auth is required to be enabled.
      *
-     * @param $data
+     * @param array $options The configuration options supplied by install.
+     *
      * @return bool
      */
-    private function isHttpAuthEnabled(array $data)
+    private function isHttpAuthEnabled(array $options)
     {
         foreach ([self::INPUT_KEY_ES_SERVER_HTTP_AUTH_USER, self::INPUT_KEY_ES_SERVER_HTTP_AUTH_PWD] as $possibleKey) {
-            if (!$this->isDataEmpty($data, $possibleKey)) {
+            if (!$this->isDataEmpty($options, $possibleKey)) {
                 return true;
             }
         }
@@ -202,15 +206,16 @@ class ConfigOptionsList implements ConfigOptionsListInterface
     }
 
     /**
-     * Check if data ($data) with key ($key) is empty
+     * Check if supplied data ($options) with key ($key) is empty.
      *
-     * @param array $data
-     * @param string $key
+     * @param array  $options Configuration data to check
+     * @param string $key     The relevant input key
+     *
      * @return bool
      */
-    private function isDataEmpty(array $data, $key)
+    private function isDataEmpty(array $options, $key)
     {
-        if (isset($data[$key]) && $data[$key] !== '') {
+        if (isset($options[$key]) && $options[$key] !== '') {
             return false;
         }
 

--- a/src/module-elasticsuite-core/Setup/ConfigOptionsList.php
+++ b/src/module-elasticsuite-core/Setup/ConfigOptionsList.php
@@ -1,0 +1,219 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\ElasticsuiteCore
+ * @author    Carey Sizer <carey@balanceinternet.com.au>
+ * @copyright 2018 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\ElasticsuiteCore\Setup;
+
+use Magento\Framework\App\DeploymentConfig;
+use Magento\Framework\Config\Data\ConfigData;
+use Magento\Framework\Config\File\ConfigFilePool;
+use Magento\Framework\Setup\Option\TextConfigOption;
+use Magento\Framework\Setup\ConfigOptionsListInterface;
+use Smile\ElasticsuiteCore\Api\Client\ClientFactoryInterface;
+use Smile\ElasticsuiteCore\Helper\ClientConfiguration;
+use Smile\ElasticsuiteCore\Client\ClientFactoryFactory;
+use Smile\ElasticsuiteCore\Setup\ClientConfigurationFactory;
+
+/**
+ * Provides configuration options to the Magento setup command for Elasticsuite.
+ *
+ * @category Smile
+ * @package  Smile\ElasticsuiteCore
+ * @author   Carey Sizer <carey@balanceinternet.com.au>
+ */
+class ConfigOptionsList implements ConfigOptionsListInterface
+{
+    /**
+     * Input key for the options
+     */
+    const INPUT_KEY_ES_SERVER = 'es-server';
+
+    /**
+     * Input key for the options
+     */
+    const INPUT_KEY_ES_SERVER_HTTP_AUTH_USER = 'es-server-http-auth-user';
+
+    /**
+     * Input key for the options
+     */
+    const INPUT_KEY_ES_SERVER_HTTP_AUTH_PWD = 'es-server-http-auth-password';
+
+    /**
+     * Default ES server variable
+     */
+    const DEFAULT_ES_SERVER = 'localhost:9200';
+
+    /**
+     * @var ClientFactoryFactory
+     */
+    private $clientFactoryFactory;
+
+    /**
+     * @var ClientConfigurationFactory
+     */
+    private $clientConfigurationFactory;
+
+    /**
+     * ConfigOptionsList constructor.
+     *
+     * @param ClientFactoryFactory $clientFactoryFactory
+     * @param ClientConfigurationFactory $clientConfigurationFactory
+     */
+    public function __construct(
+        ClientFactoryFactory $clientFactoryFactory,
+        ClientConfigurationFactory $clientConfigurationFactory
+    ) {
+        $this->clientFactoryFactory = $clientFactoryFactory;
+        $this->clientConfigurationFactory = $clientConfigurationFactory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getOptions()
+    {
+        return [
+            new TextConfigOption(
+                self::INPUT_KEY_ES_SERVER,
+                TextConfigOption::FRONTEND_WIZARD_TEXT,
+                ClientConfiguration::CONFIG_PATH_CLIENT_SERVERS,
+                'Elasticsuite server(s)',
+                self::DEFAULT_ES_SERVER
+            ),
+            new TextConfigOption(
+                self::INPUT_KEY_ES_SERVER_HTTP_AUTH_USER,
+                TextConfigOption::FRONTEND_WIZARD_TEXT,
+                ClientConfiguration::CONFIG_PATH_HTTP_AUTH_USER,
+                'Elasticsuite server(s) HTTP Auth User'
+            ),
+            new TextConfigOption(
+                self::INPUT_KEY_ES_SERVER_HTTP_AUTH_PWD,
+                TextConfigOption::FRONTEND_WIZARD_TEXT,
+                ClientConfiguration::CONFIG_PATH_HTTP_AUTH_PWD,
+                'Elasticsuite server(s) HTTP Auth Pass'
+            ),
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function createConfig(array $data, DeploymentConfig $deploymentConfig)
+    {
+        $configData = new ConfigData(ConfigFilePool::APP_ENV);
+        $configPrefix = 'system/default/';
+
+        // Apply the provided server configuration if it is set and not an empty string
+        if (!$this->isDataEmpty($data, self::INPUT_KEY_ES_SERVER)) {
+            $configData->set(
+                $configPrefix . ClientConfiguration::CONFIG_PATH_CLIENT_SERVERS,
+                $data[self::INPUT_KEY_ES_SERVER]
+            );
+        }
+
+        // If the user has supplied a username or password, assume they are using auth
+        if (!$this->isDataEmpty($data, self::INPUT_KEY_ES_SERVER_HTTP_AUTH_USER) ||
+            !$this->isDataEmpty($data, self::INPUT_KEY_ES_SERVER_HTTP_AUTH_PWD)) {
+            $httpAuthConfig = [
+                ClientConfiguration::CONFIG_PATH_ENABLE_HTTP_AUTH => 1,
+                ClientConfiguration::CONFIG_PATH_HTTP_AUTH_USER => $data[self::INPUT_KEY_ES_SERVER_HTTP_AUTH_USER],
+                ClientConfiguration::CONFIG_PATH_HTTP_AUTH_PWD => $data[self::INPUT_KEY_ES_SERVER_HTTP_AUTH_PWD],
+            ];
+            foreach ($httpAuthConfig as $configKey => $configValue) {
+                $configData->set($configPrefix . $configKey, $configKey);
+            }
+        }
+
+        return [$configData];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validate(array $options, DeploymentConfig $deploymentConfig)
+    {
+        $errors = [];
+
+        if (!$this->isDataEmpty($options, self::INPUT_KEY_ES_SERVER)) {
+            /** @var ClientFactoryInterface $clientFactory */
+            $clientFactory = $this->clientFactoryFactory->create([
+                'clientConfiguration' => $this->createClientConfiguration($options),
+            ]);
+
+            try {
+                if (!$clientFactory->createClient()->ping()) {
+                    $errors[] = "Could not ping the supplied Elasticsuite server.";
+                }
+            } catch (\Exception $ex) {
+                $errors[] = "Elasticsuite server error: " . $ex->getMessage();
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param array $options
+     * @return \Smile\ElasticsuiteCore\Setup\ClientConfiguration
+     */
+    private function createClientConfiguration(array $options)
+    {
+        /** @var  $clientConfiguration */
+        $configurationArgs = [
+            'serverList' => $options[self::INPUT_KEY_ES_SERVER],
+        ];
+
+        // If HTTP Auth is enabled, add those configurations
+        if ($this->isHttpAuthEnabled($options)) {
+            $configurationArgs = array_merge($configurationArgs, [
+                'isHttpAuthEnabled' => true,
+                'httpAuthUser'      => $options[self::INPUT_KEY_ES_SERVER_HTTP_AUTH_USER] ?? null,
+                'httpAuthPassword'  => $options[self::INPUT_KEY_ES_SERVER_HTTP_AUTH_PWD] ?? null,
+            ]);
+        }
+
+        return $this->clientConfigurationFactory->create($configurationArgs);
+    }
+
+    /**
+     * Check if HTTP Auth is required to be enabled.
+     *
+     * @param $data
+     * @return bool
+     */
+    private function isHttpAuthEnabled(array $data)
+    {
+        foreach ([self::INPUT_KEY_ES_SERVER_HTTP_AUTH_USER, self::INPUT_KEY_ES_SERVER_HTTP_AUTH_PWD] as $possibleKey) {
+            if (!$this->isDataEmpty($data, $possibleKey)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if data ($data) with key ($key) is empty
+     *
+     * @param array $data
+     * @param string $key
+     * @return bool
+     */
+    private function isDataEmpty(array $data, $key)
+    {
+        if (isset($data[$key]) && $data[$key] !== '') {
+            return false;
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
Allows users to specify connection flags, such as `--es-server` to `setup:install`.

Unsure of the best way to approach the use of deprecated ClientFactory. 

## Fixes 
Fixes #692 - issue with installation process (as currently described in the wiki) requiring a new module to define a custom elasticsearch endpoint (where it is not localhost:9200) to allow install to succeed. 

---

## Integration Test Compatibility

This PR also allows the Magento integration test framework  to run when elasticsuite is installed (which is our immediate motivation for adding this).

Example integration test configuration:

`dev/tests/integration/phpunit.custom.xml`
```xml
<phpunit>
   <testsuites>
      <!-- Define custom test suite, eg app/code/Vendor -->
   </testsuites>
   <php>
      <!-- Specify a custom install configuration file --->
      <const name="TESTS_INSTALL_CONFIG_FILE" value="etc/install-config-mysql.custom.php"/>
   </php>
</phpunit>
```

`dev/tests/integration/etc/install-config-mysql.custom.php`
```php
<?php
return [
    'db-host' => 'mysql',
    'db-user' => 'root',
    'db-password' => 'root',
    'db-name' => 'magento_integration_tests',
    'db-prefix' => '',
    'backend-frontname' => 'backend',
    'admin-user' => \Magento\TestFramework\Bootstrap::ADMIN_NAME,
    'admin-password' => \Magento\TestFramework\Bootstrap::ADMIN_PASSWORD,
    'admin-email' => \Magento\TestFramework\Bootstrap::ADMIN_EMAIL,
    'admin-firstname' => \Magento\TestFramework\Bootstrap::ADMIN_FIRSTNAME,
    'admin-lastname' => \Magento\TestFramework\Bootstrap::ADMIN_LASTNAME,
    // Specify the --es-server install flag to setup::install
    'es-server' => 'elasticsearch:9200',
];
```

`dev/tests/integration/etc/config-global.php`
```php
<?php
// Set the default search engine to Elasticsuite
return [
    'catalog/search/engine' => 'elasticsuite',
];
```


Running as follows:

```bash
$ vendor/bin/phpunit -c dev/tests/integration/phpunit.custom.xml --testsuite Custom
```
