### PR TITLE
Fixing wrong route for merchandiser in admin.

### DIFF
--- a/src/module-elasticsuite-catalog/etc/adminhtml/routes.xml
+++ b/src/module-elasticsuite-catalog/etc/adminhtml/routes.xml
@@ -18,7 +18,7 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:App/etc/routes.xsd">
     <router id="admin">
         <route id="search" frontName="search">
-            <module name="Magento_Search" before="Magento_Backend" />
+            <module name="Smile_ElasticsuiteCatalog" before="Magento_Search" />
         </route>
     </router>
 </config>


### PR DESCRIPTION
Actual version of routes.xml leads to a 404 error when accessing the "Merchandiser" link.