### PR TITLE
Check if adminSoertIndex key exists

### DIFF
--- a/src/module-elasticsuite-catalog/Model/Layer/Filter/Attribute.php
+++ b/src/module-elasticsuite-catalog/Model/Layer/Filter/Attribute.php
@@ -267,10 +267,29 @@ class Attribute extends \Magento\CatalogSearch\Model\Layer\Filter\Attribute impl
                 }
             }
 
-            usort($items, function ($item1, $item2) {
-                return $item1['adminSortIndex'] <= $item2['adminSortIndex'] ? -1 : 1;
-            });
+            $items = $this->sortOptionsData($items);
         }
+
+        return $items;
+    }
+
+    /**
+     * Sort items by adminSortIndex key.
+     *
+     * @param array $items to be sorted.
+     *
+     * @return array
+     */
+    private function sortOptionsData(array $items)
+    {
+
+        usort($items, function ($item1, $item2) {
+            if (!isset($item1['adminSortIndex']) or !isset($item2['adminSortIndex'])) {
+                return 0;
+            }
+
+            return $item1['adminSortIndex'] <= $item2['adminSortIndex'] ? -1 : 1;
+        });
 
         return $items;
     }


### PR DESCRIPTION
Issue: https://github.com/Smile-SA/elasticsuite/issues/729

This one fix the missing adminSortIndex issue.
If you change the option label in the filter attribute in the admin panel, the script doesn't see this option, doesn't set key adminSortIndex and throws an error in usort() function.

This issue exists in all versions.

Regards,
Grzegorz