### PR TITLE
Changed ClientConfiguration instance used in ConfigOptionsList

### DIFF
--- a/src/module-elasticsuite-core/Client/Client.php
+++ b/src/module-elasticsuite-core/Client/Client.php
@@ -38,18 +38,15 @@ class Client implements ClientInterface
     /**
      * Constructor.
      *
-     * @param ClientConfigurationInterfaceFactory $clientConfigurationFactory Client configuration factory.
-     * @param ClientBuilder                       $clientBuilder              ES client builder.
-     * @param LoggerInterface                     $logger                     Logger.
-     * @param array                               $options                    Client options.
+     * @param ClientConfigurationInterface $clientConfiguration Client configuration factory.
+     * @param ClientBuilder                $clientBuilder       ES client builder.
+     * @param LoggerInterface              $logger              Logger.
      */
     public function __construct(
-        \Smile\ElasticsuiteCore\Client\ClientConfigurationFactory $clientConfigurationFactory,
+        ClientConfigurationInterface $clientConfiguration,
         ClientBuilder $clientBuilder,
-        LoggerInterface $logger,
-        $options = []
+        LoggerInterface $logger
     ) {
-        $clientConfiguration = $clientConfigurationFactory->create(['options' => $options]);
         $this->esClient = $this->createClient($clientConfiguration, $clientBuilder, $logger);
     }
 

--- a/src/module-elasticsuite-core/Client/ClientConfiguration.php
+++ b/src/module-elasticsuite-core/Client/ClientConfiguration.php
@@ -33,11 +33,6 @@ class ClientConfiguration implements ClientConfigurationInterface
     const ES_CLIENT_CONFIG_XML_PREFIX = 'smile_elasticsuite_core_base_settings/es_client';
 
     /**
-     * @var array
-     */
-    private $options;
-
-    /**
      * @var \Magento\Framework\App\Config\ScopeConfigInterface
      */
     private $scopeConfig;
@@ -45,14 +40,11 @@ class ClientConfiguration implements ClientConfigurationInterface
     /**
      *
      * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig Config.
-     * @param array                                              $options     Custom options.
      */
     public function __construct(
-        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
-        $options = []
+        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
     ) {
         $this->scopeConfig = $scopeConfig;
-        $this->options     = $options;
     }
 
     /**
@@ -124,6 +116,6 @@ class ClientConfiguration implements ClientConfigurationInterface
     {
         $path = self::ES_CLIENT_CONFIG_XML_PREFIX . '/' . $configField;
 
-        return $this->options[$configField] ?? $this->scopeConfig->getValue($path);
+        return $this->scopeConfig->getValue($path);
     }
 }

--- a/src/module-elasticsuite-core/Setup/ClientConfiguration.php
+++ b/src/module-elasticsuite-core/Setup/ClientConfiguration.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * DISCLAIMER :
+ *
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile_Elasticsuite
+ * @package   Smile\ElasticsuiteCore
+ * @author    Carey Sizer <carey@balanceinternet.com.au>
+ * @copyright 2018 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+
+namespace Smile\ElasticsuiteCore\Setup;
+
+use Smile\ElasticsuiteCore\Api\Client\ClientConfigurationInterface;
+
+/**
+ * ElasticSearch client configuration implementation.
+ *
+ * @category  Smile
+ * @package   Smile\ElasticsuiteCore
+ * @author    Carey Sizer <carey@balanceinternet.com.au>
+ */
+class ClientConfiguration implements ClientConfigurationInterface
+{
+    /**
+     * Location of Elasticsearch client configuration.
+     *
+     * @var string
+     */
+    const ES_CLIENT_CONFIG_XML_PREFIX = 'smile_elasticsuite_core_base_settings/es_client';
+
+    /**
+     * @var array
+     */
+    private $options;
+
+    /**
+     * @param array $options Custom options.
+     */
+    public function __construct($options = [])
+    {
+        $this->options = $options;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getServerList()
+    {
+        return explode(',', ($this->options['servers'] ?? null));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isDebugModeEnabled()
+    {
+        return (bool) ($this->options['enable_debug_mode'] ?? false);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getConnectionTimeout()
+    {
+        return (int) ($this->options['connection_timeout'] ?? 0);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getScheme()
+    {
+        return (bool) ($this->options['enable_https_mode'] ?? false) ? 'https' : 'http';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isHttpAuthEnabled()
+    {
+        $authEnabled = (bool) ($this->options['enable_http_auth'] ?? false);
+
+        return $authEnabled && !empty($this->getHttpAuthUser()) && !empty($this->getHttpAuthPassword());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getHttpAuthUser()
+    {
+        return (string) ($this->options['http_auth_user'] ?? null);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getHttpAuthPassword()
+    {
+        return (string) ($this->options['http_auth_pwd'] ?? null);
+    }
+}

--- a/src/module-elasticsuite-core/Setup/ConfigOptionsList.php
+++ b/src/module-elasticsuite-core/Setup/ConfigOptionsList.php
@@ -53,15 +53,23 @@ class ConfigOptionsList implements ConfigOptionsListInterface
      * @var ClientFactoryInterface
      */
     private $clientFactory;
+    /**
+     * @var ClientConfigurationFactory
+     */
+    private $clientConfigurationFactory;
 
     /**
      * Constructor.
      *
-     * @param \Smile\ElasticsuiteCore\Client\ClientFactory $clientFactory ES Client factory.
+     * @param \Smile\ElasticsuiteCore\Client\ClientFactory             $clientFactory              ES Client factory.
+     * @param \Smile\ElasticsuiteCore\Setup\ClientConfigurationFactory $clientConfigurationFactory Client Configuration factory.
      */
-    public function __construct(\Smile\ElasticsuiteCore\Client\ClientFactory $clientFactory)
-    {
+    public function __construct(
+        \Smile\ElasticsuiteCore\Client\ClientFactory $clientFactory,
+        \Smile\ElasticsuiteCore\Setup\ClientConfigurationFactory $clientConfigurationFactory
+    ) {
         $this->clientFactory = $clientFactory;
+        $this->clientConfigurationFactory = $clientConfigurationFactory;
     }
 
     /**
@@ -120,7 +128,9 @@ class ConfigOptionsList implements ConfigOptionsListInterface
 
         try {
             $clientsOptions = array_filter($this->getClientOptions($options, $deploymentConfig));
-            $this->clientFactory->create(['options' => $clientsOptions])->info();
+            $clientConfiguration = $this->clientConfigurationFactory->create(['options' => $clientsOptions]);
+
+            $this->clientFactory->create(['clientConfiguration' => $clientConfiguration])->info();
         } catch (\Exception $e) {
             $errors[] = "Unable to connect ElasticSearch server : {$e->getMessage()}";
         }


### PR DESCRIPTION
Changed ClientConfiguration instance used in ConfigOptionsList to ensure that ScopeConfigInteface isn't accessed prior to Magento initialization.

The custom options array previously passed to Client\ClientConfiguration was to allow for the setup:install parameters supplied via CLI to be passed to the client in order to validate the connection settings before proceeding with Magento installation.

This has been removed, as it doesn't look like there is currently any use cases that require it. It has been extracted into a separate ClientConfigurationInterface implementation so that ConfigOptionsList can construct an instance without touching ScopeConfigInterface, as this caused the following:

- Notice: Undefined index: websites in module-config/App/Config/Type/System.php on line 248
- Empty config to be saved to cache prior to Magento install (unknown what this causes currently)

Fixes #738