### PR TITLE
Feature gdpr consent tracking

### DIFF
--- a/src/module-elasticsuite-tracker/Block/Config.php
+++ b/src/module-elasticsuite-tracker/Block/Config.php
@@ -23,6 +23,11 @@ namespace Smile\ElasticsuiteTracker\Block;
 class Config extends \Magento\Framework\View\Element\Template
 {
     /**
+     * The default tracking consent component, used as a fallback if none defined in layout.
+     */
+    const DEFAULT_CONSENT_COMPONENT = 'Smile_ElasticsuiteTracker/js/user-consent';
+
+    /**
      * Magento Configuration
      *
      * @var \Magento\Framework\App\Config\ScopeConfigInterface
@@ -44,6 +49,13 @@ class Config extends \Magento\Framework\View\Element\Template
     private $trackerHelper;
 
     /**
+     * Javascript component that will handle User consent.
+     *
+     * @var string
+     */
+    private $userConsentComponent;
+
+    /**
      * PHP Constructor
      *
      * @param \Magento\Framework\View\Element\Template\Context $context       App context
@@ -59,9 +71,10 @@ class Config extends \Magento\Framework\View\Element\Template
     ) {
         parent::__construct($context, $data);
 
-        $this->scopeConfig   = $context->getScopeConfig();
-        $this->jsonHelper    = $jsonHelper;
-        $this->trackerHelper = $trackerHelper;
+        $this->scopeConfig          = $context->getScopeConfig();
+        $this->jsonHelper           = $jsonHelper;
+        $this->trackerHelper        = $trackerHelper;
+        $this->userConsentComponent = $data['userConsentComponent'] ?? self::DEFAULT_CONSENT_COMPONENT;
     }
 
     /**
@@ -115,5 +128,15 @@ class Config extends \Magento\Framework\View\Element\Template
     public function getStoreId()
     {
         return $this->trackerHelper->getStoreId();
+    }
+
+    /**
+     * Return the JS component to be used to check if user did consent tracking.
+     *
+     * @return string
+     */
+    public function getUserConsentComponent()
+    {
+        return $this->userConsentComponent;
     }
 }

--- a/src/module-elasticsuite-tracker/view/frontend/layout/default.xml
+++ b/src/module-elasticsuite-tracker/view/frontend/layout/default.xml
@@ -21,7 +21,11 @@
     </head>
     <body>
         <referenceContainer name="head.additional">
-            <block template="config.phtml" class="Smile\ElasticsuiteTracker\Block\Config" name="smile.tracker.config" />
+            <block template="config.phtml" class="Smile\ElasticsuiteTracker\Block\Config" name="smile.tracker.config">
+                <arguments>
+                    <argument name="userConsentComponent" xsi:type="string">Smile_ElasticsuiteTracker/js/user-consent</argument>
+                </arguments>
+            </block>
         </referenceContainer>
         <referenceContainer name="before.body.end">
             <block class="Smile\ElasticsuiteTracker\Block\Variables\Page\Base" name="smile.tracker.page.base" />

--- a/src/module-elasticsuite-tracker/view/frontend/layout/default.xml
+++ b/src/module-elasticsuite-tracker/view/frontend/layout/default.xml
@@ -23,7 +23,7 @@
         <referenceContainer name="head.additional">
             <block template="config.phtml" class="Smile\ElasticsuiteTracker\Block\Config" name="smile.tracker.config">
                 <arguments>
-                    <argument name="userConsentComponent" xsi:type="string">Smile_ElasticsuiteTracker/js/user-consent</argument>
+                    <argument name="userConsentComponent" xsi:type="string">elasticsuiteTrackerUserConsent</argument>
                 </arguments>
             </block>
         </referenceContainer>

--- a/src/module-elasticsuite-tracker/view/frontend/requirejs-config.js
+++ b/src/module-elasticsuite-tracker/view/frontend/requirejs-config.js
@@ -1,0 +1,21 @@
+/**
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ *
+ * @category  Smile
+ * @package   Smile\ElasticsuiteTracker
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2018 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+
+var config = {
+    map: {
+        '*': {
+            elasticsuiteTrackerUserConsent: 'Smile_ElasticsuiteTracker/js/user-consent'
+        }
+    }
+};

--- a/src/module-elasticsuite-tracker/view/frontend/templates/config.phtml
+++ b/src/module-elasticsuite-tracker/view/frontend/templates/config.phtml
@@ -20,11 +20,24 @@
 <script type="text/javascript">
 //<![CDATA[
     smileTracker.setConfig({
-        beaconUrl  : '<?php /* @noEscape */ echo $this->escapeJsQuote($block->getBeaconUrl()); ?>',
-        sessionConfig : <?php /* @noEscape */ echo $jsonHelper->jsonEncode($block->getCookieConfig()); ?>
+        beaconUrl     : '<?php /* @noEscape */ echo $this->escapeJsQuote($block->getBeaconUrl()); ?>',
+        sessionConfig : <?php /* @noEscape */ echo $jsonHelper->jsonEncode($block->getCookieConfig()); ?>,
+        userConsent   : '<?php /* @noEscape */ echo $this->escapeJsQuote($block->getUserConsentComponent()); ?>'
     });
 
     smileTracker.addPageVar('store_id', '<?php /* @noEscape */ echo $this->escapeJsQuote($block->getStoreId());?>');
 //]]>
+</script>
+
+<?php $cookieRestrictionEnabled = (bool) $this->helper(\Magento\Cookie\Helper\Cookie::class)->isCookieRestrictionModeEnabled() ;?>
+<script type="text/x-magento-init">
+{
+    "*": {
+        "Smile_ElasticsuiteTracker/js/user-consent": {
+            "cookieRestrictionEnabled": <?= $jsonHelper->jsonEncode($cookieRestrictionEnabled) ?>,
+            "cookieRestrictionName": "<?= /* @noEscape */ \Magento\Cookie\Helper\Cookie::IS_USER_ALLOWED_SAVE_COOKIE ?>"
+        }
+    }
+}
 </script>
 <?php endif; ?>

--- a/src/module-elasticsuite-tracker/view/frontend/web/js/tracking.js
+++ b/src/module-elasticsuite-tracker/view/frontend/web/js/tracking.js
@@ -139,22 +139,20 @@ var smileTracker = (function () {
     // Append a transparent pixel to the body
     function sendTag(forceCollect) {
         if (this.trackerSent === false || forceCollect === true) {
-            var bodyNode = document.getElementsByTagName('body')[0];
+            require([this.config.userConsent], function(UserConsent) {
+                var canSend = (typeof UserConsent.getUserConsent === 'function') && (UserConsent.getUserConsent() === true);
 
-            if (this.config && this.config.hasOwnProperty('sessionConfig')) {
-                var trackingUrl = getTrackerUrl.bind(this)();
-                var imgNode = document.createElement('img');
-                imgNode.setAttribute('src', trackingUrl);
-                setTrackerStyle(imgNode);
-                bodyNode.appendChild(imgNode);
-                this.trackerSent = true;
-                this.vars = {};
-            }
-
-            var extImgNode = document.createElement('img');
-            extImgNode.setAttribute('src', "//t.smile.eu/h.png?magento2");
-            setTrackerStyle(extImgNode);
-            bodyNode.appendChild(extImgNode);
+                if (canSend && this.config && this.config.hasOwnProperty('sessionConfig')) {
+                    var bodyNode = document.getElementsByTagName('body')[0];
+                    var trackingUrl = getTrackerUrl.bind(this)();
+                    var imgNode = document.createElement('img');
+                    imgNode.setAttribute('src', trackingUrl);
+                    setTrackerStyle(imgNode);
+                    bodyNode.appendChild(imgNode);
+                    this.trackerSent = true;
+                    this.vars = {};
+                }
+            }.bind(this));
         }
     }
 

--- a/src/module-elasticsuite-tracker/view/frontend/web/js/user-consent.js
+++ b/src/module-elasticsuite-tracker/view/frontend/web/js/user-consent.js
@@ -1,0 +1,47 @@
+/**
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ *
+ * @category  Smile
+ * @package   Smile\ElasticsuiteTracker
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2018 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+
+define(['jquery', 'mage/cookies'], function ($) {
+    'use strict';
+
+    var hasUserConsent = function(configuration) {
+        // If cookie restriction mode is not enabled, consider the user consent as accepted.
+        var result = !isCookieRestrictionEnabled(configuration);
+
+        // Otherwise, return true only if the user has accepted cookies.
+        if (!result && configuration.hasOwnProperty('cookieRestrictionName')) {
+            result = ($.mage.cookies.get(configuration.cookieRestrictionName) !== null);
+        }
+
+        return result;
+    };
+
+    var isCookieRestrictionEnabled = function(configuration) {
+        return configuration.hasOwnProperty('cookieRestrictionEnabled')
+            && configuration.cookieRestrictionEnabled === true;
+    };
+
+    return {
+
+        /**
+         * @param {Object} config
+         * @constructor
+         */
+        'Smile_ElasticsuiteTracker/js/user-consent': function (config) {
+            this.getUserConsent = function() {
+                return hasUserConsent(config);
+            }
+        }
+    };
+});


### PR DESCRIPTION
I added a Javascript class to handle user consent.

Default implementation is based on cookie restriction (`true` if cookie restriction is disabled, `true` if restriction is enabled and the user accepted cookies, `false` otherwise).

There are 2 points of extension : 

- via the layout, one can change the UserConsent JS component used by the block.
- via the requirejs-config, one change the mapping of the default component name to point on a custom implementation.

I tested overriding with a dummy one (returning always true or false) and it was working.

