### PR TITLE
Fix prevent spellcheck fields

### DIFF
--- a/src/module-elasticsuite-catalog/Block/Plugin/Adminhtml/Product/Attribute/Edit/Tab/FrontPlugin.php
+++ b/src/module-elasticsuite-catalog/Block/Plugin/Adminhtml/Product/Attribute/Edit/Tab/FrontPlugin.php
@@ -106,7 +106,7 @@ class FrontPlugin
             $form->getElement('is_searchable')->setDisabled(1);
         }
 
-        $this->appendFieldsDependency($form, $subject);
+        $this->appendFieldsDependency($subject);
 
         return $block;
     }
@@ -366,7 +366,10 @@ class FrontPlugin
             $dependencyBlock
                 ->addFieldMap('is_displayed_in_autocomplete', 'is_displayed_in_autocomplete')
                 ->addFieldMap('is_filterable_in_search', 'is_filterable_in_search')
-                ->addFieldDependence('is_displayed_in_autocomplete', 'is_filterable_in_search', '1');
+                ->addFieldMap('is_searchable', 'is_searchable')
+                ->addFieldMap('is_used_in_spellcheck', 'is_used_in_spellcheck')
+                ->addFieldDependence('is_displayed_in_autocomplete', 'is_filterable_in_search', '1')
+                ->addFieldDependence('is_used_in_spellcheck', 'is_searchable', '1');
         }
 
         return $this;

--- a/src/module-elasticsuite-core/Index/Mapping/Field.php
+++ b/src/module-elasticsuite-core/Index/Mapping/Field.php
@@ -130,7 +130,7 @@ class Field implements FieldInterface
      */
     public function isUsedInSpellcheck()
     {
-        return (bool) $this->config['is_used_in_spellcheck'];
+        return (bool) $this->config['is_used_in_spellcheck'] && (bool) $this->config['is_searchable'];
     }
 
     /**

--- a/src/module-elasticsuite-core/Test/Unit/Index/Mapping/FieldTest.php
+++ b/src/module-elasticsuite-core/Test/Unit/Index/Mapping/FieldTest.php
@@ -157,4 +157,46 @@ class FieldTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(null, $field->getMappingProperty());
         $this->assertEquals('field', $field->getMappingProperty(FieldInterface::ANALYZER_STANDARD));
     }
+
+    /**
+     * @dataProvider getIsUsedInSpellcheckFieldConfigDataProvider
+     *
+     * @param array $fieldConfig        Field configuration from data provider
+     * @param bool  $isSearchable       Expected result for is_searchable property
+     * @param bool  $isUsedInSpellcheck Expected result for is_used_in_spellcheck property
+     */
+    public function testIsUsedInSpellcheckField($fieldConfig, $isSearchable, $isUsedInSpellcheck)
+    {
+        $fieldType   = FieldInterface::FIELD_TYPE_STRING;
+        $field       = new Field('field', $fieldType, null, $fieldConfig);
+
+        $this->assertEquals($isSearchable, $field->isSearchable());
+        $this->assertEquals($isUsedInSpellcheck, $field->isUsedInSpellcheck());
+    }
+
+    /**
+     * Data provider to test combinations of is_searchable/is_used_in_spellcheck for field configuration.
+     *
+     * @return array
+     */
+    public function getIsUsedInSpellcheckFieldConfigDataProvider()
+    {
+        return [
+            [
+                ['is_searchable' => true, 'is_used_in_spellcheck' => false],
+                true,
+                false,
+            ],
+            [
+                ['is_searchable' => true, 'is_used_in_spellcheck' => true],
+                true,
+                true,
+            ],
+            [
+                ['is_searchable' => false, 'is_used_in_spellcheck' => true],
+                false,
+                false,
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
Fix #827 

I discovered there was also a bug in the BO attribute edit block, this PR embeds the fix (dependency block was broken).

I changed the isUsedInSpellecheck method for FieldInterface and added the associated unit test.

Let me know