### PR TITLE
Adding conditional fieldsets for optimizers.

### DIFF
--- a/src/module-elasticsuite-catalog-optimizer/Ui/Component/Listing/Column/YesNo.php
+++ b/src/module-elasticsuite-catalog-optimizer/Ui/Component/Listing/Column/YesNo.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\ElasticsuiteCatalogOptimizer
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2018 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\ElasticsuiteCatalogOptimizer\Ui\Component\Listing\Column;
+
+/**
+ * Simple Yes/No column renderer.
+ *
+ * @category Smile
+ * @package  Smile\ElasticsuiteCatalogOptimizer
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class YesNo extends \Magento\Ui\Component\Listing\Columns\Column
+{
+    /**
+     * Convert boolean value to Yes/No text output.
+     *
+     * @param mixed[] $dataSource The data source
+     *
+     * @return mixed[]
+     */
+    public function prepareDataSource(array $dataSource)
+    {
+        if (isset($dataSource['data']['items'])) {
+            $config = $this->getConfiguration();
+            $name   = $config['fieldName'] ?? $this->getName();
+            foreach ($dataSource['data']['items'] as & $item) {
+                $item[$name] = ($item[$name] ? __('Yes') : __('No'));
+            }
+        }
+
+        return parent::prepareDataSource($dataSource);
+    }
+}

--- a/src/module-elasticsuite-catalog-optimizer/view/adminhtml/ui_component/smile_elasticsuite_catalog_optimizer_form.xml
+++ b/src/module-elasticsuite-catalog-optimizer/view/adminhtml/ui_component/smile_elasticsuite_catalog_optimizer_form.xml
@@ -189,6 +189,338 @@
         </field>
     </fieldset>
 
+    <fieldset name="quick_search_container">
+        <argument name="data" xsi:type="array">
+            <item name="config" xsi:type="array">
+                <item name="label" xsi:type="string" translate="true">Catalog Product Search</item>
+                <item name="component" xsi:type="string">Smile_ElasticsuiteCatalogOptimizer/js/components/form/optimizer/fieldset-visibility</item>
+                <item name="imports" xsi:type="array">
+                    <item name="initValue" xsi:type="string">${ $.provider }:data.search_container</item>
+                </item>
+                <item name="listens" xsi:type="array">
+                    <item name="${ $.provider }:data.search_container" xsi:type="string">onChange</item>
+                </item>
+            </item>
+        </argument>
+        <field name="search_term_apply_to">
+            <argument name="data" xsi:type="array">
+                <item name="options" xsi:type="array">
+                    <item name="0" xsi:type="array">
+                        <item name="value" xsi:type="number">0</item>
+                        <item name="label" xsi:type="string" translate="true">All search terms</item>
+                    </item>
+                    <item name="1" xsi:type="array">
+                        <item name="value" xsi:type="number">1</item>
+                        <item name="label" xsi:type="string" translate="true">Selected search terms</item>
+                    </item>
+                </item>
+                <item name="config" xsi:type="array">
+                    <item name="dataType" xsi:type="string">text</item>
+                    <item name="label" xsi:type="string" translate="true">Apply to</item>
+                    <item name="formElement" xsi:type="string">select</item>
+                    <item name="source" xsi:type="string">optimizer</item>
+                    <item name="dataScope" xsi:type="string">quick_search_container.apply_to</item>
+                    <item name="sortOrder" xsi:type="number">10</item>
+                </item>
+            </argument>
+            <settings>
+                <switcherConfig>
+                    <rules>
+                        <rule name="0">
+                            <value>0</value>
+                            <actions>
+                                <action name="0">
+                                    <target>smile_elasticsuite_catalog_optimizer_form.smile_elasticsuite_catalog_optimizer_form.quick_search_container.query_ids_fieldset</target>
+                                    <callback>close</callback>
+                                </action>
+                            </actions>
+                        </rule>
+                        <rule name="1">
+                            <value>1</value>
+                            <actions>
+                                <action name="0">
+                                    <target>smile_elasticsuite_catalog_optimizer_form.smile_elasticsuite_catalog_optimizer_form.quick_search_container.query_ids_fieldset</target>
+                                    <callback>open</callback>
+                                </action>
+                            </actions>
+                        </rule>
+                    </rules>
+                    <enabled>true</enabled>
+                </switcherConfig>
+            </settings>
+        </field>
+
+        <fieldset name="query_ids_fieldset">
+            <settings>
+                <label/>
+                <ns>smile_elasticsuite_catalog_optimizer_form.smile_elasticsuite_catalog_optimizer_form.quick_search_container</ns>
+                <collapsible>true</collapsible>
+                <opened>true</opened>
+            </settings>
+            <container name="button_set" template="ui/form/components/complex">
+                <argument name="data" xsi:type="array">
+                    <item name="config" xsi:type="array">
+                        <item name="label" xsi:type="string"/>
+                        <item name="content" xsi:type="string" translate="true"><![CDATA[Select the search terms for which you want the optimizer to apply.]]></item>
+                    </item>
+                </argument>
+                <button name="release_notification_button_back" displayArea="actions-secondary">
+                    <argument name="data" xsi:type="array">
+                        <item name="config" xsi:type="array">
+                            <item name="buttonClasses" xsi:type="string"></item>
+                            <item name="actions" xsi:type="array">
+                                <item name="0" xsi:type="array">
+                                    <item name="targetName" xsi:type="string">smile_elasticsuite_catalog_optimizer_form.smile_elasticsuite_catalog_optimizer_form.quick_search_container.search_terms_modal</item>
+                                    <item name="actionName" xsi:type="string">toggleModal</item>
+                                </item>
+                            </item>
+                            <item name="title" xsi:type="string" translate="true">Add Search Terms</item>
+                        </item>
+                    </argument>
+                </button>
+            </container>
+
+            <dynamicRows
+                    name="quick_search_container.query_ids"
+                    sortOrder="200"
+                    component="Magento_Ui/js/dynamic-rows/dynamic-rows-grid"
+                    template="ui/dynamic-rows/templates/grid"
+            >
+                <argument name="data" xsi:type="array">
+                    <item name="config" xsi:type="array">
+                        <item name="columnsHeaderAfterRender" xsi:type="boolean">true</item>
+                        <item name="deleteButtonLabel" xsi:type="string" translate="true">Remove</item>
+                        <item name="dataProvider" xsi:type="string">search_term_listing</item>
+                        <item name="map" xsi:type="array">
+                            <item name="id" xsi:type="string">query_id</item>
+                            <item name="query_text" xsi:type="string">query_text</item>
+                            <item name="is_spellchecked" xsi:type="string">is_spellchecked</item>
+                        </item>
+                    </item>
+                </argument>
+                <settings>
+                    <addButton>false</addButton>
+                    <defaultRecord>false</defaultRecord>
+                    <columnsHeader>false</columnsHeader>
+                    <recordTemplate>record</recordTemplate>
+                    <additionalClasses>
+                        <class name="admin__field-wide">true</class>
+                    </additionalClasses>
+                    <dndConfig>
+                        <param name="enabled" xsi:type="boolean">false</param>
+                    </dndConfig>
+                    <links>
+                        <link name="insertData">${ $.provider }:${ $.dataProvider }</link>
+                    </links>
+                </settings>
+                <container name="record" component="Magento_Ui/js/dynamic-rows/record">
+                    <argument name="data" xsi:type="array">
+                        <item name="config" xsi:type="array">
+                            <item name="isTemplate" xsi:type="boolean">true</item>
+                            <item name="is_collection" xsi:type="boolean">true</item>
+                            <item name="componentType" xsi:type="string">container</item>
+                            <item name="dataScope" xsi:type="string"></item>
+                        </item>
+                    </argument>
+                    <field name="id" formElement="input" template="ui/dynamic-rows/cells/text">
+                        <settings>
+                            <dataType>text</dataType>
+                            <label translate="true">ID</label>
+                            <visible>true</visible>
+                            <dataScope>id</dataScope>
+                        </settings>
+                    </field>
+                    <field name="query_text" formElement="input" template="ui/dynamic-rows/cells/text">
+                        <settings>
+                            <dataType>text</dataType>
+                            <label translate="true">Query Text</label>
+                            <visible>true</visible>
+                        </settings>
+                    </field>
+                    <field name="is_spellchecked" formElement="text" component="Magento_Ui/js/form/element/text" template="ui/dynamic-rows/cells/text">
+                        <argument name="data" xsi:type="array">
+                            <item name="config" xsi:type="array">
+                                <item name="visible" xsi:type="boolean">true</item>
+                                <item name="label" xsi:type="string" translate="true">Is Spellchecked</item>
+                                <item name="dataType" xsi:type="string">string</item>
+                                <item name="fit" xsi:type="boolean">true</item>
+                            </item>
+                        </argument>
+                    </field>
+                    <actionDelete name="delete">
+                        <settings>
+                            <dataType>text</dataType>
+                            <label translate="true">Actions</label>
+                            <visible>true</visible>
+                            <dataScope>query_text</dataScope>
+                            <additionalClasses>
+                                <class name="data-grid-actions-cell">true</class>
+                            </additionalClasses>
+                        </settings>
+                    </actionDelete>
+                </container>
+            </dynamicRows>
+        </fieldset>
+
+        <modal name="search_terms_modal">
+            <settings>
+                <options>
+                    <option name="title" xsi:type="string" translate="true">Select Search Terms</option>
+                    <option name="type" xsi:type="string">slide</option>
+                    <option name="responsive" xsi:type="boolean">true</option>
+                    <option name="innerScroll" xsi:type="boolean">true</option>
+                    <option name="autoOpen" xsi:type="boolean">false</option>
+                </options>
+            </settings>
+            <button name="search_terms_modal_button_back" displayArea="actions-secondary">
+                <argument name="data" xsi:type="array">
+                    <item name="config" xsi:type="array">
+                        <item name="buttonClasses" xsi:type="string">action-secondary</item>
+                        <item name="actions" xsi:type="array">
+                            <item name="0" xsi:type="array">
+                                <item name="targetName" xsi:type="string">smile_elasticsuite_catalog_optimizer_form.smile_elasticsuite_catalog_optimizer_form.quick_search_container.search_terms_modal</item>
+                                <item name="actionName" xsi:type="string">closeModal</item>
+                            </item>
+                        </item>
+                        <item name="title" xsi:type="string" translate="true">Cancel</item>
+                    </item>
+                </argument>
+            </button>
+            <button name="search_terms_modal_button_save" displayArea="actions-primary">
+                <argument name="data" xsi:type="array">
+                    <item name="config" xsi:type="array">
+                        <item name="buttonClasses" xsi:type="string">action-primary</item>
+                        <item name="actions" xsi:type="array">
+                            <item name="0" xsi:type="array">
+                                <item name="targetName" xsi:type="string">index = search_term_listing</item>
+                                <item name="actionName" xsi:type="string">save</item>
+                            </item>
+                            <item name="1" xsi:type="array">
+                                <item name="targetName" xsi:type="string">smile_elasticsuite_catalog_optimizer_form.smile_elasticsuite_catalog_optimizer_form.quick_search_container.search_terms_modal</item>
+                                <item name="actionName" xsi:type="string">closeModal</item>
+                            </item>
+                        </item>
+                        <item name="title" xsi:type="string" translate="true">Add Selected Terms</item>
+                    </item>
+                </argument>
+            </button>
+            <insertListing name="search_term_listing" component="Magento_Ui/js/form/components/insert-listing">
+                <settings>
+                    <externalProvider>${ $.ns }.search_term_listing_data_source</externalProvider>
+                    <selectionsProvider>${ $.ns }.${ $.ns }.search_term_listing_columns.ids</selectionsProvider>
+                    <realTimeLink>true</realTimeLink>
+                    <autoRender>true</autoRender>
+                    <externalFilterMode>true</externalFilterMode>
+                    <dataScope>search_term_listing</dataScope>
+                    <dataLinks>
+                        <imports>false</imports>
+                        <exports>true</exports>
+                    </dataLinks>
+                    <ns>search_term_listing</ns>
+                    <imports>
+                        <link name="optimizerId">${ $.provider }:data.optimizer_id</link>
+                    </imports>
+                    <exports>
+                        <link name="optimizerId">${ $.externalProvider }:params.optimizer_id</link>
+                    </exports>
+                    <links>
+                        <link name="value">${ $.provider }:${ $.ns }</link>
+                    </links>
+                </settings>
+            </insertListing>
+        </modal>
+    </fieldset>
+
+    <fieldset name="catalog_view_container">
+        <argument name="data" xsi:type="array">
+            <item name="config" xsi:type="array">
+                <item name="label" xsi:type="string" translate="true">Category Product View</item>
+                <item name="component" xsi:type="string">Smile_ElasticsuiteCatalogOptimizer/js/components/form/optimizer/fieldset-visibility</item>
+                <item name="imports" xsi:type="array">
+                    <item name="initValue" xsi:type="string">${ $.provider }:data.search_container</item>
+                </item>
+                <item name="listens" xsi:type="array">
+                    <item name="${ $.provider }:data.search_container" xsi:type="string">onChange</item>
+                </item>
+            </item>
+        </argument>
+
+        <field name="category_apply_to">
+            <argument name="data" xsi:type="array">
+                <item name="options" xsi:type="array">
+                    <item name="0" xsi:type="array">
+                        <item name="value" xsi:type="number">0</item>
+                        <item name="label" xsi:type="string" translate="true">All Categories</item>
+                    </item>
+                    <item name="1" xsi:type="array">
+                        <item name="value" xsi:type="number">1</item>
+                        <item name="label" xsi:type="string" translate="true">Selected categories</item>
+                    </item>
+                </item>
+                <item name="config" xsi:type="array">
+                    <item name="dataType" xsi:type="string">text</item>
+                    <item name="label" xsi:type="string" translate="true">Apply to</item>
+                    <item name="formElement" xsi:type="string">select</item>
+                    <item name="source" xsi:type="string">optimizer</item>
+                    <item name="dataScope" xsi:type="string">catalog_view_container.apply_to</item>
+                    <item name="sortOrder" xsi:type="number">10</item>
+                </item>
+            </argument>
+            <settings>
+                <switcherConfig>
+                    <rules>
+                        <rule name="0">
+                            <value>0</value>
+                            <actions>
+                                <action name="0">
+                                    <target>smile_elasticsuite_catalog_optimizer_form.smile_elasticsuite_catalog_optimizer_form.catalog_view_container.category_ids</target>
+                                    <callback>hide</callback>
+                                </action>
+                            </actions>
+                        </rule>
+                        <rule name="1">
+                            <value>1</value>
+                            <actions>
+                                <action name="0">
+                                    <target>smile_elasticsuite_catalog_optimizer_form.smile_elasticsuite_catalog_optimizer_form.catalog_view_container.category_ids</target>
+                                    <callback>show</callback>
+                                </action>
+                            </actions>
+                        </rule>
+                    </rules>
+                    <enabled>true</enabled>
+                </switcherConfig>
+            </settings>
+        </field>
+
+        <field name="category_ids">
+            <argument name="data" xsi:type="array">
+                <item name="options" xsi:type="object">Magento\Catalog\Ui\Component\Product\Form\Categories\Options</item>
+                <item name="config" xsi:type="array">
+                    <item name="label" xsi:type="string" translate="true">Apply to categories</item>
+                    <item name="componentType" xsi:type="string">field</item>
+                    <item name="formElement" xsi:type="string">select</item>
+                    <item name="component" xsi:type="string">Magento_Catalog/js/components/new-category</item>
+                    <item name="elementTmpl" xsi:type="string">ui/grid/filters/elements/ui-select</item>
+                    <item name="dataScope" xsi:type="string">catalog_view_container.category_ids</item>
+                    <item name="filterOptions" xsi:type="boolean">true</item>
+                    <item name="showCheckbox" xsi:type="boolean">false</item>
+                    <item name="disableLabel" xsi:type="boolean">true</item>
+                    <item name="multiple" xsi:type="boolean">true</item>
+                    <item name="levelsVisibility" xsi:type="number">1</item>
+                    <item name="required" xsi:type="boolean">true</item>
+                    <item name="sortOrder" xsi:type="number">20</item>
+                    <item name="validation" xsi:type="array">
+                        <item name="required-entry" xsi:type="boolean">true</item>
+                    </item>
+                    <item name="listens" xsi:type="array">
+                        <item name="${ $.namespace }.${ $.namespace }:responseData" xsi:type="string">setParsed</item>
+                    </item>
+                </item>
+            </argument>
+        </field>
+    </fieldset>
+
     <fieldset name="constant_score">
         <argument name="data" xsi:type="array">
             <item name="config" xsi:type="array">

--- a/src/module-elasticsuite-catalog-optimizer/view/adminhtml/web/js/components/form/optimizer/fieldset-visibility.js
+++ b/src/module-elasticsuite-catalog-optimizer/view/adminhtml/web/js/components/form/optimizer/fieldset-visibility.js
@@ -19,16 +19,19 @@ define(['Magento_Ui/js/form/components/fieldset'], function(Fieldset) {
                 "initValue": "${ $.provider }:data.model"
             },
             listens: {
-                "${ $.provider }:data.model" : "onModelChange"
+                "${ $.provider }:data.model" : "onChange"
             }
         },
         initialize: function() {
             this._super();
             this.observe(['disableChildren']);
-            this.onModelChange(this.initValue);
+            this.onChange(this.initValue);
         },
-        onModelChange: function(value)  {
+        onChange: function(value)  {
             var isVisible = this.index == value;
+            if (Array.isArray(value)) {
+                isVisible = (value.indexOf(this.index) !== -1);
+            }
             this.visible(isVisible);
             this.disableChildren(!isVisible);
         }

--- a/src/module-elasticsuite-catalog/Ui/Component/Search/Term/Listing/DataProvider.php
+++ b/src/module-elasticsuite-catalog/Ui/Component/Search/Term/Listing/DataProvider.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\ElasticsuiteCatalog
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2018 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\ElasticsuiteCatalog\Ui\Component\Search\Term\Listing;
+
+/**
+ * Search terms listing data provider.
+ *
+ * @category Smile
+ * @package  Smile\ElasticsuiteCatalog
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class DataProvider extends \Magento\Ui\DataProvider\AbstractDataProvider
+{
+    /**
+     * Search term collection
+     *
+     * @var \Magento\Search\Model\ResourceModel\Query\Collection
+     */
+    protected $collection;
+
+    /**
+     * @var \Magento\Ui\DataProvider\AddFieldToCollectionInterface[]
+     */
+    protected $addFieldStrategies;
+
+    /**
+     * @var \Magento\Ui\DataProvider\AddFilterToCollectionInterface[]
+     */
+    protected $addFilterStrategies;
+
+    /**
+     * Construct
+     *
+     * @param string                                                      $name                Component name
+     * @param string                                                      $primaryFieldName    Primary field Name
+     * @param string                                                      $requestFieldName    Request field name
+     * @param \Magento\Search\Model\ResourceModel\Query\CollectionFactory $collectionFactory   The collection factory
+     * @param \Magento\Ui\DataProvider\AddFieldToCollectionInterface[]    $addFieldStrategies  Add field Strategy
+     * @param \Magento\Ui\DataProvider\AddFilterToCollectionInterface[]   $addFilterStrategies Add filter Strategy
+     * @param array                                                       $meta                Component Meta
+     * @param array                                                       $data                Component extra data
+     */
+    public function __construct(
+        $name,
+        $primaryFieldName,
+        $requestFieldName,
+        $collectionFactory,
+        array $addFieldStrategies = [],
+        array $addFilterStrategies = [],
+        array $meta = [],
+        array $data = []
+    ) {
+        parent::__construct($name, $primaryFieldName, $requestFieldName, $meta, $data);
+
+        $this->collection = $collectionFactory->create();
+
+        $this->addFieldStrategies  = $addFieldStrategies;
+        $this->addFilterStrategies = $addFilterStrategies;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addField($field, $alias = null)
+    {
+        if (isset($this->addFieldStrategies[$field])) {
+            $this->addFieldStrategies[$field]->addField($this->getCollection(), $field, $alias);
+
+            return;
+        }
+
+        parent::addField($field, $alias);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addFilter(\Magento\Framework\Api\Filter $filter)
+    {
+        if (isset($this->addFilterStrategies[$filter->getField()])) {
+            $this->addFilterStrategies[$filter->getField()]
+                ->addFilter(
+                    $this->getCollection(),
+                    $filter->getField(),
+                    [$filter->getConditionType() => $filter->getValue()]
+                );
+
+            return;
+        }
+
+        parent::addFilter($filter);
+    }
+}

--- a/src/module-elasticsuite-catalog/view/adminhtml/ui_component/search_term_listing.xml
+++ b/src/module-elasticsuite-catalog/view/adminhtml/ui_component/search_term_listing.xml
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Search Terms listing UI Component.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\ElasticsuiteCatalogOptimizer
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2018 Smile
+ * @license   Apache License Version 2.0
+ */
+-->
+<listing xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
+    <argument name="data" xsi:type="array">
+        <item name="js_config" xsi:type="array">
+            <item name="provider" xsi:type="string">search_term_listing.search_term_listing_data_source</item>
+            <item name="deps" xsi:type="string">search_term_listing.search_term_listing_data_source</item>
+        </item>
+        <item name="spinner" xsi:type="string">search_term_listing_columns</item>
+        <item name="buttons" xsi:type="array">
+            <item name="add" xsi:type="array">
+                <item name="name" xsi:type="string">add</item>
+                <item name="label" xsi:type="string" translate="true">Add New Optimizer</item>
+                <item name="class" xsi:type="string">primary</item>
+                <item name="url" xsi:type="string">*/*/create</item>
+            </item>
+        </item>
+    </argument>
+    <dataSource name="search_term_listing_data_source">
+        <argument name="dataProvider" xsi:type="configurableObject">
+            <argument name="class" xsi:type="string">Smile\ElasticsuiteCatalog\Ui\Component\Search\Term\Listing\DataProvider</argument>
+            <argument name="name" xsi:type="string">search_term_listing_data_source</argument>
+            <argument name="primaryFieldName" xsi:type="string">query_id</argument>
+            <argument name="requestFieldName" xsi:type="string">id</argument>
+            <argument name="collectionFactory" xsi:type="object">Magento\Search\Model\ResourceModel\Query\CollectionFactory</argument>
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="component" xsi:type="string">Magento_Ui/js/grid/provider</item>
+                    <item name="update_url" xsi:type="url" path="mui/index/render"/>
+                    <item name="storageConfig" xsi:type="array">
+                        <item name="indexField" xsi:type="string">query_id</item>
+                    </item>
+                </item>
+            </argument>
+        </argument>
+    </dataSource>
+    <listingToolbar name="listing_top">
+        <argument name="data" xsi:type="array">
+            <item name="config" xsi:type="array">
+                <item name="sticky" xsi:type="boolean">true</item>
+            </item>
+        </argument>
+        <bookmark name="bookmarks"/>
+        <columnsControls name="columns_controls"/>
+        <filters name="listing_filters">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="templates" xsi:type="array">
+                        <item name="filters" xsi:type="array">
+                            <item name="select" xsi:type="array">
+                                <item name="component" xsi:type="string">Magento_Ui/js/form/element/ui-select</item>
+                                <item name="template" xsi:type="string">ui/grid/filters/elements/ui-select</item>
+                            </item>
+                        </item>
+                    </item>
+                </item>
+                <item name="observers" xsi:type="array">
+                    <item name="column" xsi:type="string">column</item>
+                </item>
+            </argument>
+            <filterSelect name="store_id">
+                <argument name="optionsProvider" xsi:type="configurableObject">
+                    <argument name="class" xsi:type="string">Magento\Store\Ui\Component\Listing\Column\Store\Options</argument>
+                </argument>
+                <argument name="data" xsi:type="array">
+                    <item name="config" xsi:type="array">
+                        <item name="provider" xsi:type="string">${ $.parentName }</item>
+                        <item name="dataScope" xsi:type="string">store_id</item>
+                        <item name="caption" xsi:type="string" translate="true">All Store Views</item>
+                        <item name="label" xsi:type="string" translate="true">Store View</item>
+                    </item>
+                </argument>
+            </filterSelect>
+        </filters>
+        <paging name="listing_paging"/>
+    </listingToolbar>
+    <columns name="search_term_listing_columns">
+        <argument name="data" xsi:type="array">
+            <item name="config" xsi:type="array">
+                <item name="childDefaults" xsi:type="array">
+                    <item name="fieldAction" xsi:type="array">
+                        <item name="provider" xsi:type="string">search_term_listing.search_term_listing.search_term_listing_columns.actions</item>
+                        <item name="target" xsi:type="string">applyAction</item>
+                        <item name="params" xsi:type="array">
+                            <item name="0" xsi:type="string">edit</item>
+                            <item name="1" xsi:type="string">${ $.$data.rowIndex }</item>
+                        </item>
+                    </item>
+                </item>
+            </item>
+        </argument>
+        <selectionsColumn name="ids">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="resizeEnabled" xsi:type="boolean">false</item>
+                    <item name="resizeDefaultWidth" xsi:type="string">55</item>
+                    <item name="indexField" xsi:type="string">query_id</item>
+                </item>
+            </argument>
+        </selectionsColumn>
+        <column name="query_id">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="filter" xsi:type="string">textRange</item>
+                    <item name="add_field" xsi:type="boolean">true</item>
+                    <item name="sorting" xsi:type="string">asc</item>
+                    <item name="label" xsi:type="string" translate="true">ID</item>
+                    <item name="sortOrder" xsi:type="number">10</item>
+                </item>
+            </argument>
+        </column>
+        <column name="query_text">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="filter" xsi:type="string">text</item>
+                    <item name="add_field" xsi:type="boolean">true</item>
+                    <item name="label" xsi:type="string" translate="true">Query Text</item>
+                    <item name="sortOrder" xsi:type="number">20</item>
+                </item>
+            </argument>
+        </column>
+        <column name="store_id" class="Magento\Store\Ui\Component\Listing\Column\Store">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="bodyTmpl" xsi:type="string">ui/grid/cells/html</item>
+                    <item name="sortable" xsi:type="boolean">false</item>
+                    <item name="label" xsi:type="string" translate="true">Store View</item>
+                    <item name="add_field" xsi:type="boolean">true</item>
+                    <item name="sortOrder" xsi:type="number">30</item>
+                </item>
+            </argument>
+        </column>
+        <column name="is_spellchecked" class="Smile\ElasticsuiteCatalogOptimizer\Ui\Component\Listing\Column\YesNo">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="filter" xsi:type="string">select</item>
+                    <item name="dataType" xsi:type="string">text</item>
+                    <item name="label" xsi:type="string" translate="true">Is Spellchecked</item>
+                    <item name="add_field" xsi:type="boolean">true</item>
+                    <item name="sortOrder" xsi:type="number">40</item>
+                </item>
+            </argument>
+        </column>
+    </columns>
+</listing>


### PR DESCRIPTION
Just a proposal of UX for the conditional behavior of the optimizers.

Actually, I decided to keep the "Request Type" selector. It will show/hide an additional fieldset according to which request type you choose : 

-  Category Product View fieldset
--- Apply to : "all categories" / "selected categories"
--- A category picker is shown if "selected categories" is chosen

- Catalog Product Search fieldset
--- Apply to "all search requests" / "selected requests"
--- A dynamic grid can be opened and filled if "selected requests" is chosen


That's where I am now. I'm thinking on switch the "selected" pattern to an exclusion, or maybe to allow both inclusion and exclusion, I'm not sure what is the more user friendly.

Btw, this UX is a bit complex (dynamicRows linked to a grid opening in a slide popup) but it only required me to write XML to get it working !