### PR TITLE
Avoid null pointer exception when storeId is not defined

### DIFF
--- a/src/module-elasticsuite-virtual-category/Model/Rule.php
+++ b/src/module-elasticsuite-virtual-category/Model/Rule.php
@@ -352,6 +352,8 @@ class Rule extends \Smile\ElasticsuiteCatalogRule\Model\Rule implements VirtualR
     {
         if (is_numeric($store) || is_string($store)) {
             $store = $this->storeManager->getStore($store);
+        } elseif (is_null($store)) {
+            $store = $this->storeManager->getStore();
         }
 
         $storeGroupId = $store->getStoreGroupId();


### PR DESCRIPTION
I have an issue that I can't exactly reproduce on a test environment... All I know, is once some setup has been done with virtual categories, I have a null pointer error on search results, coming from this snippet.

I've fixed this with the most logic code (and it works) for me, but I can't tell if something else should be done.
Feel free to send me feedback.