### PR TITLE
Change the implemented interface of the Elasticsuite Search Engine.

### DIFF
--- a/src/module-elasticsuite-core/Model/Search.php
+++ b/src/module-elasticsuite-core/Model/Search.php
@@ -20,7 +20,7 @@ namespace Smile\ElasticSuiteCore\Model;
  * @package  Smile\ElasticsuiteCore
  * @author    Aurelien FOUCRET <aurelien.foucret@smile.fr>
  */
-class Search implements \Magento\Framework\Api\Search\SearchInterface
+class Search implements \Magento\Search\Api\SearchInterface
 {
     /**
      * @var \Smile\ElasticsuiteCore\Model\Search\RequestBuilder


### PR DESCRIPTION
This one is a pre-requisite for fixing #855 

This is just changing the implemented interface from `\Magento\Framework\Api\Search\SearchInterface` to `\Magento\Search\Api\SearchInterface`.

The `\Magento\Search\Api\SearchInterface` is an `@api` flagged one also, and is empty and just inheriting the `\Magento\Framework\Api\Search\SearchInterface` : https://github.com/magento/magento2/blob/2.2-develop/app/code/Magento/Search/Api/SearchInterface.php

So for me, this is not too much risky to inherit this interface instead of the previous one, since they are the same for now. Also, the new interface is part of the `Magento_Search` module but we already depend on it.

Regards