### PR TITLE
Prevent building cross-tree virtual categories.

### DIFF
--- a/src/module-elasticsuite-catalog-rule/Block/Product/Conditions.php
+++ b/src/module-elasticsuite-catalog-rule/Block/Product/Conditions.php
@@ -105,6 +105,10 @@ class Conditions extends Template implements RendererInterface
             'element_name' => $this->getElement()->getName(),
         ];
 
+        if (is_array($this->getData('url_params'))) {
+            $urlParams = array_merge($urlParams, $this->getData('url_params'));
+        }
+
         return $this->getUrl('catalog_search_rule/product_rule/conditions', $urlParams);
     }
 
@@ -153,6 +157,50 @@ class Conditions extends Template implements RendererInterface
         $this->input = $this->elementFactory->create('text');
         $this->input->setRule($this->rule)->setRenderer($this->conditions);
 
+        $this->setConditionFormName($this->rule->getConditions(), $this->getElement()->getContainer()->getHtmlId());
+
+        if (is_array($this->getData('url_params'))) {
+            $this->setConditionUrlParams($this->rule->getConditions(), $this->getData('url_params'));
+        }
+
         return $this->input->toHtml();
+    }
+
+    /**
+     * Set proper form name to rule conditions.
+     *
+     * @param \Magento\Rule\Model\Condition\AbstractCondition $conditions Rule conditions.
+     * @param string                                          $formName   Form Name.
+     *
+     * @return void
+     */
+    private function setConditionFormName(\Magento\Rule\Model\Condition\AbstractCondition $conditions, $formName)
+    {
+        $conditions->setJsFormObject($formName);
+
+        if ($conditions->getConditions() && is_array($conditions->getConditions())) {
+            foreach ($conditions->getConditions() as $condition) {
+                $this->setConditionFormName($condition, $formName);
+            }
+        }
+    }
+
+    /**
+     * Set proper url params to rule conditions.
+     *
+     * @param \Magento\Rule\Model\Condition\AbstractCondition $conditions Rule conditions.
+     * @param array                                           $urlParams  URL Params.
+     *
+     * @return void
+     */
+    private function setConditionUrlParams(\Magento\Rule\Model\Condition\AbstractCondition $conditions, $urlParams)
+    {
+        $conditions->setUrlParams($urlParams);
+
+        if ($conditions->getConditions() && is_array($conditions->getConditions())) {
+            foreach ($conditions->getConditions() as $condition) {
+                $this->setConditionUrlParams($condition, $urlParams);
+            }
+        }
     }
 }

--- a/src/module-elasticsuite-catalog-rule/Controller/Adminhtml/Product/Rule/Conditions.php
+++ b/src/module-elasticsuite-catalog-rule/Controller/Adminhtml/Product/Rule/Conditions.php
@@ -80,6 +80,7 @@ class Conditions extends Action
         $result = '';
         if ($model instanceof AbstractCondition) {
             $model->setJsFormObject($this->getRequest()->getParam('form'));
+            $model->setData('url_params', $this->getRequest()->getParams());
             $result = $model->asHtmlRecursive();
         }
         $this->getResponse()->setBody($result);

--- a/src/module-elasticsuite-virtual-category/Block/Adminhtml/Catalog/Category/Checkboxes/Tree.php
+++ b/src/module-elasticsuite-virtual-category/Block/Adminhtml/Catalog/Category/Checkboxes/Tree.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\ElasticsuiteVirtualCategory
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2018 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\ElasticsuiteVirtualCategory\Block\Adminhtml\Catalog\Category\Checkboxes;
+
+/**
+ * Custom Categories checkboxes tree.
+ *
+ * Extends the legacy block to be able to limit the displayed tree to the current category upper root.
+ *
+ * @category Smile
+ * @package  Smile\ElasticsuiteVirtualCategory
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class Tree extends \Magento\Catalog\Block\Adminhtml\Category\Checkboxes\Tree
+{
+    /**
+     * {@inheritdoc}
+     *
+     * Overridden to load only Root of the current category if needed.
+     */
+    public function getRoot($parentNodeCategory = null, $recursionLevel = 3)
+    {
+        if ($parentNodeCategory === null) {
+            if ($this->getCurrentCategoryId()) {
+                $this->getRootByIds([$this->getCurrentCategoryId()]);
+            }
+        }
+
+        return parent::getRoot($parentNodeCategory, $recursionLevel);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Overridden to exclude other trees than the current category.
+     */
+    public function getCategoryCollection()
+    {
+        $collection = parent::getCategoryCollection();
+
+        // Previous call to $this->getRootByIds() will exclude all other category trees but keep their root.
+        // Now we exclude all root categories except root associated to the current one.
+        if ($this->getCurrentCategory()) {
+            $rootPath      = array_slice($this->getCurrentCategory()->getPathIds(), 0, 2);
+            $pathCondition = implode('/', $rootPath) . '%';
+            $collection->addFieldToFilter('path', ['like' => $pathCondition]);
+
+            // We also exclude current category, to prevent inception.
+            $collection->addFieldToFilter('entity_id', ['neq' => $this->getCurrentCategory()->getId()]);
+
+            // Overwrite collection already set in parent call.
+            $this->setData('category_collection', $collection);
+        }
+
+        return $collection;
+    }
+
+    /**
+     * @SuppressWarnings(PHPMD.CamelCaseMethodName)
+     *
+     * {@inheritdoc}
+     */
+    protected function _prepareLayout()
+    {
+        parent::_prepareLayout();
+        $this->setTemplate('Magento_Catalog::catalog/category/checkboxes/tree.phtml');
+    }
+}

--- a/src/module-elasticsuite-virtual-category/Block/Adminhtml/Catalog/Category/VirtualRule.php
+++ b/src/module-elasticsuite-virtual-category/Block/Adminhtml/Catalog/Category/VirtualRule.php
@@ -90,6 +90,10 @@ class VirtualRule extends \Magento\Backend\Block\AbstractBlock
 
         $virtualRuleField->setValue($this->getCategory()->getVirtualRule());
         $virtualRuleRenderer = $this->getLayout()->createBlock('Smile\ElasticsuiteCatalogRule\Block\Product\Conditions');
+
+        $urlParams = ['category_id' => $this->getCategory()->getId()];
+
+        $virtualRuleRenderer->addData(['url_params' => $urlParams]);
         $virtualRuleField->setRenderer($virtualRuleRenderer);
 
         return $form;

--- a/src/module-elasticsuite-virtual-category/Model/Rule.php
+++ b/src/module-elasticsuite-virtual-category/Model/Rule.php
@@ -352,7 +352,7 @@ class Rule extends \Smile\ElasticsuiteCatalogRule\Model\Rule implements VirtualR
     {
         if (is_numeric($store) || is_string($store)) {
             $store = $this->storeManager->getStore($store);
-        } elseif (is_null($store)) {
+        } elseif (null === $store) {
             $store = $this->storeManager->getStore();
         }
 

--- a/src/module-elasticsuite-virtual-category/Model/Rule/Condition/Product.php
+++ b/src/module-elasticsuite-virtual-category/Model/Rule/Condition/Product.php
@@ -102,6 +102,22 @@ class Product extends \Smile\ElasticsuiteCatalogRule\Model\Rule\Condition\Produc
     }
 
     /**
+     * Retrieve value element chooser URL
+     *
+     * @return string
+     */
+    public function getValueElementChooserUrl()
+    {
+        $url = parent::getValueElementChooserUrl();
+
+        if ($this->getAttribute() === 'category_ids') {
+            $url = $this->getCategoryChooserUrl();
+        }
+
+        return $url;
+    }
+
+    /**
      * Retrieve a query used to apply category filter rule.
      *
      * @param array $excludedCategories Category excluded from the loading (avoid infinite loop in query
@@ -130,5 +146,31 @@ class Product extends \Smile\ElasticsuiteCatalogRule\Model\Rule\Condition\Produc
         }
 
         return $query;
+    }
+
+    /**
+     * Get category chooser Url.
+     * Might be contextualised according to current object data, if needed.
+     * This will allow the Ajax call to the chooser to transfer current context (especially category_id).
+     *
+     * @return string
+     */
+    private function getCategoryChooserUrl()
+    {
+        $url = 'catalog_rule/promo_widget/chooser/attribute/' . $this->getAttribute();
+
+        $chooserUrlParams = [];
+        if ($this->getJsFormObject()) {
+            $chooserUrlParams['form'] = $this->getJsFormObject();
+        }
+
+        $urlParams = $this->getUrlParams();
+        if ($urlParams && is_array($urlParams) && isset($urlParams['category_id'])) {
+            $chooserUrlParams['category_id'] = $urlParams['category_id'];
+        }
+
+        $url = $this->_backendData->getUrl($url, $chooserUrlParams);
+
+        return $url;
     }
 }

--- a/src/module-elasticsuite-virtual-category/Plugin/Catalog/Category/ChooserPlugin.php
+++ b/src/module-elasticsuite-virtual-category/Plugin/Catalog/Category/ChooserPlugin.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\ElasticsuiteVirtualCategory
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2017 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\ElasticsuiteVirtualCategory\Plugin\Catalog\Category;
+
+/**
+ * Plugin on Catalog Category Widget Chooser controller.
+ *
+ * Used to change the block class used when editing virtual category rule.
+ *
+ * @category Smile
+ * @package  Smile\ElasticsuiteVirtualCategory
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ */
+class ChooserPlugin
+{
+    /**
+     * @var \Magento\Framework\View\LayoutInterface
+     */
+    private $layout;
+
+    /**
+     * @var \Magento\Catalog\Api\CategoryRepositoryInterface
+     */
+    private $categoryRepository;
+
+    /**
+     * ChooserPlugin constructor.
+     *
+     * @param \Magento\Framework\View\LayoutInterface          $layoutInterface    Layout
+     * @param \Magento\Catalog\Api\CategoryRepositoryInterface $categoryRepository Category Repository
+     */
+    public function __construct(
+        \Magento\Framework\View\LayoutInterface $layoutInterface,
+        \Magento\Catalog\Api\CategoryRepositoryInterface $categoryRepository
+    ) {
+        $this->layout = $layoutInterface;
+        $this->categoryRepository = $categoryRepository;
+    }
+
+    /**
+     * Plugin on execute() function of the category chooser controller.
+     * Done via a plugin instead of layout because legacy controller is already creating block via getLayout()->createBlock().
+     *
+     * @param \Magento\CatalogRule\Controller\Adminhtml\Promo\Widget\Chooser $controller The controller
+     * @param \Closure                                                       $proceed    The execute() function
+     *
+     * @return mixed
+     */
+    public function aroundExecute(
+        \Magento\CatalogRule\Controller\Adminhtml\Promo\Widget\Chooser $controller,
+        \Closure $proceed
+    ) {
+        // Exit if we are not building a category chooser.
+        if ($controller->getRequest()->getParam('attribute') !== 'category_ids') {
+            return $proceed();
+        }
+
+        // Fallback to legacy action if there is no category context.
+        if ($controller->getRequest()->getParam('category_id') === null) {
+            return $proceed();
+        }
+
+        // Retrieve current category.
+        $category = $this->categoryRepository->get($controller->getRequest()->getParam('category_id'));
+
+        $block = $this->layout->createBlock(
+            \Smile\ElasticsuiteVirtualCategory\Block\Adminhtml\Catalog\Category\Checkboxes\Tree::class,
+            'promo_widget_chooser_category_ids',
+            [
+                'data' => [
+                    'js_form_object'   => $controller->getRequest()->getParam('form'),
+                    'current_category' => $category,
+                ],
+            ]
+        )->setCategoryIds(
+            $this->getIds($controller)
+        );
+
+        $controller->getResponse()->setBody($block->toHtml());
+    }
+
+    /**
+     * Retrieve currently selected Ids.
+     *
+     * @param \Magento\Backend\App\Action $controller The controller
+     *
+     * @return array
+     */
+    private function getIds($controller)
+    {
+        $ids = $controller->getRequest()->getParam('selected', []);
+
+        if (!is_array($ids)) {
+            $ids = [];
+        }
+
+        foreach ($ids as $key => &$id) {
+            $id = (int) $id;
+            if ($id <= 0) {
+                unset($ids[$key]);
+            }
+        }
+
+        return array_unique($ids);
+    }
+}

--- a/src/module-elasticsuite-virtual-category/etc/adminhtml/di.xml
+++ b/src/module-elasticsuite-virtual-category/etc/adminhtml/di.xml
@@ -26,4 +26,7 @@
     <!-- Overridden directly because this block is called via hardcoded calls -->
     <preference for="\Magento\Catalog\Block\Adminhtml\Category\Tab\Product" type="Smile\ElasticsuiteVirtualCategory\Block\Adminhtml\Catalog\Category\Tab\Product"/>
 
+    <type name="\Magento\CatalogRule\Controller\Adminhtml\Promo\Widget\Chooser">
+        <plugin name="category_chooser_plugin" type="Smile\ElasticsuiteVirtualCategory\Plugin\Catalog\Category\ChooserPlugin"/>
+    </type>
 </config>


### PR DESCRIPTION
This one was more painful to do than I expected because it's kinda hard to inject the context (current category) and to keep it along all ajax requests used by the rule form (even this form has different behavior when adding a new condition or when editing a previously created one).

Actually this prevent you from creating a "Category" condition outside of the current category tree.
It also prevent the user to create a "Category" condition on the same category.

Imho another PR (or new commit on this one ?) will be needed to prevent the same thing for the "Category Root".

Let me know,