### PR TITLE
Add dependency to Magento_LayeredNavigationStaging for Smile_ElasticsuiteCatalog. 

### DIFF
--- a/src/module-elasticsuite-catalog/etc/module.xml
+++ b/src/module-elasticsuite-catalog/etc/module.xml
@@ -24,6 +24,7 @@
             <module name="Magento_CatalogSearch" />
             <module name="Magento_LayeredNavigation" />
             <module name="Magento_CatalogInventory" />
+            <module name="Magento_LayeredNavigationStaging" />
         </sequence>
     </module>
 </config>


### PR DESCRIPTION
Fix #886.

@romainruaud : can you test it please.