### PR TITLE
Omit page tracking variables in disabled

### DIFF
--- a/src/module-elasticsuite-tracker/Block/Variables/AbstractBlock.php
+++ b/src/module-elasticsuite-tracker/Block/Variables/AbstractBlock.php
@@ -66,6 +66,16 @@ class AbstractBlock extends \Magento\Framework\View\Element\Template
         $this->registry      = $registry;
     }
 
+    /**
+     * Check that the module is currently enabled
+     *
+     * @return bool
+     */
+    public function isEnabled()
+    {
+        return $this->trackerHelper->isEnabled();
+    }
+
 
     /**
      * Retrieve the Json Helper

--- a/src/module-elasticsuite-tracker/view/frontend/templates/variables/page.phtml
+++ b/src/module-elasticsuite-tracker/view/frontend/templates/variables/page.phtml
@@ -17,7 +17,7 @@
 <?php /** @var $block Smile\ElasticsuiteTracker\Block\Variables\AbstractBlock **/ ?>
 <?php $variables = $block->getVariables(); ?>
 
-<?php if (!empty($variables)) : ?>
+<?php if ($block->isEnabled() && !empty($variables)) : ?>
     <script type="text/javascript">
     <!--
     <?php foreach ($variables as $varName => $value) : ?>


### PR DESCRIPTION
This will fix the following error from the browser console,
when Smile_ElasticsuiteTracker is disabled:

`Uncaught ReferenceError: smileTracker is not defined`