### PR TITLE
Make the InventoryData resource model easier to extend/replace

### DIFF
--- a/src/module-elasticsuite-catalog/Model/Product/Indexer/Fulltext/Datasource/InventoryData.php
+++ b/src/module-elasticsuite-catalog/Model/Product/Indexer/Fulltext/Datasource/InventoryData.php
@@ -13,7 +13,7 @@
 namespace Smile\ElasticsuiteCatalog\Model\Product\Indexer\Fulltext\Datasource;
 
 use Smile\ElasticsuiteCore\Api\Index\DatasourceInterface;
-use Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Indexer\Fulltext\Datasource\InventoryData as ResourceModel;
+use Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Indexer\Fulltext\Datasource\InventoryDataInterface;
 
 /**
  * Datasource used to append inventory data to product during indexing.
@@ -25,16 +25,16 @@ use Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Indexer\Fulltext\Datas
 class InventoryData implements DatasourceInterface
 {
     /**
-     * @var \Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Indexer\Fulltext\Datasource\InventoryData
+     * @var InventoryDataInterface
      */
     private $resourceModel;
 
     /**
      * Constructor.
      *
-     * @param ResourceModel $resourceModel Resource model.
+     * @param InventoryDataInterface $resourceModel Resource model.
      */
-    public function __construct(ResourceModel $resourceModel)
+    public function __construct(InventoryDataInterface $resourceModel)
     {
         $this->resourceModel = $resourceModel;
     }

--- a/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Indexer/Fulltext/Datasource/InventoryData.php
+++ b/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Indexer/Fulltext/Datasource/InventoryData.php
@@ -26,23 +26,23 @@ use Smile\ElasticsuiteCatalog\Model\ResourceModel\Eav\Indexer\Indexer;
  * @package  Smile\ElasticsuiteCatalog
  * @author   Romain Ruaud <romain.ruaud@smile.fr>
  */
-class InventoryData extends Indexer
+class InventoryData extends Indexer implements InventoryDataInterface
 {
     /**
      * @var \Magento\CatalogInventory\Api\StockRegistryInterface
      */
-    private $stockRegistry;
+    protected $stockRegistry;
 
 
     /**
      * @var \Magento\CatalogInventory\Api\StockConfigurationInterface
      */
-    private $stockConfiguration;
+    protected $stockConfiguration;
 
     /**
      * @var int[]
      */
-    private $stockIdByWebsite = [];
+    protected $stockIdByWebsite = [];
 
     /**
      * InventoryData constructor.
@@ -67,12 +67,7 @@ class InventoryData extends Indexer
     }
 
     /**
-     * Load inventory data for a list of product ids and a given store.
-     *
-     * @param integer $storeId    Store id.
-     * @param array   $productIds Product ids list.
-     *
-     * @return array
+     * {@inheritdoc}
      */
     public function loadInventoryData($storeId, $productIds)
     {
@@ -95,7 +90,7 @@ class InventoryData extends Indexer
      *
      * @return int
      */
-    private function getStockId($websiteId)
+    protected function getStockId($websiteId)
     {
         if (!isset($this->stockIdByWebsite[$websiteId])) {
             $stockId = $this->stockRegistry->getStock($websiteId)->getStockId();
@@ -112,7 +107,7 @@ class InventoryData extends Indexer
      *
      * @return int
      */
-    private function getWebsiteId($storeId)
+    protected function getWebsiteId($storeId)
     {
         return $this->storeManager->getStore($storeId)->getWebsiteId();
     }

--- a/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Indexer/Fulltext/Datasource/InventoryDataInterface.php
+++ b/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Indexer/Fulltext/Datasource/InventoryDataInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Indexer\Fulltext\Datasource;
+
+interface InventoryDataInterface
+{
+    /**
+     * Load inventory data for a list of product ids and a given store.
+     *
+     * @param integer $storeId    Store id.
+     * @param array   $productIds Product ids list.
+     *
+     * @return array
+     */
+    public function loadInventoryData($storeId, $productIds);
+}

--- a/src/module-elasticsuite-catalog/etc/di.xml
+++ b/src/module-elasticsuite-catalog/etc/di.xml
@@ -17,6 +17,8 @@
  -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
 
+    <preference for="Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Indexer\Fulltext\Datasource\InventoryDataInterface" type="Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Indexer\Fulltext\Datasource\InventoryData" />
+
     <virtualType name="catalogProductSearchIndexHandler" type="\Smile\ElasticsuiteCore\Indexer\GenericIndexerHandler">
         <arguments>
             <argument name="indexName" xsi:type="string">catalog_product</argument>


### PR DESCRIPTION
I wanted to rewrite parts of the `loadInventoryData` method but it seems like I can't do it easily without replacing the datasource because:

- I couldn't inherit the class or use a plugin because the class attributes and methods are all `private`.
- I couldn't switch the ResourceModel class to an other class because the construct parameter must be of InventoryData  resource model type, which I can't because of the first reason.

That is why I offer this solution to both of these problems if someone needs to inherit the current InventoryData resource model class or change the class entirely.