### PR TITLE
Add default tax class rate to the price index

### DIFF
--- a/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Indexer/Fulltext/Datasource/PriceData.php
+++ b/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Indexer/Fulltext/Datasource/PriceData.php
@@ -14,7 +14,12 @@
 
 namespace Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Indexer\Fulltext\Datasource;
 
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\EntityManager\MetadataPool;
+use Magento\Store\Model\Store;
+use Magento\Store\Model\StoreManagerInterface;
 use Smile\ElasticsuiteCatalog\Model\ResourceModel\Eav\Indexer\Indexer;
+use Magento\Eav\Model\ResourceModel\Entity\Attribute;
 
 /**
  * Prices data datasource resource model.
@@ -25,6 +30,24 @@ use Smile\ElasticsuiteCatalog\Model\ResourceModel\Eav\Indexer\Indexer;
  */
 class PriceData extends Indexer
 {
+    /**
+     * @var Attribute
+     */
+    private $eavAttribute;
+
+    public function __construct(
+        ResourceConnection $resource,
+        StoreManagerInterface $storeManager,
+        MetadataPool $metadataPool,
+        Attribute $eavAttribute
+    )
+    {
+        $this->eavAttribute = $eavAttribute;
+
+        parent::__construct($resource, $storeManager, $metadataPool);
+    }
+
+
     /**
      * Load prices data for a list of product ids and a given store.
      *
@@ -37,11 +60,36 @@ class PriceData extends Indexer
     {
         $websiteId = $this->getStore($storeId)->getWebsiteId();
 
+        $taxClassAttrId = $this->eavAttribute->getIdByCode('catalog_product', 'tax_class_id');
+
         $select = $this->getConnection()->select()
             ->from(['p' => $this->getTable('catalog_product_index_price')])
+            ->join(
+                ['tcd' => $this->getTable('catalog_product_entity_int')],
+                $this->taxClassJoinCondition('tcd', $taxClassAttrId, Store::DEFAULT_STORE_ID),
+                []
+            )
+            ->joinLeft(
+                ['tcs' => $this->getTable('catalog_product_entity_int')],
+                $this->taxClassJoinCondition('tcs', $taxClassAttrId, $storeId),
+                []
+            )
+            ->columns([
+                'tax_class_id' => 'IFNULL(tcs.value, tcd.value)'
+            ])
             ->where('p.website_id = ?', $websiteId)
             ->where('p.entity_id IN(?)', $productIds);
 
         return $this->getConnection()->fetchAll($select);
+    }
+
+    private function taxClassJoinCondition($alias, $taxClassAttrId, $storeId)
+    {
+        return join(' AND ', [
+                $alias . '.row_id = p.entity_id',
+                $this->getConnection()->quoteInto($alias . '.store_id = ?', $storeId),
+                $this->getConnection()->quoteInto($alias . '.attribute_id = ?', $taxClassAttrId)
+            ]
+        );
     }
 }


### PR DESCRIPTION
Hi!

This PR is related to this issue: #571

This is an attempt at fixing the price index so that it includes the default store tax.

In order to recover this tax, I added the `tax_class_id` to the price index request to limit the performance impact.

I'm not yet sure about the `$this->taxCalculation->getCalculatedRate` call in terms of performance, though it seems like the rate recovery is cached:
https://github.com/magento/magento2/blob/50f974b0c8f3ada8d7a2c9b0f9924976dacd2088/app/code/Magento/Tax/Model/Calculation.php#L362-L378