### PR TITLE
Allow Subclasses of backend models to be indexed

### DIFF
--- a/src/module-elasticsuite-catalog/Model/Eav/Indexer/Fulltext/Datasource/AbstractAttributeData.php
+++ b/src/module-elasticsuite-catalog/Model/Eav/Indexer/Fulltext/Datasource/AbstractAttributeData.php
@@ -62,13 +62,13 @@ abstract class AbstractAttributeData
      * @var array
      */
     protected $indexedBackendModels = [
-        'Magento\Eav\Model\Entity\Attribute\Backend\ArrayBackend',
-        'Magento\Eav\Model\Entity\Attribute\Backend\Datetime',
-        'Magento\Catalog\Model\Attribute\Backend\Startdate',
-        'Magento\Catalog\Model\Product\Attribute\Backend\Boolean',
-        'Magento\Eav\Model\Entity\Attribute\Backend\DefaultBackend',
-        'Magento\Catalog\Model\Product\Attribute\Backend\Weight',
-        'Magento\Catalog\Model\Product\Attribute\Backend\Price',
+        \Magento\Eav\Model\Entity\Attribute\Backend\ArrayBackend::class,
+        \Magento\Eav\Model\Entity\Attribute\Backend\Datetime::class,
+        \Magento\Catalog\Model\Attribute\Backend\Startdate::class,
+        \Magento\Catalog\Model\Product\Attribute\Backend\Boolean::class,
+        \Magento\Eav\Model\Entity\Attribute\Backend\DefaultBackend::class,
+        \Magento\Catalog\Model\Product\Attribute\Backend\Weight::class,
+        \Magento\Catalog\Model\Product\Attribute\Backend\Price::class,
     ];
 
     /**
@@ -159,9 +159,13 @@ abstract class AbstractAttributeData
         $canIndex = $attribute->getBackendType() != 'static' && $attribute->getAttributeCode() !== 'price';
 
         if ($canIndex && $attribute->getBackendModel()) {
-            $canIndex = in_array($attribute->getBackendModel(), $this->indexedBackendModels);
+            foreach ($this->indexedBackendModels as $indexedBackendModel) {
+                $canIndex = is_a($attribute->getBackendModel(), $indexedBackendModel, true);
+                if ($canIndex) {
+                    return $canIndex;
+                }
+            }
         }
-
         return $canIndex;
     }
 

--- a/src/module-elasticsuite-catalog/Model/Eav/Indexer/Fulltext/Datasource/AbstractAttributeData.php
+++ b/src/module-elasticsuite-catalog/Model/Eav/Indexer/Fulltext/Datasource/AbstractAttributeData.php
@@ -166,6 +166,7 @@ abstract class AbstractAttributeData
                 }
             }
         }
+
         return $canIndex;
     }
 


### PR DESCRIPTION
Some sites may have attributes with custom backend models. We should allow them to be indexed provided they extend one of the backend models we support.