### PR TITLE
Adds a check for used array indexes

### DIFF
--- a/src/module-elasticsuite-tracker/Model/SessionIndex.php
+++ b/src/module-elasticsuite-tracker/Model/SessionIndex.php
@@ -78,10 +78,12 @@ class SessionIndex implements SessionIndexInterface
             $sessionData = $this->resourceModel->getSessionData($storeId, $sessionIds);
 
             foreach ($sessionData as $session) {
-                $index = $this->indexResolver->getIndex(self::INDEX_IDENTIFIER, $session['store_id'], $session['start_date']);
-                if ($index !== null) {
-                    $indices[$index->getName()] = $index;
-                    $bulk->addDocument($index, $index->getDefaultSearchType(), $session['session_id'], $session);
+                if (isset($session['store_id']) && isset($session['start_date'])) {
+                    $index = $this->indexResolver->getIndex(self::INDEX_IDENTIFIER, $session['store_id'], $session['start_date']);
+                    if ($index !== null) {
+                        $indices[$index->getName()] = $index;
+                        $bulk->addDocument($index, $index->getDefaultSearchType(), $session['session_id'], $session);
+                    }
                 }
             }
         }


### PR DESCRIPTION
We have run into scenarios where the assumed array index values
referenced are not set which throws an error.