### PR TITLE
Replace StoreResolver by StoreManager into request builder.

### DIFF
--- a/src/module-elasticsuite-core/Model/Search/RequestBuilder.php
+++ b/src/module-elasticsuite-core/Model/Search/RequestBuilder.php
@@ -34,9 +34,9 @@ class RequestBuilder
     private $searchRequestBuilder;
 
     /**
-     * @var \Magento\Store\Api\StoreResolverInterface
+     * @var \Magento\Store\Model\StoreManagerInterface
      */
-    private $storeResolver;
+    private $storeManager;
 
     /**
      * @var \Smile\ElasticsuiteCore\Api\Search\Request\ContainerConfigurationInterfaceFactory
@@ -53,19 +53,19 @@ class RequestBuilder
      *
      * @param \Smile\ElasticsuiteCore\Search\Request\Builder                                    $searchRequestBuilder   Search request
      *                                                                                                                  builder.
-     * @param \Magento\Store\Api\StoreResolverInterface                                         $storeResolver          Store resolver.
+     * @param \Magento\Store\Model\StoreManagerInterface                                        $storeManager           Store resolver.
      * @param \Smile\ElasticsuiteCore\Api\Search\Request\ContainerConfigurationInterfaceFactory $containerConfigFactory Container config
      *                                                                                                                  factory.
      * @param RequestMapper                                                                     $requestMapper          Request mapper.
      */
     public function __construct(
         \Smile\ElasticsuiteCore\Search\Request\Builder $searchRequestBuilder,
-        \Magento\Store\Api\StoreResolverInterface $storeResolver,
+        \Magento\Store\Model\StoreManagerInterface $storeManager,
         \Smile\ElasticsuiteCore\Api\Search\Request\ContainerConfigurationInterfaceFactory $containerConfigFactory,
         RequestMapper $requestMapper
     ) {
         $this->searchRequestBuilder   = $searchRequestBuilder;
-        $this->storeResolver          = $storeResolver;
+        $this->storeManager           = $storeManager;
         $this->requestMapper          = $requestMapper;
         $this->containerConfigFactory = $containerConfigFactory;
     }
@@ -79,7 +79,7 @@ class RequestBuilder
      */
     public function getRequest(\Magento\Framework\Api\Search\SearchCriteriaInterface $searchCriteria)
     {
-        $storeId       = $this->storeResolver->getCurrentStoreId();
+        $storeId       = $this->storeManager->getStore()->getId();
         $containerName = $searchCriteria->getRequestName();
 
         $containerConfiguration = $this->getSearchContainerConfiguration($storeId, $containerName);


### PR DESCRIPTION
Fix #1010 

Tested working OK with two store views : `fr` and `default`.

I have 5 products named "sac" on the french store, which are named "bag" on the default website.

Tested OK via cURL (note the store code used in URL) : 

Search for "sac" on default store view, get 0 results : 
```
curl -X GET "http://magento22ce.lxc/rest/V1/search?searchCriteria\[requestName\]=quick_search_container&searchCriteria\[filterGroups\]\[0\]\[filters\]\[0\]\[field\]=search_term&searchCriteria\[filterGroups\]\[0\]\[filters\]\[0\]\[value\]=sac" 

{"items":[],"aggregations":{"buckets":[],"bucket_names":[]},"search_criteria":{"request_name":"quick_search_container","filter_groups":[{"filters":[{"field":"search_term","value":"sac","condition_type":"eq"}]}]},"total_count":0}
```

Same query on french store : 

```
curl -X GET "http://magento22ce.lxc/fr/rest/V1/search?searchCriteria\[requestName\]=quick_search_container&searchCriteria\[filterGroups\]\[0\]\[filters\]\[0\]\[field\]=search_term&searchCriteria\[filterGroups\]\[0\]\[filters\]\[0\]\[value\]=sac"

{"items":[{"id":1},{"id":12},{"id":11},{"id":6},{"id":3}],"aggregations":{"buckets":[],"bucket_names":[]},"search_criteria":{"request_name":"quick_search_container","filter_groups":[{"filters":[{"field":"search_term","value":"sac","condition_type":"eq"}]}]},"total_count":5}
```