### PR TITLE
Replace SwatchAttributeType by Swatch Helper to ensure BC.

### DIFF
--- a/src/module-elasticsuite-swatches/Block/Plugin/Adminhtml/Product/Attribute/Edit/Tab/FrontPlugin.php
+++ b/src/module-elasticsuite-swatches/Block/Plugin/Adminhtml/Product/Attribute/Edit/Tab/FrontPlugin.php
@@ -30,22 +30,22 @@ class FrontPlugin
     private $registry;
 
     /**
-     * @var \Magento\Swatches\Model\SwatchAttributeType
+     * @var \Magento\Swatches\Helper\Data
      */
-    private $swatchAttributeType;
+    private $swatchHelper;
 
     /**
      * FrontPlugin constructor.
      *
-     * @param \Magento\Framework\Registry                 $registry            Registry
-     * @param \Magento\Swatches\Model\SwatchAttributeType $swatchAttributeType Swatch Attribute Type
+     * @param \Magento\Framework\Registry   $registry     Registry
+     * @param \Magento\Swatches\Helper\Data $swatchHelper Swatch Attribute Helper
      */
     public function __construct(
         \Magento\Framework\Registry $registry,
-        \Magento\Swatches\Model\SwatchAttributeType $swatchAttributeType
+        \Magento\Swatches\Helper\Data $swatchHelper
     ) {
-        $this->registry            = $registry;
-        $this->swatchAttributeType = $swatchAttributeType;
+        $this->registry     = $registry;
+        $this->swatchHelper = $swatchHelper;
     }
 
     /**
@@ -57,7 +57,7 @@ class FrontPlugin
      */
     public function afterSetForm(\Magento\Catalog\Block\Adminhtml\Product\Attribute\Edit\Tab\Front $subject)
     {
-        if ($this->getAttribute() && $this->swatchAttributeType->isSwatchAttribute($this->getAttribute())) {
+        if ($this->getAttribute() && $this->swatchHelper->isSwatchAttribute($this->getAttribute())) {
             if ($subject->getForm() && $subject->getForm()->getElement('facet_max_size')) {
                 $subject->getForm()->getElement('facet_max_size')->setDisabled(true);
             }

--- a/src/module-elasticsuite-swatches/Plugin/Layer/Filter/SwatchAttribute.php
+++ b/src/module-elasticsuite-swatches/Plugin/Layer/Filter/SwatchAttribute.php
@@ -22,18 +22,18 @@ namespace Smile\ElasticsuiteSwatches\Plugin\Layer\Filter;
 class SwatchAttribute
 {
     /**
-     * @var \Magento\Swatches\Model\SwatchAttributeType
+     * @var \Magento\Swatches\Helper\Data
      */
-    private $swatchAttributeType;
+    private $swatchHelper;
 
     /**
-     * ProductAttribute constructor.
+     * FrontPlugin constructor.
      *
-     * @param \Magento\Swatches\Model\SwatchAttributeType $swatchAttributeType Swatch Attribute Type
+     * @param \Magento\Swatches\Helper\Data $swatchHelper Swatch Attribute Helper
      */
-    public function __construct(\Magento\Swatches\Model\SwatchAttributeType $swatchAttributeType)
+    public function __construct(\Magento\Swatches\Helper\Data $swatchHelper)
     {
-        $this->swatchAttributeType = $swatchAttributeType;
+        $this->swatchHelper = $swatchHelper;
     }
 
     /**
@@ -48,7 +48,7 @@ class SwatchAttribute
         \Smile\ElasticsuiteCatalog\Model\Layer\Filter\Attribute $subject,
         $config = []
     ) {
-        if ($this->swatchAttributeType->isSwatchAttribute($subject->getAttributeModel())) {
+        if ($this->swatchHelper->isSwatchAttribute($subject->getAttributeModel())) {
             $config['size'] = 0;
         }
 


### PR DESCRIPTION
Fix #1059 where `Magento\Swatches\Model\SwatchAttributeType` is not existing in Magento <2.4

Maybe we could merge it to 2.5x and cascade.