### PR TITLE
Fix manual sort position not reindexing on index by schedule

### DIFF
--- a/src/module-elasticsuite-catalog/etc/mview.xml
+++ b/src/module-elasticsuite-catalog/etc/mview.xml
@@ -21,6 +21,8 @@
         <subscriptions>
             <!-- This subscription aims to reindex products after their category is modified -->
             <table name="catalog_category_product" entity_column="product_id" />
+            <!-- This subscription aims to reindex the manual sort position -->
+            <table name="smile_virtualcategory_catalog_category_product_position" entity_column="product_id" />
         </subscriptions>
     </view>
     <view id="elasticsuite_categories_fulltext" class="Smile\ElasticsuiteCatalog\Model\Category\Indexer\Fulltext" group="indexer">


### PR DESCRIPTION
Fix for: #947

This fix schedule an update on the `catalogsearch_fulltext` index for any products updated with manual sort since it seems to be depending on it.

I am not totally sure why the manual sort depends on this index but I guess someone could change that.