### PR TITLE
Fix for: RelevanceConfig isn't saving to DB

### DIFF
--- a/src/module-elasticsuite-core/Model/Search/Request/RelevanceConfig.php
+++ b/src/module-elasticsuite-core/Model/Search/Request/RelevanceConfig.php
@@ -61,6 +61,7 @@ class RelevanceConfig extends \Magento\Config\Model\Config
      * @param StoreManagerInterface     $storeManager       Store Manager
      * @param Containers                $containersSource   The Containers source model
      * @param ScopePool                 $scopePool          RelevanceConfiguration Scope Pool
+     * @param array                     $data               Data
      */
     public function __construct(
         ReinitableConfigInterface $config,
@@ -71,7 +72,8 @@ class RelevanceConfig extends \Magento\Config\Model\Config
         ValueFactory $configValueFactory,
         StoreManagerInterface $storeManager,
         Containers $containersSource,
-        ScopePool $scopePool
+        ScopePool $scopePool,
+        array $data = []
     ) {
         $this->containersSource = $containersSource;
         $this->fullConfig = true;
@@ -83,7 +85,8 @@ class RelevanceConfig extends \Magento\Config\Model\Config
             $transactionFactory,
             $configLoader,
             $configValueFactory,
-            $storeManager
+            $storeManager,
+            $data
         );
     }
 


### PR DESCRIPTION
RelevanceConfig changes in admin aren't saving to DB. This pull request fixes this.