### PR TITLE
Fix usage of wrong ItemCollectionProvider to re-enable category filter

### DIFF
--- a/src/module-elasticsuite-catalog/etc/di.xml
+++ b/src/module-elasticsuite-catalog/etc/di.xml
@@ -94,6 +94,12 @@
         </arguments>
     </virtualType>
 
+    <type name="Magento\Catalog\Model\ResourceModel\Product\CollectionFactory">
+        <arguments>
+            <argument name="instanceName" xsi:type="string">Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Fulltext\Collection</argument>
+        </arguments>
+    </type>
+
     <virtualType name="Magento\CatalogSearch\Model\ResourceModel\Fulltext\SearchCollection"
                  type="Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Fulltext\Collection">
         <arguments>
@@ -111,7 +117,7 @@
         </arguments>
     </virtualType>
 
-    <virtualType name="Smile\ElasticsuiteCatalog\Model\Layer\Category\ItemCollectionProvider" type="Magento\Catalog\Model\Layer\Search\ItemCollectionProvider">
+    <virtualType name="Smile\ElasticsuiteCatalog\Model\Layer\Category\ItemCollectionProvider" type="Magento\Catalog\Model\Layer\Category\ItemCollectionProvider">
         <arguments>
             <argument name="collectionFactory" xsi:type="object">Magento\CatalogSearch\Model\ResourceModel\Fulltext\CollectionFactory</argument>
         </arguments>


### PR DESCRIPTION
Currently the category filter doesn't get applied. The consequence is that every category shows all products, which is obviously not the intended behavior.

By using the Magento\Catalog\Model\Layer\Category\ItemCollectionProvider the filtering is re-enabled.
Also the elastic suite collection is used by setting the instance name for Magento\Catalog\Model\ResourceModel\Product\CollectionFactory.
(This fixes the plugin call for \Smile\ElasticsuiteCatalog\Plugin\LayerPlugin::beforePrepareProductCollection due to using the correct class instead of the standard product collection)

### Preconditions
PHP: 7.1.16
Magento Version: 2.2.5 (B2B-Edition)
        "magento/product-enterprise-edition": "2.2.5",
        "magento/extension-b2b": "^1.0",
ElasticSuite Version: 2.6.1 (latest)
Environment: Both developer and production

Third party modules: none

### Steps to reproduce
1. Install module on clean magento
2. reindex, clear cache
3. navigate to category page without layered navigation (is_anchor = 0)

### Expected result
1. see only products assigned to the category

### Actual result
1. all products are shown instead of only the products assigned to the category
![bildschirmfoto 2018-10-02 um 11 54 42](https://user-images.githubusercontent.com/9307310/46342159-5b7b2500-c63a-11e8-9ef0-db36b7a28ee8.png)

Relations are set correctly, index has been refreshed, also cache has been cleared
![bildschirmfoto 2018-10-02 um 11 56 42](https://user-images.githubusercontent.com/9307310/46342138-4ef6cc80-c63a-11e8-9f2d-3c7907f34419.png)

This has to to with \Smile\ElasticsuiteCatalog\Model\Layer\Filter\Category::apply only being called when the layered navigation is enabled on a category. @see categoryFilterList in src/vendor/smile/elasticsuite/src/module-elasticsuite-catalog/etc/frontend/di.xml:93