### PR TITLE
Add "To Top" button to the manual sort category listing

### DIFF
--- a/src/module-elasticsuite-catalog/view/adminhtml/web/css/source/_module.less
+++ b/src/module-elasticsuite-catalog/view/adminhtml/web/css/source/_module.less
@@ -141,6 +141,25 @@
                 }
             }
 
+            .totop-handle {
+                position: absolute;
+                top: 30px;
+                right: 11px;
+
+                a {
+                    text-decoration: none;
+                    cursor: pointer;
+                }
+                a:before {
+                    color: #9e9e9e;
+                    font-family: 'Admin Icons';
+                    font-style: normal;
+                    font-weight: normal;
+                    line-height: 1;
+                    content: "\e615";
+                }
+            }
+
             &.blacklisted {
                 div.product-image, div.info {
                     opacity: 0.6;

--- a/src/module-elasticsuite-catalog/view/adminhtml/web/js/form/element/product-sorter.js
+++ b/src/module-elasticsuite-catalog/view/adminhtml/web/js/form/element/product-sorter.js
@@ -245,6 +245,28 @@ define([
             this.editPositions(editPositions);
         },
 
+        sendToTop: function(product) {
+            var products      = this.products();
+            var editPositions = this.editPositions();
+            var position      = 1;
+
+            var currentProductId = product.getId();
+            var list = $('li.product-list-item[data-product-id=' + currentProductId + ']').parent();
+            list.find('li.product-list-item').each(function (index, element) {
+                var currentProduct = this.getProductById(element.getAttribute('data-product-id'));
+                if(currentProduct.getPosition() && currentProduct.getId() !== currentProductId) {
+                    position = position + 1;
+                    currentProduct.setPosition(position);
+                    editPositions[currentProduct.getId()] = position;
+                }
+            }.bind(this));
+
+            editPositions[product.getId()] = 1;
+            product.setPosition(1);
+            this.products(this.sortProduct(products));
+            this.editPositions(editPositions);
+        },
+
         allowBlacklist: function() {
             return this.allowBlacklist;
         },

--- a/src/module-elasticsuite-catalog/view/adminhtml/web/template/form/element/product-sorter.html
+++ b/src/module-elasticsuite-catalog/view/adminhtml/web/template/form/element/product-sorter.html
@@ -28,7 +28,7 @@
                     <a data-bind="click: $parent.toggleBlackListed.bind($parent), attr: { title: isBlacklisted() ? $t('Blacklisted') : $t('Visible') }"></a>
                 </div>
                 <div class="totop-handle" data-bind="if: hasPosition()">
-                    <a data-bind="click: $parent.sendToTop.bind($parent), attr: { title: isBlacklisted() ? $t('Blacklisted') : $t('Visible') }"></a>
+                    <a data-bind="click: $parent.sendToTop.bind($parent), attr: { title: $t('To Top') }"></a>
                 </div>
 
                 <div class="product-image"><img data-bind="attr: { src: getImageUrl() }" /></div>

--- a/src/module-elasticsuite-catalog/view/adminhtml/web/template/form/element/product-sorter.html
+++ b/src/module-elasticsuite-catalog/view/adminhtml/web/template/form/element/product-sorter.html
@@ -27,6 +27,9 @@
                 <div class="blacklist-handle" data-bind="if: $parent.allowBlacklist">
                     <a data-bind="click: $parent.toggleBlackListed.bind($parent), attr: { title: isBlacklisted() ? $t('Blacklisted') : $t('Visible') }"></a>
                 </div>
+                <div class="totop-handle" data-bind="if: hasPosition()">
+                    <a data-bind="click: $parent.sendToTop.bind($parent), attr: { title: isBlacklisted() ? $t('Blacklisted') : $t('Visible') }"></a>
+                </div>
 
                 <div class="product-image"><img data-bind="attr: { src: getImageUrl() }" /></div>
     


### PR DESCRIPTION
**How it looks:**

![to-top](https://user-images.githubusercontent.com/11569701/46523076-e94a5080-c884-11e8-9064-f41becb7e5e1.jpg)

**The reason why:**

I added this feature on our project because we had a lot of products in manual sort.

When you add a product as Manual sort, it gets to the end of the Manual sort product list and using the drag and drop to get a few products to the top is not really practical and can take some time, especially for a user that is not really good with a mouse.

**Technical Details:**

I did it and tested it in a few hours because I did not have too much time to spend on this so it might not be perfectly coded. I tried to reuse the API and logic that was currently available but the code could clearly be improved / refactored.

**What's missing:**

* Hide the button for the element at the top of the list (that is not really a problem though).
