### PR TITLE
Display correct count in price slider if range ‚from value‘ = ‚to value‘

### DIFF
--- a/src/module-elasticsuite-catalog/Model/Layer/Filter/DecimalFilterTrait.php
+++ b/src/module-elasticsuite-catalog/Model/Layer/Filter/DecimalFilterTrait.php
@@ -52,7 +52,7 @@ trait DecimalFilterTrait
 
                 $this->getLayer()->getProductCollection()->addFieldToFilter(
                     $this->getAttributeModel()->getAttributeCode(),
-                    array_filter(['gte' => $fromValue, 'lt' => $toValue])
+                    array_filter(['gte' => $fromValue, 'lte' => $toValue])
                 );
 
                 $this->getLayer()->getState()->addFilter(

--- a/src/module-elasticsuite-catalog/view/frontend/web/js/range-slider-widget.js
+++ b/src/module-elasticsuite-catalog/view/frontend/web/js/range-slider-widget.js
@@ -110,7 +110,7 @@ define(["jquery", 'Magento_Catalog/js/price-utils', 'mage/template', "jquery/ui"
 
         _getItemCount : function() {
             var from = this.from, to = this.to, intervals = this.intervals;
-            var count = intervals.map(function(item) {return item.value >= from && item.value < to ? item.count : 0;})
+            var count = intervals.map(function(item) {return item.value >= from && item.value <= to ? item.count : 0;})
                                  .reduce(function(a,b) {return a + b;});
             return count;
         },


### PR DESCRIPTION
f.e. we have products in shop with price 100$. If we make in price slider "from value" = "to value", we got "No products in the selected range." message. Also if we open direct url https://some_shop/some_url?price=100-100 we didn't see the products with price 100$