### PR TITLE
Fix array/string issue

### DIFF
--- a/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Fulltext/Collection.php
+++ b/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Fulltext/Collection.php
@@ -300,9 +300,11 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Product\Collection
     {
         $this->_renderFilters();
         $result = [];
+        $bucket = [];
         $aggregations = $this->queryResponse->getAggregations();
 
-        $bucket = $aggregations->getBucket($field);
+        if ($aggregations)
+            $bucket = $aggregations->getBucket($field);
 
         if ($bucket) {
             foreach ($bucket->getValues() as $value) {
@@ -629,9 +631,16 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Product\Collection
         $this->countByAttributeSet  = [];
         $this->countByAttributeCode = [];
         $this->isSpellchecked       = $searchRequest->isSpellchecked();
+        $attributeSetIdBucket       = [];
+        $attributeCodeBucket        = [];
 
-        $attributeSetIdBucket = $searchResponse->getAggregations()->getBucket('attribute_set_id');
-        $attributeCodeBucket  = $searchResponse->getAggregations()->getBucket('indexed_attributes');
+        if ($searchResponse !== null
+            && ($getAggregations = $searchResponse->getAggregations() !== null)
+            && ($getBucket       = $getAggregations->getBucket('attribute_set_id') !== null)
+        ) {
+            $attributeSetIdBucket = $getBucket;
+            $attributeCodeBucket  = $getAggregations->getBucket('indexed_attributes');
+        }
 
         if ($attributeSetIdBucket) {
             foreach ($attributeSetIdBucket->getValues() as $value) {

--- a/src/module-elasticsuite-core/Search/Adapter/Elasticsuite/Response/QueryResponse.php
+++ b/src/module-elasticsuite-core/Search/Adapter/Elasticsuite/Response/QueryResponse.php
@@ -50,15 +50,17 @@ class QueryResponse implements ResponseInterface
      *
      * @param DocumentFactory    $documentFactory    Document factory.
      * @param AggregationFactory $aggregationFactory Aggregation factory.
-     * @param array              $searchResponse     Engine raw response.
+     * @param mixed $searchResponse     Engine raw response.
      */
     public function __construct(
         DocumentFactory $documentFactory,
         AggregationFactory $aggregationFactory,
-        array $searchResponse
+        $searchResponse
     ) {
-        $this->prepareDocuments($searchResponse, $documentFactory);
-        $this->prepareAggregations($searchResponse, $aggregationFactory);
+        if (is_array($searchResponse)) {
+            $this->prepareDocuments($searchResponse, $documentFactory);
+            $this->prepareAggregations($searchResponse, $aggregationFactory);
+        }
     }
 
     /**


### PR DESCRIPTION
After proper installation, indexing and deploying the extension provided with the issue (any category-view page):

![screenshot-20181011164927-1920x1053](https://user-images.githubusercontent.com/9606476/46826495-a22cf580-cd85-11e8-8b45-69962f810dea.png)

The patch fixed the issue, but after deploying no any products loaded in any category-view pages.

Note:

Installed and enabled extensions:

Smile_ElasticsuiteCore
Smile_ElasticsuiteCatalog
Smile_ElasticsuiteCatalogRule
Smile_ElasticsuiteCatalogOptimizer
Smile_ElasticsuiteCms
Smile_ElasticsuiteVirtualCategory
Smile_ElasticsuiteSwatches
Smile_ElasticsuiteThesaurus
Smile_ElasticsuiteTracker
Smile_ElasticsuiteRating
Comwrap_ElasticsuiteBlog

