### PR TITLE
Remove regular price span to show price label

### DIFF
--- a/src/module-elasticsuite-catalog/view/frontend/web/template/autocomplete/product.html
+++ b/src/module-elasticsuite-catalog/view/frontend/web/template/autocomplete/product.html
@@ -7,7 +7,7 @@
             <div class="product-primary"><div class="product-name"><%= data.title %></div></div>
             <div class="product-secondary">
                 <div class="price-box">
-                    <span class="regular-price"><span class="price"><%= data.price %></span></span>
+                    <span class="price"><%= data.price %></span>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Currently when searching it is not possible to show the price label. If you perform a search an the autocomplete shows products and their prices these prices are not labeled. Is this behavior intended?

In our case we have many products with tier prices and in the autocomplete will be shown the regular price and the tier price but you cannot distinguish them so we want the "As low as" label to be shown for the tier price. But due to the `<span class="regular-price">` it's not displayed by magento2 css.
Basically, prices contained in the template are not always regular prices, they can be other prices as well
so this class "regular-price" does not make sense at this point.