### PR TITLE
Remove regular price span to show price label

### DIFF
--- a/src/module-elasticsuite-catalog/view/frontend/web/template/autocomplete/product.html
+++ b/src/module-elasticsuite-catalog/view/frontend/web/template/autocomplete/product.html
@@ -7,7 +7,7 @@
             <div class="product-primary"><div class="product-name"><%= data.title %></div></div>
             <div class="product-secondary">
                 <div class="price-box">
-                    <span class="regular-price"><span class="price"><%= data.price %></span></span>
+                    <span class="price"><%= data.price %></span>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Replace #1139 to be merged in 2.6.x instead of master.