### PR TITLE
Extend the doc block to explain the possibility to return null to unset filter

### DIFF
--- a/src/module-elasticsuite-core/Api/Search/Request/Container/FilterInterface.php
+++ b/src/module-elasticsuite-core/Api/Search/Request/Container/FilterInterface.php
@@ -24,11 +24,11 @@ namespace Smile\ElasticsuiteCore\Api\Search\Request\Container;
 interface FilterInterface
 {
     /**
-     * Get filter query according to current search context.
+     * Get filter query according to current search context. Return null to unset filter query.
      *
      * @param \Smile\ElasticsuiteCore\Api\Search\ContextInterface $searchContext Search Context
      *
-     * @return \Smile\ElasticsuiteCore\Search\Request\QueryInterface
+     * @return \Smile\ElasticsuiteCore\Search\Request\QueryInterface|null
      */
     public function getFilterQuery(\Smile\ElasticsuiteCore\Api\Search\ContextInterface $searchContext);
 }


### PR DESCRIPTION
Basically an extension due to the discussion in #1158. Since one does not need to return a \Smile\ElasticsuiteCore\Search\Request\QueryInterface the doc block comment should indicate that.