### PR TITLE
Dropdown attribute values not displaying in adminhtml

### DIFF
--- a/src/module-elasticsuite-catalog/view/adminhtml/templates/catalog/product/attribute/js.phtml
+++ b/src/module-elasticsuite-catalog/view/adminhtml/templates/catalog/product/attribute/js.phtml
@@ -66,7 +66,7 @@
                 ($('frontend_input').value == 'select'
                 || $('frontend_input').value == 'multiselect'
                 || $('frontend_input').value == 'price'
-                || $('frontend_input').value == 'text')
+                || $('frontend_input').value == 'text'
                 || $('frontend_input').value == 'boolean')
             ) {
                 if($('is_filterable') && !$('is_filterable').getAttribute('readonly')){

--- a/src/module-elasticsuite-catalog/view/adminhtml/templates/catalog/product/attribute/js.phtml
+++ b/src/module-elasticsuite-catalog/view/adminhtml/templates/catalog/product/attribute/js.phtml
@@ -14,6 +14,15 @@
  */
 
 ?>
+<script type="text/x-magento-init">
+    {
+        "*": {
+            "swatchesProductAttributes": {
+                "hiddenFields": {"swatch_visual":["is_unique","is_required","frontend_class","_scope","_default_value","_front_fieldset"],"swatch_text":["is_unique","is_required","frontend_class","_scope","_default_value","_front_fieldset"],"weee":["is_unique","is_required","frontend_class","_scope","_default_value","_front_fieldset"]}            },
+            "swatchesTypeChange": { }
+        }
+     }
+</script>
 <script>
     require([
         "jquery",


### PR DESCRIPTION
I migrated from 1.9.2.2 to 2.2.6, and when I go to stores -> Attributes -> Product, and select a attribute with a dropdown type, I see no attribute values in there. For example, if I had an attribute color, I would not see any migrated Values of "Blue", "Red", etc under "Manage Options".
Creating a new attribute with dropdowns would yield the same behavior.
Any new or existing values would appear in the front end and the product pages, so I know they were saving.
If I add any new values, It would save, but upon refresh would disappear.

Creating a whole new attribute had the same issue.

I however, could not delete any values, because they were not populating.

Disabling Smile_ElasticsuiteCatalog fixes the issue.

Commit 1bcebbe did not appear to fix the issue, just cleaning up noise in the browser Javascript console.

Commit 489cfce ultimately fixed the issue, but it smells pretty bad. When doing a diff of the product attribute page with Smile_ElasticsuiteCatalog enabled and then disabled, I noticed this code missing, so I stuffed it in here. I am sure there is a better fix.