### PR TITLE
Feature #1196 Multi Source Inventory support

### DIFF
--- a/src/module-elasticsuite-catalog/Model/Product/Indexer/Fulltext/Datasource/InventoryData.php
+++ b/src/module-elasticsuite-catalog/Model/Product/Indexer/Fulltext/Datasource/InventoryData.php
@@ -13,7 +13,7 @@
 namespace Smile\ElasticsuiteCatalog\Model\Product\Indexer\Fulltext\Datasource;
 
 use Smile\ElasticsuiteCore\Api\Index\DatasourceInterface;
-use Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Indexer\Fulltext\Datasource\InventoryData as ResourceModel;
+use Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Indexer\Fulltext\Datasource\InventoryDataInterface as ResourceModel;
 
 /**
  * Datasource used to append inventory data to product during indexing.
@@ -25,7 +25,7 @@ use Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Indexer\Fulltext\Datas
 class InventoryData implements DatasourceInterface
 {
     /**
-     * @var \Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Indexer\Fulltext\Datasource\InventoryData
+     * @var \Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Indexer\Fulltext\Datasource\InventoryDataInterface
      */
     private $resourceModel;
 

--- a/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Indexer/Fulltext/Datasource/InventoryDataInterface.php
+++ b/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Indexer/Fulltext/Datasource/InventoryDataInterface.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future.
+ *
+ *
+ * @category  Smile
+ * @package   Smile\ElasticsuiteCatalog
+ * @author    Richard BAYET <richard.bayet@smile.fr>
+ * @copyright 2018 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+
+namespace Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Indexer\Fulltext\Datasource;
+
+/**
+ * Interface InventoryDataInterface
+ *
+ * @category Smile
+ * @package  Smile\ElasticsuiteCatalog
+ */
+interface InventoryDataInterface
+{
+    /**
+     * Load inventory data for a list of product ids and a given store.
+     * Expected rows structure : ['product_id', 'stock_status', 'qty'].
+     *
+     * @param integer $storeId    Store id.
+     * @param array   $productIds Product ids list.
+     *
+     * @return array
+     */
+    public function loadInventoryData($storeId, $productIds);
+}

--- a/src/module-elasticsuite-catalog/etc/di.xml
+++ b/src/module-elasticsuite-catalog/etc/di.xml
@@ -243,4 +243,6 @@
         </arguments>
     </type>
 
+    <preference for="Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Indexer\Fulltext\Datasource\InventoryDataInterface"
+                type="Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Indexer\Fulltext\Datasource\InventoryData" />
 </config>


### PR DESCRIPTION
Created an additional module with a somewhat evocative name, but I'm not so sure about it anymore, since \Magento\CatalogInventory\Api\StockRegistryInterface and \Magento\CatalogInventory\Api\StockConfigurationInterface are cleared marked as deprecated (see full list in https://devdocs.magento.com/guides/v2.3/inventory/catalog-inventory-replacements.html).

Having the changes directly in elasticsuite-catalog would remove the need for the extra interface I had to introduce.
