### PR TITLE
Fixes #1201 Allow elasticsearch/elasticsearch 6.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "magento/module-catalog": ">=102.0.0",
         "magento/module-catalog-search": ">=100.2.0",
         "magento/magento-composer-installer": "*",
-        "elasticsearch/elasticsearch": "~5.1"
+        "elasticsearch/elasticsearch": "~5.1|~6.0"
     },
     "replace": {
         "smile/module-elasticsuite-core": "self.version",


### PR DESCRIPTION
which is required for an Elasticsearch server in 6.x