### PR TITLE
Fixes Smile-SA/elasticsuite#1223

### DIFF
--- a/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Indexer/Fulltext/Datasource/InventoryData.php
+++ b/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Indexer/Fulltext/Datasource/InventoryData.php
@@ -93,7 +93,9 @@ class InventoryData extends Indexer implements InventoryDataInterface
                     'stock_status'  => 'stock_index.' . IndexStructure::IS_SALABLE,
                     'qty'           => 'stock_index.' . IndexStructure::QUANTITY,
                 ]
-            );
+            )
+            ->where('product.entity_id IN (?)', $productIds)
+            ->group('product.entity_id');
 
         return $this->getConnection()->fetchAll($select);
     }


### PR DESCRIPTION
Fixes Smile-SA/elasticsuite#1223

On a side note; is there a specific reason for joining on SKU? The index table (`inventory_stock_x`) does contain a `product_id` column, no need to join `catalog_product_entity`. Create a secondary pull request with the adjusted select statement https://github.com/Smile-SA/elasticsuite/pull/1225.