### PR TITLE
Proof of concept using elastic suite for product listing

### DIFF
--- a/src/module-elasticsuite-catalog/Data/Collection/Db/FetchStrategy/SearchQuery.php
+++ b/src/module-elasticsuite-catalog/Data/Collection/Db/FetchStrategy/SearchQuery.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile ElasticSuite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\ElasticsuiteCore
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2018 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\ElasticsuiteCatalog\Data\Collection\Db\FetchStrategy;
+
+use Magento\Framework\Data\Collection\Db\FetchStrategyInterface;
+use Magento\Framework\DB\Select;
+use Magento\Search\Model\SearchEngine;
+use Smile\ElasticsuiteCatalog\Helper\ProductListing;
+use Magento\Framework\Data\Collection\Db\FetchStrategy\Query;
+use Smile\ElasticsuiteCore\Helper\Mapping;
+
+/**
+ * Class SearchQuery
+ */
+class SearchQuery extends Query implements FetchStrategyInterface
+{
+    /**
+     * Search Request
+     *
+     * @var \Smile\ElasticsuiteCore\Search\RequestInterface
+     */
+    private $request;
+
+    /**
+     *
+     *
+     * @var \Magento\Framework\Search\ResponseInterface
+     */
+    private $response;
+
+    /**
+     * Search Engine
+     *
+     * @var \Magento\Search\Model\SearchEngine
+     */
+    private $searchEngine;
+
+    /**
+     * Product Listing helper used to check if product listing is enabled
+     *
+     * @var \Smile\ElasticsuiteCatalog\Helper\ProductListing
+     */
+    private $productListingHelper;
+
+    /**
+     * SearchQuery constructor.
+     *
+     * @param \Magento\Search\Model\SearchEngine               $searchEngine         Search Engine
+     * @param \Smile\ElasticsuiteCatalog\Helper\ProductListing $productListingHelper Product Listing Helper
+     */
+    public function __construct(
+        SearchEngine $searchEngine,
+        ProductListing $productListingHelper
+    ) {
+        $this->searchEngine = $searchEngine;
+        $this->productListingHelper = $productListingHelper;
+    }
+
+    /**
+     * @param \Smile\ElasticsuiteCore\Search\RequestInterface $request Search Request
+     */
+    public function setRequest(\Smile\ElasticsuiteCore\Search\RequestInterface $request)
+    {
+        $this->request = $request;
+    }
+
+    /**
+     * @return \Magento\Framework\Search\ResponseInterface|null Search Response
+     */
+    public function getResponse()
+    {
+        return $this->response;
+    }
+
+    /**
+     * @param \Magento\Framework\DB\Select $select     Database select statement
+     * @param string[]                     $bindParams Database select statement bind params
+     * @return array[][]
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function fetchAll(Select $select, array $bindParams = [])
+    {
+        if (!$this->request) {
+            return parent::fetchAll($select, $bindParams);
+        }
+
+        $this->response = $this->searchEngine->search($this->request);
+        $products = [];
+
+        foreach ($this->response->getIterator() as $item) {
+            /** @var \Smile\ElasticsuiteCore\Search\Adapter\Elasticsuite\Response\Document $item */
+            $source = $item->getSource();
+            $source = array_merge($source, $source['price'][0]);
+
+            foreach ($source as $attributeCode => $value) {
+                $source[$attributeCode] = in_array($attributeCode, $source['indexed_attributes'])
+                && is_array($value) ? count($value) > 1 ? $value : $value[0] : $value;
+
+                if (0 === strpos($attributeCode, Mapping::OPTION_TEXT_PREFIX)) {
+                    $key = str_replace(
+                        Mapping::OPTION_TEXT_PREFIX.'_',
+                        '',
+                        $attributeCode
+                    );
+                    $source[$key.'_value'] = is_array($value) ? count($value) > 1 ? $value : $value[0] : $value;
+                }
+            }
+
+            $products[] = $source;
+        }
+
+        return $products;
+    }
+}

--- a/src/module-elasticsuite-catalog/Helper/ProductListing.php
+++ b/src/module-elasticsuite-catalog/Helper/ProductListing.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile ElasticSuite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\ElasticsuiteCore
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2018 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+namespace Smile\ElasticsuiteCatalog\Helper;
+
+use Smile\ElasticsuiteCore\Helper\AbstractConfiguration;
+
+/**
+ * Class product_listing
+ */
+class ProductListing extends AbstractConfiguration
+{
+    /**
+     * @var string
+     */
+    const PRODUCT_LISTING_SETTINGS_CONFIG_XML_PREFIX = 'smile_elasticsuite_product_listing_settings';
+
+    /**
+     * Returns if an autocomplete type is enabled or not.
+     *
+     * @return boolean
+     */
+    public function isEnabled()
+    {
+        return (bool) $this->getConfigValue('product_listing/use_for_product_listing');
+    }
+
+    /**
+     * Retrieve a configuration value by its key
+     *
+     * @param string $key The configuration key
+     *
+     * @return mixed
+     */
+    protected function getConfigValue($key)
+    {
+        return $this->scopeConfig->getValue(self::PRODUCT_LISTING_SETTINGS_CONFIG_XML_PREFIX . "/" . $key);
+    }
+}

--- a/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Indexer/Fulltext/Datasource/AttributeData.php
+++ b/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Indexer/Fulltext/Datasource/AttributeData.php
@@ -16,6 +16,7 @@ namespace Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Indexer\Fulltext
 
 use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Framework\EntityManager\MetadataPool;
+use Smile\ElasticsuiteCatalog\Helper\ProductListing;
 use Smile\ElasticsuiteCatalog\Model\ResourceModel\Eav\Indexer\Fulltext\Datasource\AbstractAttributeData;
 use Magento\Framework\App\ResourceConnection;
 use Magento\Store\Model\StoreManagerInterface;
@@ -50,20 +51,22 @@ class AttributeData extends AbstractAttributeData
     /**
      * Constructor.
      *
-     * @param ResourceConnection    $resource           Database adpater.
-     * @param StoreManagerInterface $storeManager       Store manager.
-     * @param MetadataPool          $metadataPool       Metadata Pool.
-     * @param ProductType           $catalogProductType Product type.
-     * @param string                $entityType         Product entity type.
+     * @param ResourceConnection    $resource             Database adpater.
+     * @param StoreManagerInterface $storeManager         Store manager.
+     * @param MetadataPool          $metadataPool         Metadata Pool.
+     * @param ProductType           $catalogProductType   Product type.
+     * @param ProductListing        $productListingHelper Product listing helper
+     * @param string                $entityType           Product entity type.
      */
     public function __construct(
         ResourceConnection $resource,
         StoreManagerInterface $storeManager,
         MetadataPool $metadataPool,
         ProductType $catalogProductType,
+        ProductListing $productListingHelper,
         $entityType = ProductInterface::class
     ) {
-        parent::__construct($resource, $storeManager, $metadataPool, $entityType);
+        parent::__construct($resource, $storeManager, $metadataPool, $productListingHelper, $entityType);
         $this->catalogProductType = $catalogProductType;
     }
 

--- a/src/module-elasticsuite-catalog/etc/adminhtml/system.xml
+++ b/src/module-elasticsuite-catalog/etc/adminhtml/system.xml
@@ -62,5 +62,19 @@
                 </field>
             </group>
         </section>
+
+        <section id="smile_elasticsuite_product_listing_settings" translate="label" type="text" sortOrder="1000" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Catalog Listing</label>
+            <tab>smile_elasticsuite</tab>
+            <resource>Magento_Backend::smile_elasticsuite_catalogsearch</resource>
+
+            <group id="product_listing" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
+                <label>Catalog Listing Configuration</label>
+                <field id="use_for_product_listing" translate="label comment" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Use Elastic Suite for product listing</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
+            </group>
+        </section>
     </system>
 </config>

--- a/src/module-elasticsuite-catalog/etc/config.xml
+++ b/src/module-elasticsuite-catalog/etc/config.xml
@@ -38,5 +38,10 @@
                 <expanded_facets>3</expanded_facets>
             </catalogsearch>
         </smile_elasticsuite_catalogsearch_settings>
+        <smile_elasticsuite_product_listing_settings>
+            <product_listing>
+                <use_for_product_listing>0</use_for_product_listing>
+            </product_listing>
+        </smile_elasticsuite_product_listing_settings>
     </default>
 </config>

--- a/src/module-elasticsuite-catalog/etc/frontend/di.xml
+++ b/src/module-elasticsuite-catalog/etc/frontend/di.xml
@@ -199,4 +199,10 @@
     <type name="Magento\Search\Model\QueryFactory">
         <plugin name="initSearchContext" type="Smile\ElasticsuiteCatalog\Plugin\Search\QueryFactoryPlugin"/>
     </type>
+
+    <type name="Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Fulltext\Collection">
+        <arguments>
+            <argument name="fetchStrategy" xsi:type="object">Smile\ElasticsuiteCatalog\Data\Collection\Db\FetchStrategy\SearchQuery</argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
References Smile-SA/elasticsuite#1205

As stated in #1205 it could be useful to use Elasticsuite (elasticsearch) as a backend for the product listing. For me there are two points of interest;
- Possible performance gain; Limiting the number of queries to the database or bypassing the database as a whole
- This could to some extend replace the product flat index; When there are too many attributes used for product listing the flat tables can no longer be used.

This is not a pull request that should be reviewed as a feature request, but rather as a proof of concept. I'm trying to figure out the direction that is preferred if this would ever be considered as a serious feature. I tried to use a minimal amount of code to get to a point where the full collection is provided by Elastic Suite.

Some initial insights / questions;
- The index source should have a list of attributes that are used for product listing. The proposal is based on the `attributes_indexed` which is far from optimal
- Is there a specific reason for having the attributes values as an array in the source document?
- Should this be part of `ElasticsuiteCatalog` or should it be developed in a separate folder?

Please share your thoughts how, and if, this could become a serious feature.