### PR TITLE
Feature/search category products preview

### DIFF
--- a/src/module-elasticsuite-catalog/Model/ProductSorter/AbstractPreview.php
+++ b/src/module-elasticsuite-catalog/Model/ProductSorter/AbstractPreview.php
@@ -43,6 +43,11 @@ abstract class AbstractPreview implements PreviewInterface
     private $size;
 
     /**
+     * @var string
+     */
+    private $search;
+
+    /**
      * @var integer
      */
     private $storeId;
@@ -59,20 +64,23 @@ abstract class AbstractPreview implements PreviewInterface
      * @param ItemDataFactory          $itemFactory       Preview item factory.
      * @param QueryFactory             $queryFactory      ES query factory.
      * @param integer                  $storeId           Store id.
-     * @param number                   $size              Preview size.
+     * @param integer                  $size              Preview size.
+     * @param string                   $search            Preview search.
      */
     public function __construct(
         ProductCollectionFactory $collectionFactory,
         ItemDataFactory $itemFactory,
         QueryFactory $queryFactory,
         $storeId,
-        $size = 10
+        $size = 10,
+        $search = ''
     ) {
         $this->collectionFactory = $collectionFactory;
         $this->itemFactory       = $itemFactory;
         $this->queryFactory      = $queryFactory;
         $this->storeId           = $storeId;
         $this->size              = $size;
+        $this->search            = $search;
     }
 
     /**
@@ -147,7 +155,10 @@ abstract class AbstractPreview implements PreviewInterface
      */
     private function getUnsortedProductData()
     {
-        $productCollection = $this->getProductCollection()->setPageSize($this->size);
+        $productCollection = $this->getProductCollection()
+            ->setSearchQuery($this->search)
+            ->setPageSize($this->size)
+        ;
 
         return ['products' => $productCollection->getItems(), 'size' => $productCollection->getSize()];
     }

--- a/src/module-elasticsuite-catalog/i18n/de_DE.csv
+++ b/src/module-elasticsuite-catalog/i18n/de_DE.csv
@@ -77,3 +77,5 @@ Pinned,Angeheftet
 Products,Produkte
 Categories,Kategorien
 Attributes,Attribute
+"Clear search","Suche abbrechen"
+"Your search returned no results.","Ihre Suche ergab keine Treffer."

--- a/src/module-elasticsuite-catalog/i18n/en_US.csv
+++ b/src/module-elasticsuite-catalog/i18n/en_US.csv
@@ -77,3 +77,5 @@ Pinned,Pinned
 Products,Products
 Categories,Categories
 Attributes,Attributes
+"Clear search","Clear search"
+"Your search returned no results.","Your search returned no results."

--- a/src/module-elasticsuite-catalog/i18n/fr_FR.csv
+++ b/src/module-elasticsuite-catalog/i18n/fr_FR.csv
@@ -77,3 +77,5 @@ No,Non
 Products,Produits
 Categories,Catégories
 Attributes,Attributs
+"Clear search","Annuler la recherche"
+"Your search returned no results.","Votre recherche n'a donné aucun résultat."

--- a/src/module-elasticsuite-catalog/view/adminhtml/ui_component/search_term_preview.xml
+++ b/src/module-elasticsuite-catalog/view/adminhtml/ui_component/search_term_preview.xml
@@ -81,6 +81,7 @@
                         <item name="pageSize" xsi:type="string">20</item>
                         <item name="forceLoading" xsi:type="boolean">true</item>
                         <item name="allowBlacklist" xsi:type="boolean">true</item>
+                        <item name="allowSearch" xsi:type="boolean">false</item>
                         <item name="messages" xsi:type="array">
                             <item name="emptyText" xsi:type="string" translate="true"><![CDATA[No search result for the current search.]]></item>
                         </item>

--- a/src/module-elasticsuite-catalog/view/adminhtml/web/css/source/_module.less
+++ b/src/module-elasticsuite-catalog/view/adminhtml/web/css/source/_module.less
@@ -22,6 +22,12 @@
         letter-spacing: .025em;
     }
 
+    .top-search {
+        a.action-reset {
+            margin: 0 1rem;
+        }
+    }
+
     .bottom-links {
         clear: both;
         width: 40%;

--- a/src/module-elasticsuite-catalog/view/adminhtml/web/template/form/element/product-sorter.html
+++ b/src/module-elasticsuite-catalog/view/adminhtml/web/template/form/element/product-sorter.html
@@ -7,20 +7,27 @@
     </div>
 
     <input type="hidden" data-bind="value: value, attr: {name: inputName}"/>
-    
+
     <span class="title" data-bind="text: label"></span>
-    
+
     <div class="elasticsuite-admin-product-sorter-empty" data-bind="if: !hasProducts()">
         <div class="message message-info">
-            <div data-bind="html: messages.emptyText"></div>
+            <div data-bind="html: messages.emptyText" visible="!hasSearch()"></div>
+            <div data-bind="html: messages.noResultsText" visible="hasSearch()"></div>
         </div>
     </div>
-    
+
+    <p class="top-search" data-bind="if: allowSearch && (hasProducts() || hasSearch())">
+        <input type="text" id="elasticsuite-preview-search" class="admin__control-text" data-bind="textInput : search, event: {keypress: enterSearch}"/>
+        <a href="#" data-bind="click: searchProducts, text: messages.search" class="action-default action-search"></a>
+        <a href="#" visible="search" data-bind="click: resetSearch, text: messages.clearSearch" class="action-reset"></a>
+    </p>
+
     <div data-bind="if: hasProducts()">
-        
+
         <ul data-bind="foreach: products, afterRender: enableSortableList" class="product-list">
             <li class="product-list-item" data-bind="
-                attr: {'data-product-id': getId()}, 
+                attr: {'data-product-id': getId()},
                 css: {'manual-sorting': hasPosition(), 'automatic-sorting': !hasPosition(), 'blacklisted': isBlacklisted() }
             ">
                 <div class="draggable-handle" data-bind="if: hasPosition()"></div>
@@ -29,14 +36,14 @@
                 </div>
 
                 <div class="product-image"><img data-bind="attr: { src: getImageUrl() }" /></div>
-    
+
                 <div class="info">
                     <h1><span data-bind="html: getName(), attr: {title: getName()"></span></h1>
                     <p class="sku" data-bind="text: getSku()"></p>
                     <p class="price" data-bind="text: getFormattedPrice()"></p>
                     <p class="stock" data-bind="text: getStockLabel()"></p>
                 </div>
-                
+
                 <div class="admin__actions-switch" data-role="switcher" data-bind="click: $parent.toggleSortType.bind($parent)">
                     <input type="checkbox" class="admin__actions-switch-checkbox" simple-checked="hasPosition()" ko-value="hasPosition()" />
                     <label class="admin__actions-switch-label">
@@ -47,7 +54,7 @@
                 </div>
             </li>
         </ul>
-    
+
         <p class="bottom-links" data-bind="visible: hasMoreProducts()">
             <a href="#" data-bind="click: showMoreProducts, text: messages.showMore" class="show-more-link"></a>
         </p>

--- a/src/module-elasticsuite-virtual-category/Controller/Adminhtml/Category/Virtual/Preview.php
+++ b/src/module-elasticsuite-virtual-category/Controller/Adminhtml/Category/Virtual/Preview.php
@@ -92,8 +92,9 @@ class Preview extends Action
     {
         $category = $this->getCategory();
         $pageSize = $this->getPageSize();
+        $search = $this->getRequest()->getParam('search');
 
-        return $this->previewModelFactory->create(['category' => $category, 'size' => $pageSize]);
+        return $this->previewModelFactory->create(['category' => $category, 'size' => $pageSize, 'search' => $search]);
     }
 
     /**

--- a/src/module-elasticsuite-virtual-category/Model/Preview.php
+++ b/src/module-elasticsuite-virtual-category/Model/Preview.php
@@ -50,15 +50,17 @@ class Preview extends \Smile\ElasticsuiteCatalog\Model\ProductSorter\AbstractPre
      * @param ItemDataFactory           $previewItemFactory       Preview item factory.
      * @param QueryFactory              $queryFactory             QueryInterface factory.
      * @param int                       $size                     Preview size.
+     * @param string                    $search                   Preview search.
      */
     public function __construct(
         CategoryInterface $category,
         FulltextCollectionFactory $productCollectionFactory,
         ItemDataFactory $previewItemFactory,
         QueryFactory $queryFactory,
-        $size = 10
+        $size = 10,
+        $search = ''
     ) {
-        parent::__construct($productCollectionFactory, $previewItemFactory, $queryFactory, $category->getStoreId(), $size);
+        parent::__construct($productCollectionFactory, $previewItemFactory, $queryFactory, $category->getStoreId(), $size, $search);
         $this->category     = $category;
         $this->queryFactory = $queryFactory;
     }

--- a/src/module-elasticsuite-virtual-category/view/adminhtml/ui_component/category_form.xml
+++ b/src/module-elasticsuite-virtual-category/view/adminhtml/ui_component/category_form.xml
@@ -143,6 +143,7 @@
                         <item name="dataScope" xsi:type="string">sorted_products</item>
                         <item name="pageSize" xsi:type="string">20</item>
                         <item name="allowBlacklist" xsi:type="boolean">true</item>
+                        <item name="allowSearch" xsi:type="boolean">true</item>
                         <item name="messages" xsi:type="array">
                             <item name="emptyText" xsi:type="string" translate="true"><![CDATA[Your product selection is empty for the selected Store View. If you are running a multi-store setup, please check this <a href='https://github.com/Smile-SA/elasticsuite/wiki/VirtualCategories#previewing-virtual-categories-on-a-multi-store-setup'>manual page</a> for more informations.]]></item>
                         </item>


### PR DESCRIPTION
Finalization of PR #1183 which was a proof of concept for #157 

Rebased on 2.6.x and squashed @rikwillems commits and treated https://github.com/Smile-SA/elasticsuite/pull/1183#issuecomment-442540605 
- search form is not visible in the search term merchandizer screen
- on the category products preview, the search form is only visible if there are products or there is an outstanding search
- added i18n for de_DE, fr_FR and en_US