### PR TITLE
Fix graphql compatibility

### DIFF
--- a/src/module-elasticsuite-catalog/Plugin/Search/RequestMapperPlugin.php
+++ b/src/module-elasticsuite-catalog/Plugin/Search/RequestMapperPlugin.php
@@ -40,6 +40,7 @@ class RequestMapperPlugin
     private $fieldMapper = [
         'price'        => 'price.price',
         'position'     => 'category.position',
+        'category_id'  => 'category.category_id',
         'category_ids' => 'category.category_id',
     ];
 

--- a/src/module-elasticsuite-core/etc/di.xml
+++ b/src/module-elasticsuite-core/etc/di.xml
@@ -429,4 +429,14 @@
             </argument>
         </arguments>
     </type>
+
+    <!-- PageSize Provider for Elasticsuite -->
+    <type name="Magento\Search\Model\Search\PageSizeProvider">
+        <arguments>
+            <argument name="pageSizeBySearchEngine" xsi:type="array">
+                <!-- Consistent with index.max_result_window default value. No real point about getting more docs at once. -->
+                <item name="elasticsuite" xsi:type="number">100000</item>
+            </argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
For now, these 2 fixes allows to run Venia PWA in front of a Magento 2.3 with Elasticsuite.

Only catalog search is supported for now, since Venia uses legacy "Product" endpoint for category navigation.