### PR TITLE
head.additional declaration

### DIFF
--- a/src/module-elasticsuite-tracker/view/frontend/layout/default.xml
+++ b/src/module-elasticsuite-tracker/view/frontend/layout/default.xml
@@ -17,11 +17,11 @@
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <head>
-        <link src="Smile_ElasticsuiteTracker::js/tracking.js" />
+        <script src="Smile_ElasticsuiteTracker::js/tracking.js" />
     </head>
     <body>
-        <referenceContainer name="head.additional">
-            <block template="config.phtml" class="Smile\ElasticsuiteTracker\Block\Config" name="smile.tracker.config">
+        <referenceBlock name="head.additional">
+            <block template="Smile_ElasticsuiteTracker::config.phtml" class="Smile\ElasticsuiteTracker\Block\Config" name="smile.tracker.config">
                 <arguments>
                     <argument name="userConsentScript" xsi:type="string">Smile_ElasticsuiteTracker/js/user-consent</argument>
                     <argument name="userConsentConfig" xsi:type="array">
@@ -30,7 +30,7 @@
                     </argument>
                 </arguments>
             </block>
-        </referenceContainer>
+        </referenceBlock>
         <referenceContainer name="before.body.end">
             <block class="Smile\ElasticsuiteTracker\Block\Variables\Page\Base" name="smile.tracker.page.base" />
             <block class="Smile\ElasticsuiteTracker\Block\Variables\Page\Catalog" name="smile.tracker.page.catalog" />


### PR DESCRIPTION
Good afternoon,

Just one typo error with the script declaration "_Smile_ElasticsuiteTracker::js/tracking.js_" (anyway, it include correctly this javascript file).

And some inconsistents with the declaration of head.additional which is a block not a container 
(Same problem on Magento_GoogleAnalytics, this is not solved in my version of _Magento 2.3_ - https://github.com/magento/magento2/issues/16497)

Personally, I would rather move the script tracking.js into _before.body.end_ before _smile.tracker.page.base_ block.
I think you recommends to place it in the <head>, so if someone aborts a load of the page, the script might get executed.
"It helps you to accurately record traffic stats because your header scripts are loaded earlier than any other scripts on your page."

Cheers,
Ilan PARMENTIER