### PR TITLE
Lowercase given sort direction for missing

### DIFF
--- a/src/module-elasticsuite-core/Search/Request/SortOrder/Standard.php
+++ b/src/module-elasticsuite-core/Search/Request/SortOrder/Standard.php
@@ -60,7 +60,7 @@ class Standard implements SortOrderInterface
         $this->name      = $name;
         $this->missing   = $missing;
         if ($this->missing === null) {
-            $this->missing = $direction == self::SORT_ASC ? self::MISSING_LAST : self::MISSING_FIRST;
+            $this->missing = strtolower($direction) == self::SORT_ASC ? self::MISSING_LAST : self::MISSING_FIRST;
         }
     }
 


### PR DESCRIPTION
Lowercase that given direction to make sure that neither magento (which it does sometimes) nor a dev can input uppercase and you get some wrong results.