### PR TITLE
Add Magento\Framework\App\ResourceConnection table name altering plugins to di.xml

### DIFF
--- a/src/module-elasticsuite-catalog/etc/di.xml
+++ b/src/module-elasticsuite-catalog/etc/di.xml
@@ -223,4 +223,9 @@
     <type name="Smile\ElasticsuiteCore\Model\Search\RequestMapper">
         <plugin name="catalogProductRequestMapper" type="Smile\ElasticsuiteCatalog\Plugin\Search\RequestMapperPlugin" sortOrder="10"/>
     </type>
+
+    <type name="Magento\Framework\App\ResourceConnection">
+        <plugin name="get_catalog_category_product_index_table_name" type="Magento\Catalog\Model\Indexer\Category\Product\Plugin\TableResolver"/>
+        <plugin name="get_catalog_product_price_index_table_name" type="Magento\Catalog\Model\Indexer\Product\Price\Plugin\TableResolver"/>
+    </type>
 </config>


### PR DESCRIPTION
Fixes my particular issue (#1322) on a migrated store from M1 to M2 where price indexes were being retrieved from a wrong database table.

The issue here is that Magento is using 2 plugins for Magento\Framework\App\ResourceConnection class but only on frontend area to alter the name of the "catalog_product_index_price" which is not the case when reindexing data, the scope is then adminhtml.

I think this might also be a Magento core issue, so if that's the case, please let me know.