### PR TITLE
Add an alt attribute to the tracking image.

### DIFF
--- a/src/module-elasticsuite-tracker/view/frontend/web/js/tracking.js
+++ b/src/module-elasticsuite-tracker/view/frontend/web/js/tracking.js
@@ -145,6 +145,7 @@ var smileTracker = (function () {
                 var trackingUrl = getTrackerUrl.bind(this)();
                 var imgNode = document.createElement('img');
                 imgNode.setAttribute('src', trackingUrl);
+                imgNode.setAttribute('alt', '');
                 setTrackerStyle(imgNode);
                 bodyNode.appendChild(imgNode);
                 this.trackerSent = true;


### PR DESCRIPTION
The tracking pixel is flagged by WCAG accessibility scanners because it doesn't have an alt tag. This change adds an empty alt attribute which means it's treated as a decorative image.