### PR TITLE
Allow resetting the sort order to an empty array

### DIFF
--- a/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Fulltext/Collection.php
+++ b/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Fulltext/Collection.php
@@ -22,6 +22,7 @@ use Smile\ElasticsuiteCore\Search\Adapter\Elasticsuite\Response\QueryResponse;
  * Search engine product collection.
  *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(PHPMD.ExcessivePublicCount)
  *
  * @category Smile
  * @package  Smile\ElasticsuiteCatalog

--- a/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Fulltext/Collection.php
+++ b/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Fulltext/Collection.php
@@ -208,6 +208,18 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Product\Collection
     }
 
     /**
+     * Reset the sort order.
+     *
+     * @return self
+     */
+    public function resetOrder()
+    {
+        $this->_orders = [];
+
+        return $this;
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function addFieldToFilter($field, $condition = null)


### PR DESCRIPTION
In a normal Magento collection you would do something like this:

`$collection->getSelect()->reset(Zend_Db_Select::ORDER);`

However, this obviously wouldn't work for elasticsuite.