### PR TITLE
Add an alt attribute to the tracking image.

### DIFF
--- a/src/module-elasticsuite-tracker/view/frontend/web/js/tracking.js
+++ b/src/module-elasticsuite-tracker/view/frontend/web/js/tracking.js
@@ -145,6 +145,7 @@ var smileTracker = (function () {
                 var trackingUrl = getTrackerUrl.bind(this)();
                 var imgNode = document.createElement('img');
                 imgNode.setAttribute('src', trackingUrl);
+                imgNode.setAttribute('alt', '');
                 setTrackerStyle(imgNode);
                 bodyNode.appendChild(imgNode);
                 this.trackerSent = true;


### PR DESCRIPTION
Add an alt tag to the tracking pixel so that it is treated as a decorative element in WCAG scanners.