### PR TITLE
Change all sort directions to lowercase

### DIFF
--- a/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Fulltext/Collection.php
+++ b/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Fulltext/Collection.php
@@ -202,7 +202,7 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Product\Collection
      */
     public function setOrder($attribute, $dir = self::SORT_ORDER_DESC)
     {
-        $this->_orders[$attribute] = $dir;
+        $this->_orders[$attribute] = strtolower($dir);
 
         return $this;
     }


### PR DESCRIPTION
Uppercase sort direction causes Elasticsearch (v2.4.x) to default to `asc`.