### PR TITLE
Fix issue with missing values on swatches attributes filters

### DIFF
--- a/src/module-elasticsuite-swatches/Block/Navigation/Renderer/Swatches/RenderLayered.php
+++ b/src/module-elasticsuite-swatches/Block/Navigation/Renderer/Swatches/RenderLayered.php
@@ -32,7 +32,7 @@ class RenderLayered extends \Magento\Swatches\Block\LayeredNavigation\RenderLaye
     protected function getFilterOption(array $filterItems, Option $swatchOption)
     {
         $resultOption = false;
-        $filterItem = $this->getFilterItemById($filterItems, $swatchOption->getLabel());
+        $filterItem = $this->getFilterItemById($filterItems, $swatchOption->getValue());
         if ($filterItem && $this->isOptionVisible($filterItem)) {
             $resultOption = $this->getOptionViewData($filterItem, $swatchOption);
         }


### PR DESCRIPTION
Hi!

I found an issue with a particular swatch attribute type only: there is no value in the left sidebar on categories but all my products have a value for this attribute! It's weird!

### Preconditions
Magento Version : EE 2.3
ElasticSuite Version : 2.7.5 (latest)
Environment : Developer and Production

### Steps to reproduce
1. Add a swatch attribute into filters. Please verify that your products have a value for this!
2. Go to a category page
3. Check your availables filters on the left

### Expected result
1. All my products related attribute values are available for filtering

### Actual result
1. This attribute is not filterable, there is no value

### Fix
I found the bug for this particular case, there is a comparaison between value (= ID) and label !

NOTE : After checking all branches, it appears this bug concerns all ElasticSuite versions! So you can merge in all branches :)

Thanks!