### PR TITLE
Fix: product-sorter - scope-selector readiness detection

### DIFF
--- a/src/module-elasticsuite-catalog/view/adminhtml/web/js/form/element/product-sorter.js
+++ b/src/module-elasticsuite-catalog/view/adminhtml/web/js/form/element/product-sorter.js
@@ -79,8 +79,7 @@ define([
             this.currentSize        = this.pageSize;
             this.enabled            = this.loadUrl != null;
             this.search             = ko.observable("");
-            this.previewOnlyMode    = (this.scopeSwitcher != null) && (parseInt(this.scopeSwitcher, 10) == 0) && (this.formData.store_id != 0);
-            this.initialSwitchCopy  = this.previewOnlyMode;
+            this.previewOnlyMode    = this.isComponentLinked() && this.isInitialSwitchCopy();
 
             this.observe(['products', 'countTotalProducts', 'currentSize', 'editPositions', 'loading', 'showSpinner', 'blacklistedProducts', 'previewOnlyMode']);
 
@@ -116,7 +115,27 @@ define([
             }
         },
 
+        isComponentLinked: function() {
+            return this.scopeSwitcher !== undefined && this.scopeSwitcher !== null;
+        },
+
+        isInitialSwitchCopy: function () {
+            if (!this.isComponentLinked()) {
+                return true;
+            }
+
+            if (this.initialSwitchCopy === undefined) {
+                this.initialSwitchCopy = parseInt(this.scopeSwitcher, 10) == 0 && this.formData['store_id'] != 0;
+            }
+
+            return this.initialSwitchCopy;
+        },
+
         switchScope: function(useStorePositions) {
+            if (!this.isComponentLinked()) {
+                return;
+            }
+
             if (parseInt(useStorePositions, 10) == 0) {
                 // Backup current store level positions and blacklist.
                 this.storeSortedProducts = JSON.stringify(this.editPositions());
@@ -125,7 +144,7 @@ define([
                 this.editPositions = JSON.parse(this.defaultSortedProducts);
                 this.blacklistedProducts(this.defaultBlacklistedProducts.slice(0));
             } else {
-                if (this.initialSwitchCopy) {
+                if (this.isInitialSwitchCopy()) {
                     // Copy current (default) positions and blacklist to store level.
                     this.storeSortedProducts = JSON.stringify(this.editPositions());
                     this.storeBlacklistedProducts = this.blacklistedProducts().slice(0);


### PR DESCRIPTION
Random crash on Catalog >> Category page in admin.   

The issue is much easier to replicate when you enable xDebug. Overall the problem is caused by a race-condition of different ui-components, which means that it's occurring randomly and might take some time to repeat.

    Uncaught SyntaxError: Unexpected end of JSON input (product-sorter.js.125)

---------------------------------------

# Pre-requisites

1. Use latest M2 2.2.X release (2.2.8 at the time of writing).
2. Enable xDebug

# Steps

1. Log into admin
2. Navigate to Catalog >> Categories
3. Select any category (root category is also fine)
4. Reload the Category Page repeatedly

# Expected

1. Category page is fully loaded and categories are shown

# Actual

1. Category page is not loaded fully, loading indicator is shown, js error in console 

---------------------------------------

# Symptoms

The sorted_products initiates sometimes (because require.js is async and initiates components somewhat randomly when they're on same level) before the ui.checkbox for use_store_positions which means that switchScope triggers when it's default value is being set.

This is not intended behaviour and the product sorting control actually switch to disabled state even when in store_id=0 scope.

# Discussion

Luckily for us, the ui-components listens VS imports has been built so that the processing of imports mapping triggers after value change listens (I presume that the previous code in this specific JS file already was trying to fix the same issue that this PR is re-visiting); This means that while the initial value is being set (when the components that we're listening) is not yet fully initiated, the import target is not even properly set yet.

Therefore the scopeSwitcher (import target) is not yet set (undefined), and will be set AFTER the source element has properly initiated.

# Solution

This could be seen as a core M2 bug as one could argue that listeners should not be notified when the thing they're listening to is not yet properly set up.

But in the context of product-sorter: we can just ignore calls to switchScope until the imported value of scopeSwitcher has actually been imported (which means that it ends up being either 1 or 0, but definitely not undefined).

NOTE: even if we see this as core bug, you'd still want this module to provide a solution that works for all M2 releases.