### PR TITLE
Allow Inventory Data indexer to work without MSI

### DIFF
--- a/src/module-elasticsuite-catalog/Model/Product/Indexer/Fulltext/Datasource/InventoryData.php
+++ b/src/module-elasticsuite-catalog/Model/Product/Indexer/Fulltext/Datasource/InventoryData.php
@@ -13,7 +13,8 @@
 namespace Smile\ElasticsuiteCatalog\Model\Product\Indexer\Fulltext\Datasource;
 
 use Smile\ElasticsuiteCore\Api\Index\DatasourceInterface;
-use Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Indexer\Fulltext\Datasource\InventoryDataInterface as ResourceModel;
+use Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Indexer\Fulltext\Datasource\InventoryDataInterface;
+use \Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Indexer\Fulltext\Datasource\Deprecation\InventoryData as Deprecation;
 
 /**
  * Datasource used to append inventory data to product during indexing.
@@ -25,18 +26,32 @@ use Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Indexer\Fulltext\Datas
 class InventoryData implements DatasourceInterface
 {
     /**
-     * @var \Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Indexer\Fulltext\Datasource\InventoryDataInterface
+     * @var InventoryDataInterface
      */
     private $resourceModel;
 
     /**
+     * @var \Magento\Framework\ObjectManagerInterface
+     */
+    private $objectManager;
+
+    /**
+     * @var \Magento\Framework\ObjectManager\ConfigInterface
+     */
+    private $config;
+
+    /**
      * Constructor.
      *
-     * @param ResourceModel $resourceModel Resource model.
+     * @param \Magento\Framework\ObjectManagerInterface        $objectManager Object Manager
+     * @param \Magento\Framework\ObjectManager\ConfigInterface $config        Configuration
      */
-    public function __construct(ResourceModel $resourceModel)
-    {
-        $this->resourceModel = $resourceModel;
+    public function __construct(
+        \Magento\Framework\ObjectManagerInterface $objectManager,
+        \Magento\Framework\ObjectManager\ConfigInterface $config
+    ) {
+        $this->objectManager = $objectManager;
+        $this->config        = $config;
     }
 
     /**
@@ -45,7 +60,7 @@ class InventoryData implements DatasourceInterface
      */
     public function addData($storeId, array $indexData)
     {
-        $inventoryData = $this->resourceModel->loadInventoryData($storeId, array_keys($indexData));
+        $inventoryData = $this->getResourceModel()->loadInventoryData($storeId, array_keys($indexData));
 
         foreach ($inventoryData as $inventoryDataRow) {
             $productId = (int) $inventoryDataRow['product_id'];
@@ -56,5 +71,37 @@ class InventoryData implements DatasourceInterface
         }
 
         return $indexData;
+    }
+
+    /**
+     * Init proper resource model.
+     *
+     * Should be default implementation of InventoryDataInterface if MSI modules are enabled.
+     *
+     * Otherwise we fallback to old-style CatalogInventory indexing.
+     *
+     * @deprecated To be removed with Magento 2.4 and the dismantlement of legacy CatalogInventory module.
+     *
+     * @return InventoryDataInterface
+     */
+    private function getResourceModel() : InventoryDataInterface
+    {
+        if ($this->resourceModel === null) {
+            $resourceName = InventoryDataInterface::class;
+
+            try {
+                // Will try to fetch default implementation and fail in case of missing MSI modules or dependencies.
+                $stockResolver = $this->config->getPreference(\Magento\InventorySalesApi\Api\StockResolverInterface::class);
+                if (ltrim($stockResolver, '\\') === ltrim(\Magento\InventorySalesApi\Api\StockResolverInterface::class, '\\')) {
+                    $resourceName = Deprecation::class;
+                }
+            } catch (\Exception $exception) {
+                ; // Nothing to do, it's already kinda hacky to allow this deprecation fallback to happen.
+            }
+
+            $this->resourceModel = $this->objectManager->get($resourceName);
+        }
+
+        return $this->resourceModel;
     }
 }

--- a/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Indexer/Fulltext/Datasource/Deprecation/InventoryData.php
+++ b/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Indexer/Fulltext/Datasource/Deprecation/InventoryData.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * DISCLAIMER
+ * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\ElasticsuiteCatalog
+ * @author    Romain Ruaud <romain.ruaud@smile.fr>
+ * @copyright 2019 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+
+namespace Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Indexer\Fulltext\Datasource\Deprecation;
+
+use Magento\CatalogInventory\Api\StockConfigurationInterface;
+use Magento\CatalogInventory\Api\StockRegistryInterface;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\EntityManager\MetadataPool;
+use Magento\Store\Model\StoreManagerInterface;
+use Smile\ElasticsuiteCatalog\Model\ResourceModel\Eav\Indexer\Indexer;
+use Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Indexer\Fulltext\Datasource\InventoryDataInterface;
+
+/**
+ * Legacy Inventory Data Source
+ *
+ * @category Smile
+ * @package  Smile\ElasticsuiteCatalog
+ * @author   Romain Ruaud <romain.ruaud@smile.fr>
+ *
+ * @deprecated To be removed once the legacy Magento CatalogInventory module is dismantled.
+ */
+class InventoryData extends Indexer implements InventoryDataInterface
+{
+    /**
+     * @var \Magento\CatalogInventory\Api\StockRegistryInterface
+     */
+    private $stockRegistry;
+
+    /**
+     * @var \Magento\CatalogInventory\Api\StockConfigurationInterface
+     */
+    private $stockConfiguration;
+
+    /**
+     * @var int[]
+     */
+    private $stockIdByWebsite = [];
+
+    /**
+     * InventoryData constructor.
+     *
+     * @param ResourceConnection          $resource           Database adapter.
+     * @param StoreManagerInterface       $storeManager       Store manager.
+     * @param MetadataPool                $metadataPool       Metadata Pool
+     * @param StockRegistryInterface      $stockRegistry      Stock registry.
+     * @param StockConfigurationInterface $stockConfiguration Stock configuration.
+     */
+    public function __construct(
+        ResourceConnection $resource,
+        StoreManagerInterface $storeManager,
+        MetadataPool $metadataPool,
+        StockRegistryInterface $stockRegistry,
+        StockConfigurationInterface $stockConfiguration
+    ) {
+        $this->stockRegistry      = $stockRegistry;
+        $this->stockConfiguration = $stockConfiguration;
+
+        parent::__construct($resource, $storeManager, $metadataPool);
+    }
+
+    /**
+     * Load inventory data for a list of product ids and a given store.
+     *
+     * @param integer $storeId    Store id.
+     * @param array   $productIds Product ids list.
+     *
+     * @return array
+     */
+    public function loadInventoryData($storeId, $productIds)
+    {
+        $websiteId = $this->getWebsiteId($storeId);
+        $stockId   = $this->getStockId($websiteId);
+
+        $select = $this->getConnection()->select()
+            ->from(['ciss' => $this->getTable('cataloginventory_stock_status')], ['product_id', 'stock_status', 'qty'])
+            ->where('ciss.stock_id = ?', $stockId)
+            ->where('ciss.website_id = ?', $this->stockConfiguration->getDefaultScopeId())
+            ->where('ciss.product_id IN(?)', $productIds);
+
+        return $this->getConnection()->fetchAll($select);
+    }
+
+    /**
+     * Retrieve stock_id by store
+     *
+     * @param int $websiteId The website Id
+     *
+     * @return int
+     */
+    private function getStockId($websiteId)
+    {
+        if (!isset($this->stockIdByWebsite[$websiteId])) {
+            $stockId = $this->stockRegistry->getStock($websiteId)->getStockId();
+            $this->stockIdByWebsite[$websiteId] = $stockId;
+        }
+
+        return $this->stockIdByWebsite[$websiteId];
+    }
+
+    /**
+     * Retrieve Website Id by Store Id
+     *
+     * @param int $storeId The store id
+     *
+     * @return int
+     */
+    private function getWebsiteId($storeId)
+    {
+        return $this->storeManager->getStore($storeId)->getWebsiteId();
+    }
+}


### PR DESCRIPTION
Fix for #1243 

Introduce a Deprecation model that allow continue working with legacy CatalogInventory tables in case of MSI is disabled.