### PR TITLE
Use correct method to add / remove class name

### DIFF
--- a/src/module-elasticsuite-catalog/view/adminhtml/templates/catalog/product/attribute/js.phtml
+++ b/src/module-elasticsuite-catalog/view/adminhtml/templates/catalog/product/attribute/js.phtml
@@ -51,11 +51,11 @@
 
                 if($('frontend_input') && ($('frontend_input').value=='select' || $('frontend_input').value=='multiselect')){
                     panel.show();
-                    panel.addClass(activePanelClass);
+                    panel.addClassName(activePanelClass);
                 }
                 else {
                     panel.hide();
-                    panel.removeClass(activePanelClass);
+                    panel.removeClassName(activePanelClass);
                 }
             }
         }


### PR DESCRIPTION
In admin, it seems the global `$` refers to PrototypeJS instead of jQuery. This `js.phtml` is otherwise aware of this, but it still assumes in one method that `$` refers to jQuery. This causes the following error:
```
Uncaught TypeError: panel.removeClass is not a function
    at checkOptionsPanelVisibility ((index):1371)
    at bindAttributeInputType ((index):1378)
    at HTMLDocument.<anonymous> ((index):1688)
    at fire (jquery.js:3232)
    at Object.add [as done] (jquery.js:3291)
    at jQuery.fn.init.jQuery.fn.ready (jquery.js:3542)
    at jQuery.fn.init (jquery.js:2967)
    at new jQuery.fn.init (jquery-migrate.js:231)
    at jQuery (jquery.js:75)
    at (index):1687
```