### PR TITLE
Remove Layer plugin reference

### DIFF
--- a/src/module-elasticsuite-catalog/Plugin/LayerPlugin.php
+++ b/src/module-elasticsuite-catalog/Plugin/LayerPlugin.php
@@ -42,15 +42,11 @@ class LayerPlugin
     /**
      * Constructor.
      *
-     * @param \Magento\CatalogInventory\Helper\Stock             $stockHelper   Stock helper.
-     * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig   Configuration.
      * @param \Magento\Search\Model\QueryFactory                 $queryFactory  Search query factory.
      * @param \Magento\Catalog\Model\Config                      $catalogConfig Catalog Configuration.
      * @param \Smile\ElasticsuiteCore\Helper\Mapping             $mappingHelper Mapping Helper.
      */
     public function __construct(
-        \Magento\CatalogInventory\Helper\Stock $stockHelper,
-        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
         \Magento\Search\Model\QueryFactory $queryFactory,
         \Magento\Catalog\Model\Config $catalogConfig,
         \Smile\ElasticsuiteCore\Helper\Mapping $mappingHelper

--- a/src/module-elasticsuite-catalog/Plugin/LayerPlugin.php
+++ b/src/module-elasticsuite-catalog/Plugin/LayerPlugin.php
@@ -13,8 +13,6 @@
  */
 namespace Smile\ElasticsuiteCatalog\Plugin;
 
-use Magento\CatalogInventory\Model\Plugin\Layer;
-
 /**
  * Replace is in stock native filter on layer.
  *
@@ -22,7 +20,7 @@ use Magento\CatalogInventory\Model\Plugin\Layer;
  * @package   Smile\ElasticsuiteCatalog
  * @author    Aurelien FOUCRET <aurelien.foucret@smile.fr>
  */
-class LayerPlugin extends \Magento\CatalogInventory\Model\Plugin\Layer
+class LayerPlugin
 {
     /**
      * @var \Magento\Search\Model\QueryFactory
@@ -57,7 +55,6 @@ class LayerPlugin extends \Magento\CatalogInventory\Model\Plugin\Layer
         \Magento\Catalog\Model\Config $catalogConfig,
         \Smile\ElasticsuiteCore\Helper\Mapping $mappingHelper
     ) {
-        parent::__construct($stockHelper, $scopeConfig);
         $this->queryFactory  = $queryFactory;
         $this->catalogConfig = $catalogConfig;
         $this->mappingHelper = $mappingHelper;


### PR DESCRIPTION
https://github.com/Smile-SA/elasticsuite/issues/1442

Magento 2.3.2 removed this plugin, see: https://github.com/magento/magento2/tree/2.3.2/app/code/Magento/CatalogInventory/Model/Plugin

I removed all references to this plugin within the ElasticSuite plugin