### PR TITLE
Temp di fix for 2.3.2 magento upgrade with 2.8.0

### DIFF
--- a/src/module-elasticsuite-catalog/etc/di.xml
+++ b/src/module-elasticsuite-catalog/etc/di.xml
@@ -16,6 +16,38 @@
  */
  -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+<virtualType name="elasticsearchLayerCategoryItemCollectionProvider" type="Magento\Elasticsearch\Model\Layer\Category\ItemCollectionProvider">
+        <arguments>
+            <argument name="factories" xsi:type="array">
+                <item name="elasticsuite" xsi:type="object">Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Fulltext\CollectionFactory</item>
+            </argument>
+        </arguments>
+    </virtualType>
+
+    <type name="Magento\CatalogSearch\Model\Search\ItemCollectionProvider">
+        <arguments>
+            <argument name="factories" xsi:type="array">
+                <item name="elasticsuite" xsi:type="object">elasticsearchAdvancedCollectionFactory</item>
+            </argument>
+        </arguments>
+    </type>
+
+    <type name="Magento\CatalogSearch\Model\Advanced\ProductCollectionPrepareStrategyProvider">
+        <arguments>
+            <argument name="strategies" xsi:type="array">
+                <item name="elasticsuite" xsi:type="object">Magento\Elasticsearch\Model\Advanced\ProductCollectionPrepareStrategy</item>
+            </argument>
+        </arguments>
+    </type>
+
+    <virtualType name="elasticsearchLayerSearchItemCollectionProvider" type="Magento\Elasticsearch\Model\Layer\Search\ItemCollectionProvider">
+        <arguments>
+            <argument name="factories" xsi:type="array">
+                <item name="elasticsuite" xsi:type="object">Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Fulltext\CollectionFactory</item>
+            </argument>
+        </arguments>
+    </virtualType>
+
 
     <virtualType name="catalogProductSearchIndexHandler" type="\Smile\ElasticsuiteCore\Indexer\GenericIndexerHandler">
         <arguments>


### PR DESCRIPTION
This solved all of my front-end issues with 2.3.2 Magento Commerce Edition..

I did have to re-install the Plugin from 2.3.1 in catalog-inventory module that was missing or disable the Elasticsuite layer plugin for addisinstock method as well.