### PR TITLE
Fixes #1494 JS error Optimizer empty terms selection

### DIFF
--- a/src/module-elasticsuite-catalog-optimizer/Ui/Component/Optimizer/Form/Modifier/SearchTerms.php
+++ b/src/module-elasticsuite-catalog-optimizer/Ui/Component/Optimizer/Form/Modifier/SearchTerms.php
@@ -67,8 +67,11 @@ class SearchTerms implements \Magento\Ui\DataProvider\Modifier\ModifierInterface
             if (isset($data[$optimizer->getId()]['quick_search_container'])
                 && isset($data[$optimizer->getId()]['quick_search_container']['query_ids'])) {
                 $queriesData = $this->fillQueryData($data[$optimizer->getId()]['quick_search_container']['query_ids']);
+                $data[$optimizer->getId()]['quick_search_container']['query_ids'] = [];
+                $data[$optimizer->getId()]['quick_search_container']['apply_to'] = (int) false;
                 if (!empty($queriesData)) {
                     $data[$optimizer->getId()]['quick_search_container']['query_ids'] = $queriesData;
+                    $data[$optimizer->getId()]['quick_search_container']['apply_to'] = (int) true;
                 }
             }
         }


### PR DESCRIPTION
The fix obviously looks like a fix, there might be in the future a need of a rework or refactoring of 
- \Smile\ElasticsuiteCatalogOptimizer\Model\Optimizer\Limitation\ReadHandler
- \Smile\ElasticsuiteCatalogOptimizer\Ui\Component\Optimizer\Form\Modifier\Limitation
- \Smile\ElasticsuiteCatalogOptimizer\Ui\Component\Optimizer\Form\Modifier\SearchTerms

which have redundant and interdependent code.