### PR TITLE
Check if index already exists

### DIFF
--- a/src/module-elasticsuite-core/Indexer/GenericIndexerHandler.php
+++ b/src/module-elasticsuite-core/Indexer/GenericIndexerHandler.php
@@ -168,7 +168,9 @@ class GenericIndexerHandler implements IndexerInterface
     public function cleanIndex($dimensions)
     {
         foreach ($dimensions as $dimension) {
-            $this->indexOperation->createIndex($this->indexName, $dimension->getValue());
+            if (!$this->indexOperation->indexExists($this->indexName, $dimension->getValue())) {
+                $this->indexOperation->createIndex($this->indexName, $dimension->getValue());
+            }
         }
 
         return $this;


### PR DESCRIPTION
We added that code in our project to prevent this annoying issue. In our case we install Magento in a build pipeline. Sometimes up to ten times the build crashes.
The fix adds a check if the index already exists.
Please have a look on that. Seems that this fixes issue #1086 