### PR TITLE
fix: prevent internal error in GraphQL queries

### DIFF
--- a/src/module-elasticsuite-virtual-category/etc/di.xml
+++ b/src/module-elasticsuite-virtual-category/etc/di.xml
@@ -116,13 +116,5 @@
 
     <preference for="Smile\ElasticsuiteCatalog\Model\Category\Filter\Provider" type="Smile\ElasticsuiteVirtualCategory\Model\Category\Filter\Provider"/>
 
-    <!-- REST Api compatibility -->
-    <type name="Magento\Eav\Model\TypeLocator">
-        <arguments>
-            <argument name="typeLocators" xsi:type="array">
-                <item name="virtualCategoryType" sortOrder="1" xsi:type="object">Smile\ElasticsuiteVirtualCategory\Model\Webapi\TypeLocator\VirtualCategoryLocator</item>
-            </argument>
-        </arguments>
-    </type>
     <preference for="Smile\ElasticsuiteVirtualCategory\Api\Data\VirtualRuleInterface" type="Smile\ElasticsuiteVirtualCategory\Model\Rule"/>
 </config>

--- a/src/module-elasticsuite-virtual-category/etc/webapi_rest/di.xml
+++ b/src/module-elasticsuite-virtual-category/etc/webapi_rest/di.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Smile_ElasticsuiteVirtualCategory DI.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade Smile ElasticSuite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\ElasticsuiteVirtualCategory
+ * @author    Aurelien FOUCRET <aurelien.foucret@smile.fr>
+ * @copyright 2019 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+ -->
+
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+
+    <type name="Magento\Eav\Model\TypeLocator">
+        <arguments>
+            <argument name="typeLocators" xsi:type="array">
+                <item name="virtualCategoryType" sortOrder="1" xsi:type="object">Smile\ElasticsuiteVirtualCategory\Model\Webapi\TypeLocator\VirtualCategoryLocator</item>
+            </argument>
+        </arguments>
+    </type>
+
+</config>


### PR DESCRIPTION
closes #1513

As discussed, this PR registers the `VirtualCategoryLocator` only in the `webapi_rest` context.

This prevents the GraphQL framework to try to create a field with an undefined `SmileElasticsuiteVirtualCategoryDataVirtualRuleInterface` type.

I left the `<preference for="Smile\ElasticsuiteVirtualCategory\Api\Data\VirtualRuleInterface" type="Smile\ElasticsuiteVirtualCategory\Model\Rule"/>` in the global `di.xml`.

If you think this would benefit from a test, I'd appreciate guidance to know where you'd prefer to add it.