### PR TITLE
Bugfix: Ordering is not applied

### DIFF
--- a/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Fulltext/Collection.php
+++ b/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Fulltext/Collection.php
@@ -203,7 +203,8 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Product\Collection
     public function setOrder($attribute, $dir = self::SORT_ORDER_DESC)
     {
         $this->_orders[$attribute] = $dir;
-
+        // Reset Filter Rendering, because otherwise the new ordering will not be picked up by ::_renderFiltersBefore  
+        $this->_isFiltersRendered = false;
         return $this;
     }
 


### PR DESCRIPTION
Hi,

I had a strange issue that the sorting was not applied to the collection. The reason for this is, that the collection has already rendered the filters, without an order. The ordering comes later through the Toolbar Block but it was not applied.

This tiny PR should fix it. 

Thanks for again these awesome module!

\- Thomas