### PR TITLE
Fixes partially sorted product on frontend

### DIFF
--- a/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Fulltext/Collection.php
+++ b/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Fulltext/Collection.php
@@ -414,6 +414,10 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Product\Collection
         }
 
         $this->getSelect()->where('e.entity_id IN (?)', ['in' => $docIds]);
+        if ($docIds) {
+            $ids = implode(',', $docIds);
+            $this->getSelect()->order(new \Zend_Db_Expr("FIELD(e.entity_id, $ids)"));
+        }
         $this->originalPageSize = $this->_pageSize;
         $this->_pageSize = false;
 


### PR DESCRIPTION
Since elasticsearch is already delivering sorted result, querying mysql without sorting will return entities sorted by ascending entity_id; therefore, if one or more entity has an id too big to fit in the pagination chunk, it won't appear in the frontend results.