### PR TITLE
Fix exception on full index generation, if magento uses table prefix

### DIFF
--- a/src/module-elasticsuite-virtual-category/Model/ResourceModel/Product/Indexer/Fulltext/Changelog/Writer.php
+++ b/src/module-elasticsuite-virtual-category/Model/ResourceModel/Product/Indexer/Fulltext/Changelog/Writer.php
@@ -61,7 +61,7 @@ class Writer
         $fullTextIndexer    = $this->indexerRegistry->get(\Magento\CatalogSearch\Model\Indexer\Fulltext::INDEXER_ID);
         $indexerChangeLog   = $fullTextIndexer->getView()->getChangelog();
 
-        $changelogTableName = $indexerChangeLog->getName();
+        $changelogTableName = $this->resource->getTableName($indexerChangeLog->getName());
         $columnName         = $indexerChangeLog->getColumnName();
 
         try {


### PR DESCRIPTION
We use `table_prefix' => 'prefix_`. When we updating a virtual category in adminhtml (e.g change product position), there will be an exception (only in logs):

~~~
Could not schedule products for reindexing : SQLSTATE[42S02]: Base table or view not found: 1146 Table 'magento.catalogsearch_fulltext_cl'
~~~

This pull request add table_prefix to `$changelogTableName`