### PR TITLE
Supporting extra parameters/config for metrics

### DIFF
--- a/src/module-elasticsuite-core/Search/Adapter/Elasticsuite/Request/Aggregation/Builder.php
+++ b/src/module-elasticsuite-core/Search/Adapter/Elasticsuite/Request/Aggregation/Builder.php
@@ -80,7 +80,8 @@ class Builder
             }
 
             foreach ($bucket->getMetrics() as $metric) {
-                $subAggregations[$metric->getName()] = [$metric->getType() => ['field' => $metric->getField()]];
+                $metricDefinition = array_merge(['field' => $metric->getField()], $metric->getConfig() ?? []);
+                $subAggregations[$metric->getName()] = [$metric->getType() => $metricDefinition];
             }
 
             foreach ($bucket->getPipelines() as $pipeline) {

--- a/src/module-elasticsuite-core/Search/Request/Aggregation/Metric.php
+++ b/src/module-elasticsuite-core/Search/Request/Aggregation/Metric.php
@@ -36,17 +36,24 @@ class Metric extends \Magento\Framework\Search\Request\Aggregation\Metric implem
     private $name;
 
     /**
+     * @var array
+     */
+    private $config;
+
+    /**
      * Constructor.
      *
-     * @param string $name  Metric name.
-     * @param string $type  Metric type.
-     * @param string $field Metric field.
+     * @param string $name   Metric name.
+     * @param string $type   Metric type.
+     * @param string $field  Metric field.
+     * @param array  $config Metric extra config.
      */
-    public function __construct($name, $type, $field)
+    public function __construct($name, $type, $field, $config = [])
     {
         parent::__construct($type);
         $this->field = $field;
         $this->name  = $name;
+        $this->config = $config;
     }
 
     /**
@@ -63,5 +70,13 @@ class Metric extends \Magento\Framework\Search\Request\Aggregation\Metric implem
     public function getName()
     {
         return $this->name;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getConfig()
+    {
+        return $this->config;
     }
 }

--- a/src/module-elasticsuite-core/Search/Request/MetricInterface.php
+++ b/src/module-elasticsuite-core/Search/Request/MetricInterface.php
@@ -54,4 +54,11 @@ interface MetricInterface
      * @return string
      */
     public function getName();
+
+    /**
+     * Metric extra config.
+     *
+     * @return array
+     */
+    public function getConfig();
 }


### PR DESCRIPTION
not available through the XML declaration though.

A case could be made that 
- "config" could be named "parameters", but "field" is already a parameter in itself
- not all metrics aggs do actually use a "field" parameter (see currently unsupported [weight avg aggregation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-weight-avg-aggregation.html))

Maybe a broader rework of metrics aggs is necessary in the long run.