### PR TITLE
Fixes #1581 Explicit fulltext collection page size

### DIFF
--- a/src/module-elasticsuite-catalog/Plugin/Ui/Category/Form/DataProviderPlugin.php
+++ b/src/module-elasticsuite-catalog/Plugin/Ui/Category/Form/DataProviderPlugin.php
@@ -237,6 +237,7 @@ class DataProviderPlugin
             /** @var \Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Fulltext\Collection $fulltextCollection */
             $fulltextCollection = $this->fulltextCollectionFactory->create();
             $fulltextCollection->setStoreId($storeId)
+                ->setPageSize(1)
                 ->addFieldToFilter('category_ids', $this->getCategoryFilterParam($category));
 
             $attributeSetIds = array_keys($fulltextCollection->getFacetedData('attribute_set_id'));


### PR DESCRIPTION
to avoid a pageSize of getSize() set in the collection ie all matching products.
Problematic on a virtual category without any rule set yet: the whole catalog matches.
Quite costly if the catalog is even of a medium size (~ 50K products).