### PR TITLE
Fixes #1591 Explicit fulltext collection page size

### DIFF
--- a/src/module-elasticsuite-catalog/Controller/Navigation/Filter/Ajax.php
+++ b/src/module-elasticsuite-catalog/Controller/Navigation/Filter/Ajax.php
@@ -116,6 +116,8 @@ class Ajax extends \Magento\Framework\App\Action\Action
 
         $this->applyFilters();
 
+        $this->layerResolver->get()->getProductCollection()->setPageSize(1);
+
         return $this;
     }
 


### PR DESCRIPTION
to avoid a pageSize of getSize() set in the collection ie all matching products.
Same issue as #1581 and same ugly fix for the time being.