### PR TITLE
Fixes #1591 #1581 Explicit collection page size

### DIFF
--- a/src/module-elasticsuite-catalog/Controller/Navigation/Filter/Ajax.php
+++ b/src/module-elasticsuite-catalog/Controller/Navigation/Filter/Ajax.php
@@ -116,6 +116,8 @@ class Ajax extends \Magento\Framework\App\Action\Action
 
         $this->applyFilters();
 
+        $this->layerResolver->get()->getProductCollection()->setPageSize(0);
+
         return $this;
     }
 

--- a/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Fulltext/Collection.php
+++ b/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Fulltext/Collection.php
@@ -222,6 +222,21 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Product\Collection
     /**
      * {@inheritDoc}
      */
+    public function setPageSize($size)
+    {
+        /*
+         * Explicitely setting the page size to false or null is to be treated as having not set any page size.
+         * That is: no pagination, all items are expected.
+         */
+        $size = ($size === null) ? false : $size;
+        $this->_pageSize = $size;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function addFieldToFilter($field, $condition = null)
     {
         $field = $this->mapFieldName($field);
@@ -532,7 +547,7 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Product\Collection
         $searchRequestName = $this->searchRequestName;
 
         // Pagination params.
-        $size = $this->_pageSize ? $this->_pageSize : $this->getSize();
+        $size = ($this->_pageSize !== false) ? $this->_pageSize : $this->getSize();
         $from = $size * (max(1, $this->_curPage) - 1);
 
         // Setup sort orders.

--- a/src/module-elasticsuite-catalog/Plugin/Ui/Category/Form/DataProviderPlugin.php
+++ b/src/module-elasticsuite-catalog/Plugin/Ui/Category/Form/DataProviderPlugin.php
@@ -237,7 +237,7 @@ class DataProviderPlugin
             /** @var \Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Fulltext\Collection $fulltextCollection */
             $fulltextCollection = $this->fulltextCollectionFactory->create();
             $fulltextCollection->setStoreId($storeId)
-                ->setPageSize(1)
+                ->setPageSize(0)
                 ->addFieldToFilter('category_ids', $this->getCategoryFilterParam($category));
 
             $attributeSetIds = array_keys($fulltextCollection->getFacetedData('attribute_set_id'));


### PR DESCRIPTION
when only fetching aggregations.
Keeps the "Show all" working by distinguishing between NO page size set ("Show all") and a page size of 0.
Also covers someone setting a page size of null for the fun.
