### PR TITLE
Fixes #1617 Use attribute id as last resort order

### DIFF
--- a/src/module-elasticsuite-catalog/view/adminhtml/web/js/category/filter-config/dynamic-rows.js
+++ b/src/module-elasticsuite-catalog/view/adminhtml/web/js/category/filter-config/dynamic-rows.js
@@ -45,7 +45,7 @@ define(['Magento_Ui/js/dynamic-rows/dynamic-rows'], function (DynamicRows) {
                     order = propOne.data().default_position - propTwo.data().default_position;
 
                     if (order === 0) {
-                        order = propOne.recordId - propTwo.recordId;
+                        order = propOne.data().attribute_id - propTwo.data().attribute_id;
                     }
                 }
 


### PR DESCRIPTION
which mirrors the way the collection of attributes is sorted when attributes have the same default_position (ie. attribute defined position).
Record id is only valid for initially UNpinned attributes.