### PR TITLE
Fix application of Math.round on slider histogram values

### DIFF
--- a/src/module-elasticsuite-catalog/view/frontend/web/js/range-slider-widget.js
+++ b/src/module-elasticsuite-catalog/view/frontend/web/js/range-slider-widget.js
@@ -47,7 +47,7 @@ define(['jquery', 'Magento_Catalog/js/price-utils', 'mage/template', 'Magento_Ui
             this.from         = Math.floor(this.options.currentValue.from * this.rate);
             this.to           = Math.round(this.options.currentValue.to * this.rate);
             this.intervals    = this.options.intervals.map(
-                function(item) { Math.round(item.value = item.value * this.rate); return item}.bind(this)
+                function(item) { item.value = Math.round(item.value * this.rate); return item}.bind(this)
             );
             this.minValue = Math.floor(this.options.minValue * this.rate);
             this.maxValue = Math.round(this.options.maxValue * this.rate);


### PR DESCRIPTION
Note that the side effect on the histogram values already worked beforehand.
It's just that values were not rounded.