### PR TITLE
Fix Elasticsearch result order not respected

### DIFF
--- a/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Fulltext/Collection.php
+++ b/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Fulltext/Collection.php
@@ -452,6 +452,17 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Product\Collection
         }
 
         $this->getSelect()->where('e.entity_id IN (?)', ['in' => $docIds]);
+
+        /**
+         * Elasticsearch result is already sorted (i.e., $docIds). Respect the order in MySQL query.
+         * @see https://dba.stackexchange.com/a/6053
+         * @see https://stackoverflow.com/a/8322898
+         */
+        $connection = $this->getSelect()->getConnection();
+        $this->getSelect()->order($connection->quoteInto('FIELD(?)', array_merge([
+            'e.entity_id',
+        ], $docIds)));
+
         $this->originalPageSize = $this->_pageSize;
         $this->_pageSize = false;
 


### PR DESCRIPTION
# Issue

Result returned from Elasticsearch is well sorted. However, during the MySQL query further, the order is not respected.

MySQL does not guarantee order of rows returned just by using WHERE clause. Instead, the only way to guarantee order is using ORDER BY clause.

https://dba.stackexchange.com/a/6053

**Related Issue**

- #1548

# Steps to replicate

Note: it may not be easy to replicate the issue, as we don't know exactly how MySQL sort results in query without ORDER BY, it may only trigger in certain environment setup.

I hope that the explanation in Stackoverflow above gives good enough reason to support the change.

1. Create products `p1`, `p2`, `p3`, `p4`, `p5`, `p6`, `p7`, `p8`, `p9`, `p10`, at prices $10, $9, $8, $7, $6, $5, $4, $3, $2, $1, respectively. (Make sure you create the product in the same order, as we would like the product ID assigned in acceding order). Assign them into a category.

2. Set the PLP page size to 9 products per page

3. Go to the PLP, sort product by price ascending.

**Expected result:**

Products are listed in order `p10`, `p9`, `p8`, `p7`, `p6`, `p5`, `p4`, `p3`, `p2`

**Actual results:**

Products are listed in random order.

# Demo

Below is the select query generated from the `\Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Fulltext\Collection::_renderFiltersBefore`

**Expected result**

```diff
SELECT
  `e`.entity_id,
  --  `e`.*,
  `price_index`.`price`, `price_index`.`tax_class_id`, `price_index`.`final_price`, IF(price_index.tier_price IS NOT NULL, LEAST(price_index.min_price, price_index.tier_price), price_index.min_price) AS `minimal_price`, `price_index`.`min_price`, `price_index`.`max_price`, `price_index`.`tier_price`, `super_link`.`product_id`, MIN(tier_price_table.value) AS `from_price`, `stock_status_index`.`stock_status` AS `is_salable`
FROM `catalog_product_entity` AS `e`
  INNER JOIN `catalog_product_index_price` AS `price_index` ON price_index.entity_id = e.entity_id AND price_index.website_id = '1' AND price_index.customer_group_id = 0
  LEFT JOIN `catalog_product_super_link` AS `super_link` ON e.entity_id = super_link.parent_id
  LEFT JOIN `catalog_product_entity_tier_price` AS `tier_price_table` ON tier_price_table.entity_id = super_link.product_id
  INNER JOIN `cataloginventory_stock_status` AS `stock_status_index` ON e.entity_id = stock_status_index.product_id AND stock_status_index.website_id = 0 AND stock_status_index.stock_id = 1
WHERE (stock_status_index.stock_status = 1) AND
      (e.entity_id IN (91316, 90015, 90812, 91338, 90964, 91289, 91399, 81947, 90049))
GROUP BY `e`.`entity_id`
+ORDER BY FIELD(e.entity_id, 91316, 90015, 90812, 91338, 90964, 91289, 91399, 81947, 90049)

+-----------+--------+--------------+-------------+---------------+-----------+-----------+------------+------------+------------+------------+
| entity_id | price  | tax_class_id | final_price | minimal_price | min_price | max_price | tier_price | product_id | from_price | is_salable |
+-----------+--------+--------------+-------------+---------------+-----------+-----------+------------+------------+------------+------------+
|     91316 | 0.0000 |            2 |      0.0000 |        4.9900 |    4.9900 |    4.9900 |       NULL |      90361 |     4.5100 |          1 |
|     90015 | 0.0000 |            2 |      0.0000 |        5.4265 |    5.4265 |    5.4265 |       NULL |      85657 |     3.3975 |          1 |
|     90812 | 0.0000 |            2 |      0.0000 |        5.7969 |    5.7969 |    5.7969 |       NULL |      89649 |     3.6293 |          1 |
|     91338 | 0.0000 |            2 |      0.0000 |        5.8394 |    5.8394 |    5.8394 |       NULL |      71751 |     3.3031 |          1 |
|     90964 | 0.0000 |            2 |      0.0000 |        6.1343 |    6.1343 |    6.1343 |       NULL |      87983 |     3.8340 |          1 |
|     91289 | 0.0000 |            2 |      0.0000 |        6.1697 |    6.1697 |    6.1697 |       NULL |      68967 |     3.7750 |          1 |
|     91399 | 0.0000 |            2 |      0.0000 |        6.5135 |    6.5135 |    6.5135 |       NULL |      85594 |     4.0772 |          1 |
|     81947 | 0.0000 |            2 |      0.0000 |        6.6108 |    6.6108 |    6.6108 |       NULL |      93470 |     4.1286 |          1 |
|     90049 | 0.0000 |            2 |      0.0000 |        7.5949 |    7.5949 |    7.5949 |       NULL |      45826 |     4.7524 |          1 |
+-----------+--------+--------------+-------------+---------------+-----------+-----------+------------+------------+------------+------------+
9 rows in set (0.02 sec)
```

**Actual result**

```sql
SELECT
  `e`.entity_id,
  --  `e`.*,
  `price_index`.`price`, `price_index`.`tax_class_id`, `price_index`.`final_price`, IF(price_index.tier_price IS NOT NULL, LEAST(price_index.min_price, price_index.tier_price), price_index.min_price) AS `minimal_price`, `price_index`.`min_price`, `price_index`.`max_price`, `price_index`.`tier_price`, `super_link`.`product_id`, MIN(tier_price_table.value) AS `from_price`, `stock_status_index`.`stock_status` AS `is_salable`
FROM `catalog_product_entity` AS `e`
  INNER JOIN `catalog_product_index_price` AS `price_index` ON price_index.entity_id = e.entity_id AND price_index.website_id = '1' AND price_index.customer_group_id = 0
  LEFT JOIN `catalog_product_super_link` AS `super_link` ON e.entity_id = super_link.parent_id
  LEFT JOIN `catalog_product_entity_tier_price` AS `tier_price_table` ON tier_price_table.entity_id = super_link.product_id
  INNER JOIN `cataloginventory_stock_status` AS `stock_status_index` ON e.entity_id = stock_status_index.product_id AND stock_status_index.website_id = 0 AND stock_status_index.stock_id = 1
WHERE (stock_status_index.stock_status = 1) AND
      (e.entity_id IN (91316, 90015, 90812, 91338, 90964, 91289, 91399, 81947, 90049))
GROUP BY `e`.`entity_id`

+-----------+--------+--------------+-------------+---------------+-----------+-----------+------------+------------+------------+------------+
| entity_id | price  | tax_class_id | final_price | minimal_price | min_price | max_price | tier_price | product_id | from_price | is_salable |
+-----------+--------+--------------+-------------+---------------+-----------+-----------+------------+------------+------------+------------+
|     81947 | 0.0000 |            2 |      0.0000 |        6.6108 |    6.6108 |    6.6108 |       NULL |      93470 |     4.1286 |          1 |
|     90015 | 0.0000 |            2 |      0.0000 |        5.4265 |    5.4265 |    5.4265 |       NULL |      85657 |     3.3975 |          1 |
|     90049 | 0.0000 |            2 |      0.0000 |        7.5949 |    7.5949 |    7.5949 |       NULL |      45826 |     4.7524 |          1 |
|     90812 | 0.0000 |            2 |      0.0000 |        5.7969 |    5.7969 |    5.7969 |       NULL |      89649 |     3.6293 |          1 |
|     90964 | 0.0000 |            2 |      0.0000 |        6.1343 |    6.1343 |    6.1343 |       NULL |      87983 |     3.8340 |          1 |
|     91289 | 0.0000 |            2 |      0.0000 |        6.1697 |    6.1697 |    6.1697 |       NULL |      68967 |     3.7750 |          1 |
|     91316 | 0.0000 |            2 |      0.0000 |        4.9900 |    4.9900 |    4.9900 |       NULL |      90361 |     4.5100 |          1 |
|     91338 | 0.0000 |            2 |      0.0000 |        5.8394 |    5.8394 |    5.8394 |       NULL |      71751 |     3.3031 |          1 |
|     91399 | 0.0000 |            2 |      0.0000 |        6.5135 |    6.5135 |    6.5135 |       NULL |      85594 |     4.0772 |          1 |
+-----------+--------+--------------+-------------+---------------+-----------+-----------+------------+------------+------------+------------+
9 rows in set (0.01 sec)
```