### PR TITLE
Fixes #1635 log1p instead of log for logarithmic fn (2.2.x)

### DIFF
--- a/src/module-elasticsuite-catalog-optimizer/view/adminhtml/ui_component/smile_elasticsuite_catalog_optimizer_form.xml
+++ b/src/module-elasticsuite-catalog-optimizer/view/adminhtml/ui_component/smile_elasticsuite_catalog_optimizer_form.xml
@@ -602,7 +602,7 @@
             <argument name="data" xsi:type="array">
                 <item name="options" xsi:type="array">
                     <item name="0" xsi:type="array">
-                        <item name="value" xsi:type="string">log</item>
+                        <item name="value" xsi:type="string">log1p</item>
                         <item name="label" xsi:type="string" translate="true">Logarithmic</item>
                     </item>
                     <item name="1" xsi:type="array">


### PR DESCRIPTION
for attribute based search optimizers