### PR TITLE
Introduce waitInterval variable in quickSearch widget

### DIFF
--- a/src/module-elasticsuite-core/view/frontend/web/js/form-mini.js
+++ b/src/module-elasticsuite-core/view/frontend/web/js/form-mini.js
@@ -34,7 +34,7 @@ define([
             selectClass: 'selected',
             submitBtn: 'button[type="submit"]',
             searchLabel: '[data-role=minisearch-label]',
-			waitInterval: 250
+            waitInterval: 250
         },
 
         /**
@@ -221,100 +221,100 @@ define([
          * @private
          */
         _onPropertyChange: function() {
-			clearTimeout(this.requestTimeout);
+            clearTimeout(this.requestTimeout);
+            
+            this.requestTimeout = setTimeout(function() {
+                var searchField = this.element,
+                    clonePosition = {
+                        position: 'absolute',
+                        // Removed to fix display issues
+                        // left: searchField.offset().left,
+                        // top: searchField.offset().top + searchField.outerHeight(),
+                        width: searchField.outerWidth()
+                    },
+                    value = this.element.val();
 
-			this.requestTimeout = setTimeout(function() {
-				var searchField = this.element,
-					clonePosition = {
-						position: 'absolute',
-						// Removed to fix display issues
-						// left: searchField.offset().left,
-						// top: searchField.offset().top + searchField.outerHeight(),
-						width: searchField.outerWidth()
-					},
-					value = this.element.val();
+                this.submitBtn.disabled = this._isEmpty(value);
 
-				this.submitBtn.disabled = this._isEmpty(value);
+                if (value.trim().length >= parseInt(this.options.minSearchLength, 10)) {
+                    this.searchForm.addClass('processing');
+                    this.currentRequest = $.ajax({
+                        method: "GET",
+                        url: this.options.url,
+                        data:{q: value},
+                        // This function will ensure proper killing of the last Ajax call.
+                        // In order to prevent requests of an old request to pop up later and replace results.
+                        beforeSend: function() { if (this.currentRequest !== null) { this.currentRequest.abort(); }}.bind(this),
+                        success: $.proxy(function (data) {
+                            var self = this;
+                            var lastElement = false;
+                            var content = this._getResultWrapper();
+                            var sectionDropdown = this._getSectionHeader();
+                            $.each(data, function(index, element) {
 
-				if (value.trim().length >= parseInt(this.options.minSearchLength, 10)) {
-					this.searchForm.addClass('processing');
-					this.currentRequest = $.ajax({
-						method: "GET",
-						url: this.options.url,
-						data:{q: value},
-						// This function will ensure proper killing of the last Ajax call.
-						// In order to prevent requests of an old request to pop up later and replace results.
-						beforeSend: function() { if (this.currentRequest !== null) { this.currentRequest.abort(); }}.bind(this),
-						success: $.proxy(function (data) {
-							var self = this;
-							var lastElement = false;
-							var content = this._getResultWrapper();
-							var sectionDropdown = this._getSectionHeader();
-							$.each(data, function(index, element) {
+                                if (!lastElement || (lastElement && lastElement.type !== element.type)) {
+                                    sectionDropdown = this._getSectionHeader(element.type, data);
+                                }
 
-								if (!lastElement || (lastElement && lastElement.type !== element.type)) {
-									sectionDropdown = this._getSectionHeader(element.type, data);
-								}
+                                var elementHtml = this._renderItem(element, index);
 
-								var elementHtml = this._renderItem(element, index);
+                                sectionDropdown.append(elementHtml);
 
-								sectionDropdown.append(elementHtml);
+                                if (!lastElement || (lastElement && lastElement.type !== element.type)) {
+                                    content.append(sectionDropdown);
+                                }
 
-								if (!lastElement || (lastElement && lastElement.type !== element.type)) {
-									content.append(sectionDropdown);
-								}
+                                lastElement = element;
+                            }.bind(this));
+                            this.responseList.indexList = this.autoComplete.html(content)
+                                .css(clonePosition)
+                                .show()
+                                .find(this.options.responseFieldElements + ':visible');
 
-								lastElement = element;
-							}.bind(this));
-							this.responseList.indexList = this.autoComplete.html(content)
-								.css(clonePosition)
-								.show()
-								.find(this.options.responseFieldElements + ':visible');
+                            this._resetResponseList(false);
+                            this.element.removeAttr('aria-activedescendant');
 
-							this._resetResponseList(false);
-							this.element.removeAttr('aria-activedescendant');
+                            if (this.responseList.indexList.length) {
+                                this._updateAriaHasPopup(true);
+                            } else {
+                                this._updateAriaHasPopup(false);
+                            }
 
-							if (this.responseList.indexList.length) {
-								this._updateAriaHasPopup(true);
-							} else {
-								this._updateAriaHasPopup(false);
-							}
-
-							this.responseList.indexList
-								.on('click vclick', function (e) {
-									self.responseList.selected = $(this);
-									if (self.responseList.selected.attr("href")) {
-										window.location.href = self.responseList.selected.attr("href");
-										e.stopPropagation();
-										return false;
-									}
-									self.searchForm.trigger('submit');
-								})
-								.on('mouseenter mouseleave', function (e) {
-									self.responseList.indexList.removeClass(self.options.selectClass);
-									$(this).addClass(self.options.selectClass);
-									self.responseList.selected = $(e.target);
-									self.element.attr('aria-activedescendant', $(e.target).attr('id'));
-								})
-								.on('mouseout', function () {
-									if (!self._getLastElement() && self._getLastElement().hasClass(self.options.selectClass)) {
-										$(this).removeClass(self.options.selectClass);
-										self._resetResponseList(false);
-									}
-								});
-						},this),
-						complete : $.proxy(function () {
-							this.searchForm.removeClass('processing');
-						}, this)
-					});
-				} else {
-					this._resetResponseList(true);
-					this.autoComplete.hide();
-					this._updateAriaHasPopup(false);
-					this.element.removeAttr('aria-activedescendant');
-				}
-			}.bind(this), this.options.waitInterval);
-		},
+                            this.responseList.indexList
+                                .on('click vclick', function (e) {
+                                    self.responseList.selected = $(this);
+                                    if (self.responseList.selected.attr("href")) {
+                                        window.location.href = self.responseList.selected.attr("href");
+                                        e.stopPropagation();
+                                        return false;
+                                    }
+                                    self.searchForm.trigger('submit');
+                                })
+                                .on('mouseenter mouseleave', function (e) {
+                                    self.responseList.indexList.removeClass(self.options.selectClass);
+                                    $(this).addClass(self.options.selectClass);
+                                    self.responseList.selected = $(e.target);
+                                    self.element.attr('aria-activedescendant', $(e.target).attr('id'));
+                                })
+                                .on('mouseout', function () {
+                                    if (!self._getLastElement() && self._getLastElement().hasClass(self.options.selectClass)) {
+                                        $(this).removeClass(self.options.selectClass);
+                                        self._resetResponseList(false);
+                                    }
+                                });
+                        },this),
+                        complete : $.proxy(function () {
+                            this.searchForm.removeClass('processing');
+                        }, this)
+                    });
+                } else {
+                    this._resetResponseList(true);
+                    this.autoComplete.hide();
+                    this._updateAriaHasPopup(false);
+                    this.element.removeAttr('aria-activedescendant');
+                }
+            }.bind(this), this.options.waitInterval);
+        },
 
         /**
          * Executes when keys are pressed in the search input field. Performs specific actions


### PR DESCRIPTION
**Description**
Right now, debounce function has wait interval value hardcoded as 250 in _onPropertyChange method. This Pull Requests allows for setting this value as widget's option. 

That change might be useful for projects that have a high amount of products and would like to increase the interval, or those with small number of products which would like to have immediate action.

Simply adding this.options.waitInterval instead of 250 will not work, as in the moment of execution of debounce in this method, widget is not initialised yet and object's options are undefined. We can achieve that effect by dropping underscore's [debounce](https://underscorejs.org/#debounce) and wrapping function's content with setTimeout.