### PR TITLE
Fixes #1660 Search terms positions sorting on REST and GraphQL

### DIFF
--- a/src/module-elasticsuite-catalog/Plugin/Search/RequestMapperPlugin.php
+++ b/src/module-elasticsuite-catalog/Plugin/Search/RequestMapperPlugin.php
@@ -119,6 +119,16 @@ class RequestMapperPlugin
                 $result['position'] = ['direction' => SortOrderInterface::SORT_ASC];
             }
 
+            if ($containerConfiguration->getName() == "quick_search_container" && empty($result)) {
+                $searchQuery = $this->searchContext->getCurrentSearchQuery();
+                if ($searchQuery->getId()) {
+                    $result['search_query.position'] = [
+                        'direction'     => SortOrderInterface::SORT_ASC,
+                        'nestedFilter'  => ['search_query.query_id' => $searchQuery->getId()],
+                    ];
+                }
+            }
+
             foreach ($result as $sortField => $sortParams) {
                 if ($sortField == 'price') {
                     $sortParams['nestedFilter'] = ['price.customer_group_id' => $this->customerSession->getCustomerGroupId()];

--- a/src/module-elasticsuite-core/Model/Search/RequestBuilder.php
+++ b/src/module-elasticsuite-core/Model/Search/RequestBuilder.php
@@ -106,10 +106,10 @@ class RequestBuilder
 
         $queryText  = $this->getFulltextFilter($searchCriteria);
 
+        $this->updateSearchContext($storeId, $queryText);
+
         $sortOrders = $this->requestMapper->getSortOrders($containerConfiguration, $searchCriteria);
         $filters    = $this->requestMapper->getFilters($containerConfiguration, $searchCriteria);
-
-        $this->updateSearchContext($storeId, $queryText);
 
         return $this->searchRequestBuilder->create($storeId, $containerName, $from, $size, $queryText, $sortOrders, $filters, []);
     }


### PR DESCRIPTION
when no sort order is provided and using the quick_search_container/in a search context.