### PR TITLE
Category Results Missing Current Category Filter

### DIFF
--- a/src/module-elasticsuite-catalog/etc/di.xml
+++ b/src/module-elasticsuite-catalog/etc/di.xml
@@ -112,7 +112,7 @@
         </arguments>
     </virtualType>
 
-    <virtualType name="Smile\ElasticsuiteCatalog\Model\Layer\Category\ItemCollectionProvider" type="Magento\Catalog\Model\Layer\Search\ItemCollectionProvider">
+    <virtualType name="Smile\ElasticsuiteCatalog\Model\Layer\Category\ItemCollectionProvider" type="Magento\CatalogSearch\Model\Layer\Category\ItemCollectionProvider">
         <arguments>
             <argument name="collectionFactory" xsi:type="object">Magento\CatalogSearch\Model\ResourceModel\Fulltext\CollectionFactory</argument>
         </arguments>


### PR DESCRIPTION
Currently the layer responsible for loading the category products doesn't take the category into consideration. Rather than re-inventing the wheel, the Magento/CatalogSearch module has already created an item provider that filters the data by the category. Changing the class the `Smile\ElasticsuiteCatalog\Model\Layer\Category\ItemCollectionProvider` is based on means a custom class that simply calls `addCategoryFilter` on the collection doesn't need to be made.

Possibly Relates to https://github.com/Smile-SA/elasticsuite/issues/706, https://github.com/Smile-SA/elasticsuite/issues/1562