### PR TITLE
Fix swatches manual sorting

### DIFF
--- a/src/module-elasticsuite-swatches/Block/Navigation/Renderer/Swatches/RenderLayered.php
+++ b/src/module-elasticsuite-swatches/Block/Navigation/Renderer/Swatches/RenderLayered.php
@@ -17,6 +17,7 @@ namespace Smile\ElasticsuiteSwatches\Block\Navigation\Renderer\Swatches;
 use Magento\Catalog\Model\Layer\Filter\Item as FilterItem;
 use Magento\Eav\Model\Entity\Attribute;
 use Magento\Eav\Model\Entity\Attribute\Option;
+use Smile\ElasticsuiteCore\Search\Request\BucketInterface;
 
 /**
  * Override Magento standard swatches renderer block.
@@ -28,13 +29,18 @@ use Magento\Eav\Model\Entity\Attribute\Option;
 class RenderLayered extends \Magento\Swatches\Block\LayeredNavigation\RenderLayered
 {
     /**
-     * Override the native method to sort swatch options in the expected
-     * order (as defined in the admin attribute parameters).
+     * Override the native method to sort swatch options in the expected when the sorting isn't set to manual order
+     * as defined in the admin attribute parameters.
      *
      * @return array
      */
     public function getSwatchData(): array
     {
+        // Fallback to core if sorting is set to manual.
+        if ($this->eavAttribute->getFacetSortOrder() === BucketInterface::SORT_ORDER_MANUAL) {
+            return parent::getSwatchData();
+        }
+
         if (false === $this->eavAttribute instanceof Attribute) {
             throw new \RuntimeException('Magento_Swatches: RenderLayered: Attribute has not been set.');
         }


### PR DESCRIPTION
Related PR: #1503 

I noticed that PR #1503 broke the manual sorting of the swatches. My solution would be to just fall back to the core method `getSwatchData()` if the attribute is set to manual sorting. The core method works just fine in this case.

## Preconditions
- Create a text swatch attribute, set sorting to 'manual'
- Version used 2.8.4 + Magento 2.3.4

## Swatches sorting in backend
![Admin screenshot](https://user-images.githubusercontent.com/14849044/74823362-dfed4700-5306-11ea-8241-578b64de182f.png)

## Before (with #1503 applied)
![Before screenshot](https://user-images.githubusercontent.com/14849044/74823619-4b371900-5307-11ea-8b32-025b50e46e20.png)

## After (with this PR applied)
![After screenshot](https://user-images.githubusercontent.com/14849044/74823685-630e9d00-5307-11ea-87ef-ec0954c888e8.png)