### PR TITLE
[HOTFIX] Remove duplicate class attribute

### DIFF
--- a/src/module-elasticsuite-catalog/view/frontend/web/template/autocomplete/product.html
+++ b/src/module-elasticsuite-catalog/view/frontend/web/template/autocomplete/product.html
@@ -1,4 +1,4 @@
-<dd class="<%- data.row_class %>" id="qs-option-<%- data.index %>" role="option" class="product-item" href="<%- data.url %>">
+<dd class="<%- data.row_class %>" id="qs-option-<%- data.index %>" role="option" href="<%- data.url %>">
     <div class="product-image-box">
         <img width="45px" height="45px" src="<%- data.image %>">
     </div>


### PR DESCRIPTION
`<dd>` element already has `class="<%- data.row_class %>"`, so `class="product-item"` shouldn't be there anymore.