### PR TITLE
Fixes #1702 Explicit cast of tracker properties

### DIFF
--- a/src/module-elasticsuite-tracker/Model/Event/DotObject.php
+++ b/src/module-elasticsuite-tracker/Model/Event/DotObject.php
@@ -1,0 +1,200 @@
+<?php
+/**
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\Elasticsuite
+ * @author    Richard BAYET <richard.bayet@smile.fr>
+ * @copyright 2020 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+
+namespace Smile\ElasticsuiteTracker\Model\Event;
+
+use Magento\Framework\DataObject;
+
+/**
+ * Variation of the DataObject to support dot notation for
+ * - testing existence
+ * - getting data
+ * - setting data
+ *
+ * @SuppressWarnings(PHPMD.CountInLoopExpression)
+ *
+ * @category Smile
+ * @package  Smile\ElasticsuiteTracker
+ */
+class DotObject extends DataObject
+{
+    /**
+     * Overwrite data in the object.
+     *
+     * The $key parameter can be string or array.
+     * If $key is string, the attribute value will be overwritten by $value
+     * If $key is an array, it will overwrite all the data in the object.
+     *
+     * Added support for "dot" notation, using inspiration from Laravel array_set helper.
+     *
+     * @SuppressWarnings(PHPMD.CountInLoopExpression)
+     *
+     * @param string|array $key   Key where to overwrite data.
+     * @param mixed        $value Value to set for the given key.
+     *
+     * @return $this
+     */
+    public function setData($key, $value = null)
+    {
+        if ($key === (array) $key) {
+            $this->_data = $key;
+
+            return $this;
+        }
+
+        $array = &$this->_data;
+
+        $keys = explode('.', $key);
+        // @codingStandardsIgnoreStart
+        while (count($keys) > 1) {
+            $key = array_shift($keys);
+
+            // If the key doesn't exist at this depth, we will just create an empty array
+            // to hold the next value, allowing us to create the arrays to hold final
+            // values at the correct depth. Then we'll keep digging into the array.
+            if (!isset($array[$key]) || !is_array($array[$key])) {
+                $array[$key] = [];
+            }
+
+            $array = &$array[$key];
+        }
+        // @codingStandardsIgnoreEnd
+
+        $array[array_shift($keys)] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Object data getter
+     *
+     * If $key is not defined will return all the data as an array.
+     * Otherwise it will return value of the element specified by $key.
+     * It is possible to use keys like a/b/c for access nested array data
+     *
+     * If $index is specified it will assume that attribute data is an array
+     * and retrieve corresponding member. If data is the string - it will be explode
+     * by new line character and converted to array.
+     *
+     * Added support for "dot" notation.
+     *
+     * @SuppressWarnings(PHPMD.ElseExpression)
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     *
+     * @param string     $key   Data key.
+     * @param string|int $index Data index.
+     * @return mixed
+     */
+    public function getData($key = '', $index = null)
+    {
+        if ('' === $key) {
+            return $this->_data;
+        }
+
+        /* process a/b/c key as ['a']['b']['c'] */
+        if (strpos($key, '/') !== false) {
+            $data = $this->getDataByPath($key);
+        } elseif (strpos($key, '.') !== false) {
+            /* process a.b.c key as ['a']['b']['c'] */
+            $data = $this->getDataByPath($key, '.');
+        } else {
+            $data = $this->_getData($key);
+        }
+
+        if ($index !== null) {
+            if ($data === (array) $data) {
+                $data = isset($data[$index]) ? $data[$index] : null;
+            } elseif (is_string($data)) {
+                $data = explode(PHP_EOL, $data);
+                $data = isset($data[$index]) ? $data[$index] : null;
+            } elseif ($data instanceof \Magento\Framework\DataObject) {
+                $data = $data->getData($index);
+            } else {
+                $data = null;
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * Get object data by path
+     *
+     * Method consider the path as chain of keys: a/b/c => ['a']['b']['c']
+     * or a path made using "do" notation: a.b.c => ['a']['b']['c']
+     *
+     * @SuppressWarnings(PHPMD.ElseExpression)
+     *
+     * @param string $path      Path to data.
+     * @param string $delimiter Path delimiter.
+     *
+     * @return mixed
+     */
+    public function getDataByPath($path, $delimiter = '/')
+    {
+        $keys = explode($delimiter, $path);
+
+        $data = $this->_data;
+        foreach ($keys as $key) {
+            if ((array) $data === $data && isset($data[$key])) {
+                $data = $data[$key];
+            } elseif ($data instanceof \Magento\Framework\DataObject) {
+                $data = $data->getDataByKey($key);
+            } else {
+                return null;
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * If $key is empty, checks whether there's any data in the object
+     *
+     * Otherwise checks if the specified attribute is set.
+     *
+     * Added support for "dot" notation.
+     *
+     * @SuppressWarnings(PHPCS.Squiz.PHP.DisallowSizeFunctionsInLoops)
+     * @SuppressWarnings(PHPMD.CountInLoopExpression)
+     *
+     * @param string $key Data key.
+     *
+     * @return bool
+     */
+    public function hasData($key = '')
+    {
+        if (empty($key) || !is_string($key)) {
+            return !empty($this->_data);
+        }
+
+        $array = &$this->_data;
+
+        $keys = explode('.', $key);
+        // @codingStandardsIgnoreStart
+        while (count($keys) > 1) {
+            $key = array_shift($keys);
+
+            // If the key doesn't exist at this depth, then the whole structure does not exists.
+            if (!isset($array[$key]) || !is_array($array[$key])) {
+                return false;
+            }
+
+            $array = &$array[$key];
+        }
+        // @codingStandardsIgnoreEnd
+
+        return array_key_exists(array_shift($keys), $array);
+    }
+}

--- a/src/module-elasticsuite-tracker/Model/Event/Mapping/Enforcer.php
+++ b/src/module-elasticsuite-tracker/Model/Event/Mapping/Enforcer.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\Elasticsuite
+ * @author    Richard BAYET <richard.bayet@smile.fr>
+ * @copyright 2020 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+
+namespace Smile\ElasticsuiteTracker\Model\Event\Mapping;
+
+use Smile\ElasticsuiteCore\Api\Index\IndexInterface;
+
+/**
+ * Mapping enforcer.
+ *
+ * @category Smile
+ * @package  Smile\ElasticsuiteTracker
+ */
+class Enforcer
+{
+    /**
+     * @var TypeEnforcerCollector
+     */
+    private $typeEnforcerCollector;
+
+    /**
+     * Enforcer constructor.
+     *
+     * @param TypeEnforcerCollector $typeEnforcerCollector Type enforcers collector.
+     */
+    public function __construct(TypeEnforcerCollector $typeEnforcerCollector)
+    {
+        $this->typeEnforcerCollector = $typeEnforcerCollector;
+    }
+
+    /**
+     * Enforces an index mapping on given data.
+     *
+     * @param IndexInterface $index Index whose mapping to enforce on data.
+     * @param array          $data  Data to enforce mapping on.
+     *
+     * @return array
+     */
+    public function enforce($index, $data)
+    {
+        $enforcers = $this->typeEnforcerCollector->getTypeEnforcers($index);
+        foreach ($enforcers as $enforcer) {
+            $data = $enforcer->enforce($data);
+        }
+
+        return $data;
+    }
+}

--- a/src/module-elasticsuite-tracker/Model/Event/Mapping/TypeEnforcer/AbstractTypeEnforcer.php
+++ b/src/module-elasticsuite-tracker/Model/Event/Mapping/TypeEnforcer/AbstractTypeEnforcer.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\ElasticsuiteTracker
+ * @author    Richard BAYET <richard.bayet@smile.fr>
+ * @copyright 2020 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+
+namespace Smile\ElasticsuiteTracker\Model\Event\Mapping\TypeEnforcer;
+
+use Smile\ElasticsuiteCore\Api\Index\Mapping\FieldInterface;
+use Smile\ElasticsuiteCore\Api\Index\MappingInterface;
+use Smile\ElasticsuiteTracker\Model\Event\DotObject;
+use Smile\ElasticsuiteTracker\Model\Event\DotObjectFactory;
+use Smile\ElasticsuiteTracker\Model\Event\Mapping\TypeEnforcerInterface;
+
+/**
+ * Abstract field type enforcer.
+ *
+ * @category Smile.
+ * @package  Smile\ElasticsuiteTracker
+ */
+abstract class AbstractTypeEnforcer implements TypeEnforcerInterface
+{
+    /**
+     * @var DotObjectFactory
+     */
+    protected $dotObjectFactory;
+
+    /**
+     * @var MappingInterface
+     */
+    protected $mapping;
+
+    /**
+     * @var FieldInterface[]
+     */
+    protected $fields;
+
+    /**
+     * Integer constructor.
+     *
+     * @param DotObjectFactory $dataObjectFactory DotObject factory.
+     * @param MappingInterface $mapping           Index mapping.
+     */
+    public function __construct(
+        DotObjectFactory $dataObjectFactory,
+        MappingInterface $mapping
+    ) {
+        $this->dotObjectFactory = $dataObjectFactory;
+        $this->mapping          = $mapping;
+        $this->fields           = [];
+        $this->collectFields();
+    }
+
+    /**
+     * Enforces value type for collected fields.
+     *
+     * @SuppressWarnings(PHPMD.ElseExpression)
+     *
+     * @param array $event Event data.
+     *
+     * @return array
+     */
+    public function enforce($event)
+    {
+        if (!empty($this->fields)) {
+            $eventData = $this->dotObjectFactory->create(['data' => $event]);
+
+            foreach ($this->fields as $field) {
+                if ($field->isNested()) {
+                    $this->handleNestedField($eventData, $field);
+                } else {
+                    $this->handleRegularField($eventData, $field);
+                }
+            }
+
+            $event = $eventData->getData();
+        }
+
+        return $event;
+    }
+
+    /**
+     * Collect the fields to enforce from the mapping.
+     *
+     * @return void
+     */
+    abstract protected function collectFields();
+
+    /**
+     * Enforce mapping for a given field value.
+     *
+     * @param mixed $fieldValue Field value.
+     *
+     * @return void
+     */
+    abstract protected function enforceField(&$fieldValue);
+
+    /**
+     * Handles a nested field.
+     *
+     * @SuppressWarnings(PHPMD.ElseExpression)
+     *
+     * @param DotObject      $eventData Event data.
+     * @param FieldInterface $field     Mapping nested field.
+     *
+     * @return void
+     */
+    protected function handleNestedField($eventData, $field)
+    {
+        $fieldPath = $field->getNestedPath();
+        if ($eventData->hasData($fieldPath)) {
+            $fieldName = $field->getNestedFieldName();
+            $items = $eventData->getData($fieldPath);
+            if (is_array($items)) {
+                foreach ($items as &$item) {
+                    if (array_key_exists($fieldName, $item)) {
+                        $fieldValue = $item[$fieldName];
+                        if (is_array($fieldValue)) {
+                            array_walk(
+                                $fieldValue,
+                                array($this, 'enforceField')
+                            );
+                        } else {
+                            $this->enforceField($fieldValue);
+                        }
+                        $item[$fieldName] = $fieldValue;
+                    }
+                }
+                $eventData->setData($fieldPath, $items);
+            }
+        }
+    }
+
+    /**
+     * Handles a regular field.
+     *
+     * @SuppressWarnings(PHPMD.ElseExpression)
+     *
+     * @param DotObject      $eventData Event data.
+     * @param FieldInterface $field     Mapping regular field.
+     *
+     * @return void
+     */
+    protected function handleRegularField($eventData, $field)
+    {
+        $fieldName = $field->getName();
+        if ($eventData->hasData($fieldName)) {
+            $fieldValue = $eventData->getData($fieldName);
+            if (is_array($fieldValue)) {
+                array_walk(
+                    $fieldValue,
+                    array($this, 'enforceField')
+                );
+            } else {
+                $this->enforceField($fieldValue);
+            }
+            $eventData->setData($fieldName, $fieldValue);
+        }
+    }
+}

--- a/src/module-elasticsuite-tracker/Model/Event/Mapping/TypeEnforcer/Boolean.php
+++ b/src/module-elasticsuite-tracker/Model/Event/Mapping/TypeEnforcer/Boolean.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\Elasticsuite
+ * @author    Richard BAYET <richard.bayet@smile.fr>
+ * @copyright 2020 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+
+namespace Smile\ElasticsuiteTracker\Model\Event\Mapping\TypeEnforcer;
+
+use Smile\ElasticsuiteCore\Api\Index\Mapping\FieldInterface;
+
+/**
+ * Boolean field type enforcer.
+ *
+ * @category Smile
+ * @package  Smile\ElasticsuiteTracker
+ */
+class Boolean extends AbstractTypeEnforcer
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected function collectFields()
+    {
+        foreach ($this->mapping->getFields() as $field) {
+            if ($field->getType() === FieldInterface::FIELD_TYPE_BOOLEAN) {
+                $this->fields[] = $field;
+            }
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function enforceField(&$fieldValue)
+    {
+        $fieldValue = (bool) $fieldValue;
+    }
+}

--- a/src/module-elasticsuite-tracker/Model/Event/Mapping/TypeEnforcer/Double.php
+++ b/src/module-elasticsuite-tracker/Model/Event/Mapping/TypeEnforcer/Double.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\Elasticsuite
+ * @author    Richard BAYET <richard.bayet@smile.fr>
+ * @copyright 2020 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+
+namespace Smile\ElasticsuiteTracker\Model\Event\Mapping\TypeEnforcer;
+
+use Smile\ElasticsuiteCore\Api\Index\Mapping\FieldInterface;
+
+/**
+ * Double field type enforcer.
+ *
+ * @category Smile
+ * @package  Smile\ElasticsuiteTracker
+ */
+class Double extends AbstractTypeEnforcer
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected function collectFields()
+    {
+        foreach ($this->mapping->getFields() as $field) {
+            if ($field->getType() === FieldInterface::FIELD_TYPE_DOUBLE) {
+                $this->fields[] = $field;
+            }
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function enforceField(&$fieldValue)
+    {
+        $fieldValue = (float) $fieldValue;
+    }
+}

--- a/src/module-elasticsuite-tracker/Model/Event/Mapping/TypeEnforcer/Integer.php
+++ b/src/module-elasticsuite-tracker/Model/Event/Mapping/TypeEnforcer/Integer.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\ElasticsuiteTracker
+ * @author    Richard BAYET <richard.bayet@smile.fr>
+ * @copyright 2020 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+
+namespace Smile\ElasticsuiteTracker\Model\Event\Mapping\TypeEnforcer;
+
+use Smile\ElasticsuiteCore\Api\Index\Mapping\FieldInterface;
+
+/**
+ * Integer field type enforcer.
+ *
+ * @category Smile
+ * @package  Smile\ElasticsuiteTracker
+ */
+class Integer extends AbstractTypeEnforcer
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected function collectFields()
+    {
+        foreach ($this->mapping->getFields() as $field) {
+            if ($field->getType() === FieldInterface::FIELD_TYPE_INTEGER) {
+                $this->fields[] = $field;
+            }
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function enforceField(&$fieldValue)
+    {
+        $fieldValue = (int) $fieldValue;
+    }
+}

--- a/src/module-elasticsuite-tracker/Model/Event/Mapping/TypeEnforcerCollector.php
+++ b/src/module-elasticsuite-tracker/Model/Event/Mapping/TypeEnforcerCollector.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\ElasticsuiteTracker
+ * @author    Richard BAYET <richard.bayet@smile.fr>
+ * @copyright 2020 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+
+namespace Smile\ElasticsuiteTracker\Model\Event\Mapping;
+
+use Smile\ElasticsuiteCore\Api\Index\IndexInterface;
+
+/**
+ * Type enforcers collector.
+ *
+ * @category Smile
+ * @package  Smile\ElasticsuiteTracker
+ */
+class TypeEnforcerCollector
+{
+    /**
+     * @var array
+     */
+    private $factories;
+
+    /**
+     * @var array
+     */
+    private $cache;
+
+    /**
+     * Enforcer constructor.
+     *
+     * @param array $factories Type enforcer factories.
+     */
+    public function __construct($factories = [])
+    {
+        $this->factories = $factories;
+        $this->cache = [];
+    }
+
+    /**
+     * Collects type enforcers for a given index mapping.
+     *
+     * @param IndexInterface $index Index.
+     *
+     * @return TypeEnforcerInterface[]
+     */
+    public function getTypeEnforcers(IndexInterface $index)
+    {
+        if (!array_key_exists($index->getIdentifier(), $this->cache)) {
+            $enforcers = [];
+            foreach ($this->factories as $enforcerFactory) {
+                $enforcers[] = $enforcerFactory->create(['mapping' => $index->getMapping()]);
+            }
+            $this->cache[$index->getIdentifier()] = $enforcers;
+        }
+
+        return $this->cache[$index->getIdentifier()];
+    }
+}

--- a/src/module-elasticsuite-tracker/Model/Event/Mapping/TypeEnforcerInterface.php
+++ b/src/module-elasticsuite-tracker/Model/Event/Mapping/TypeEnforcerInterface.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\Elasticsuite
+ * @author    Richard BAYET <richard.bayet@smile.fr>
+ * @copyright 2020 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+
+namespace Smile\ElasticsuiteTracker\Model\Event\Mapping;
+
+/**
+ * Enforcers interface.
+ *
+ * @category Smile
+ * @package  Smile\ElasticsuiteTracker
+ */
+interface TypeEnforcerInterface
+{
+    /**
+     * Enforce a given mapping field type on event data.
+     *
+     * @param array $data Event data.
+     *
+     * @return array Event data with the mapping enforced.
+     */
+    public function enforce($data);
+}

--- a/src/module-elasticsuite-tracker/Model/EventIndex.php
+++ b/src/module-elasticsuite-tracker/Model/EventIndex.php
@@ -15,6 +15,7 @@
 namespace Smile\ElasticsuiteTracker\Model;
 
 use Smile\ElasticsuiteTracker\Api\EventIndexInterface;
+use Smile\ElasticsuiteTracker\Model\Event\Mapping\Enforcer as MappingEnforcer;
 
 /**
  * Event index implementation.
@@ -36,17 +37,25 @@ class EventIndex implements EventIndexInterface
     private $indexOperation;
 
     /**
+     * @var MappingEnforcer
+     */
+    private $mappingEnforcer;
+
+    /**
      * Constructor.
      *
-     * @param IndexResolver                                             $indexResolver  Resource model.
-     * @param \Smile\ElasticsuiteCore\Api\Index\IndexOperationInterface $indexOperation Index operation.
+     * @param IndexResolver                                             $indexResolver   Resource model.
+     * @param \Smile\ElasticsuiteCore\Api\Index\IndexOperationInterface $indexOperation  Index operation.
+     * @param MappingEnforcer                                           $mappingEnforcer Mapping enforcer.
      */
     public function __construct(
         IndexResolver $indexResolver,
-        \Smile\ElasticsuiteCore\Api\Index\IndexOperationInterface $indexOperation
+        \Smile\ElasticsuiteCore\Api\Index\IndexOperationInterface $indexOperation,
+        MappingEnforcer $mappingEnforcer
     ) {
         $this->indexResolver  = $indexResolver;
         $this->indexOperation = $indexOperation;
+        $this->mappingEnforcer = $mappingEnforcer;
     }
 
     /**
@@ -69,6 +78,7 @@ class EventIndex implements EventIndexInterface
             if (isset($event['page']['store_id'])) {
                 $index = $this->indexResolver->getIndex(self::INDEX_IDENTIFIER, $event['page']['store_id'], $event['date']);
                 if ($index !== null) {
+                    $event = $this->mappingEnforcer->enforce($index, $event);
                     $indices[$index->getName()] = $index;
                     $bulk->addDocument($index, $index->getDefaultSearchType(), $event['event_id'], $event);
                 }

--- a/src/module-elasticsuite-tracker/etc/di.xml
+++ b/src/module-elasticsuite-tracker/etc/di.xml
@@ -35,6 +35,15 @@
     <type name="Magento\Quote\Model\Quote">
       <plugin name="trackAddedProduct" type="Smile\ElasticsuiteTracker\Plugin\QuotePlugin" sortOrder="1" />
     </type>
-    
+
+    <type name="Smile\ElasticsuiteTracker\Model\Event\Mapping\TypeEnforcerCollector">
+        <arguments>
+            <argument name="factories" xsi:type="array">
+                <item name="integer" xsi:type="object">Smile\ElasticsuiteTracker\Model\Event\Mapping\TypeEnforcer\IntegerFactory</item>
+                <item name="double" xsi:type="object">Smile\ElasticsuiteTracker\Model\Event\Mapping\TypeEnforcer\DoubleFactory</item>
+                <item name="boolean" xsi:type="object">Smile\ElasticsuiteTracker\Model\Event\Mapping\TypeEnforcer\BooleanFactory</item>
+            </argument>
+        </arguments>
+    </type>
 
 </config>


### PR DESCRIPTION
when indexing events for boolean, integer and double properties.
Reduces the risk of document being rejected if Elasticsearch cannot coerce a field value into its intended type.