### PR TITLE
Preventing indexing cron failure on bad json data

### DIFF
--- a/src/module-elasticsuite-tracker/Model/ResourceModel/EventQueue.php
+++ b/src/module-elasticsuite-tracker/Model/ResourceModel/EventQueue.php
@@ -79,7 +79,12 @@ class EventQueue extends AbstractDb
         $eventData = $this->getConnection()->fetchAll($select);
 
         foreach ($eventData as &$currentEvent) {
-            $currentEvent = array_merge($currentEvent, $this->jsonSerializer->unserialize($currentEvent['data']));
+            try {
+                $currentEventData = $this->jsonSerializer->unserialize($currentEvent['data']);
+            } catch (\InvalidArgumentException $e) {
+                $currentEventData = [];
+            }
+            $currentEvent = array_merge($currentEvent, $currentEventData);
             unset($currentEvent['data']);
         }
 


### PR DESCRIPTION
usefull if DB storage table was populated with external data.