### PR TITLE
Fixes #1728 Special chars support in thesaurus rules

### DIFF
--- a/src/module-elasticsuite-thesaurus/Model/Indexer/IndexHandler.php
+++ b/src/module-elasticsuite-thesaurus/Model/Indexer/IndexHandler.php
@@ -152,7 +152,7 @@ class IndexHandler
 
     /**
      * Prepare the thesaurus data to be saved.
-     * Spaces are replaced with "_" into multiwords expression (ex foo bar => foo_bar).
+     * Spaces and hyphens are replaced with "_" into multiwords expression (ex foo bar => foo_bar).
      *
      * @param string[] $rows Original thesaurus text rows.
      *
@@ -161,7 +161,7 @@ class IndexHandler
     private function prepareSynonymFilterData($rows)
     {
         $rowMaper = function ($row) {
-            return preg_replace('/([\w])[\s-](?=[\w])/u', '\1_', $row);
+            return preg_replace('/([^\s-])[\s-]+(?=[^\s-])/u', '\1_', $row);
         };
 
         return array_map($rowMaper, $rows);


### PR DESCRIPTION
as well as multiple space/hyphen separating characters.
Please note this only special characters related errors when indexing the thesaurus rules,
but does not offer any warranty that those special characters will be accurately matched
when those rules are applied.