### PR TITLE
Reset page size before load

### DIFF
--- a/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Fulltext/Collection.php
+++ b/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Fulltext/Collection.php
@@ -446,6 +446,21 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Product\Collection
     }
 
     /**
+     * Set _pageSize false since it is managed by the engine and might have been changed since _renderFiltersBefore.
+     *
+     * @inheritDoc
+     */
+    protected function _beforeLoad()
+    {
+        if ($this->_pageSize !== false) {
+            $this->originalPageSize = $this->_pageSize;
+            $this->_pageSize = false;
+        }
+
+        return parent::_beforeLoad();
+    }
+
+    /**
      * @SuppressWarnings(PHPMD.CamelCaseMethodName)
      *
      * {@inheritDoc}

--- a/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Fulltext/Collection.php
+++ b/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Fulltext/Collection.php
@@ -26,6 +26,7 @@ use Smile\ElasticsuiteCore\Search\Adapter\Elasticsuite\Response\QueryResponse;
  * @author   Aurelien FOUCRET <aurelien.foucret@smile.fr>
  *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
  * @SuppressWarnings(PHPMD.TooManyPublicMethods)
  */
 class Collection extends \Magento\Catalog\Model\ResourceModel\Product\Collection
@@ -448,7 +449,9 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Product\Collection
     /**
      * Set _pageSize false since it is managed by the engine and might have been changed since _renderFiltersBefore.
      *
-     * @inheritDoc
+     * @SuppressWarnings(PHPMD.CamelCaseMethodName)
+     *
+     * {@inheritDoc}
      */
     protected function _beforeLoad()
     {


### PR DESCRIPTION
### Summary
The page size is already reset in _renderFiltersBefore but might be changed between rendering the filters and loading the collection. If that happens no items will be found.

### Related Issues
#249

### Description
When moving the navigation (`catalog.leftnav`) it will change the load order of the blocks. In our case we moved it in `catalog_category_view_type_layered.xml`:
```xml
<move element="catalog.leftnav" destination="content" before="-"/>
```
When rendering a category view `\Magento\Catalog\Block\Product\ProductList\Toolbar::setCollection` is called multiple times. Within `setCollection` `$this->_collection->setCurPage($this->getCurrentPage());` is called and will overwrite resetting the page size in [_renderFiltersBefore](https://github.com/Smile-SA/elasticsuite/blob/2.8.x/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Fulltext/Collection.php#L441) if `_renderFiltersBefore` is called outside of `\Magento\Framework\Data\Collection\AbstractDb::load` since filters will be only rendered once (see [\Magento\Framework\Data\Collection\AbstractDb::_renderFilters](https://github.com/magento/magento2/blob/52d92dbd07f09620d23693ba0c4d4bdb4ba09916/lib/internal/Magento/Framework/Data/Collection/AbstractDb.php#L337)).

So we need to make sure `_pageSize` is false when loading the collection and setting it in [_renderFiltersBefore](https://github.com/Smile-SA/elasticsuite/blob/2.8.x/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Fulltext/Collection.php#L414) is good but it might be overwritten if the method is called outside of `\Magento\Framework\Data\Collection\AbstractDb::load`.

Setting `_pageSize` to false in `_beforeLoad()` makes sure the page size is handled by the engine and the collection does not depend on block load order anymore.

The commit should be applied to 2.9.x as well since it might have the same issue (not verified by myself tho).