### PR TITLE
Fix store specific attribute label on GraphQL products aggregations query

### DIFF
--- a/src/module-elasticsuite-catalog-graph-ql/DataProvider/Product/LayeredNavigation/Builder/Attribute.php
+++ b/src/module-elasticsuite-catalog-graph-ql/DataProvider/Product/LayeredNavigation/Builder/Attribute.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * DISCLAIMER
  * Do not edit or add to this file if you wish to upgrade Smile Elastic Suite to newer
@@ -82,9 +83,14 @@ class Attribute implements LayerBuilderInterface
             $label = $attributeCode;
             try {
                 $attribute      = $this->attributeRepository->get($attributeCode);
-                $frontendLabels = $attribute->getFrontendLabels();
+                $frontendLabels = array_filter(
+                    $attribute->getFrontendLabels(),
+                    function ($frontendLabel) use ($storeId) {
+                        return $frontendLabel->getStoreId() == $storeId;
+                    }
+                );
                 if (!empty($frontendLabels)) {
-                    $label = ($frontendLabels[$storeId] ?? reset($frontendLabels))->getLabel();
+                    $label = reset($frontendLabels)->getLabel();
                 }
             } catch (\Magento\Framework\Exception\NoSuchEntityException $exception) {
                 $label = $attributeCode;


### PR DESCRIPTION
When querying product aggregations using GraphQL, the returned attribute label is not always the correct one for the requested store view.

The issue is reproducible when the store views IDs are not consecutive.

`Magento\Eav\Model\Entity\Attribute\AbstractAttribute::getFrontendLabels()` returns an array of labels, where the key is numeric, starting from 0, however, `Smile\ElasticsuiteCatalogGraphQl\DataProvider\Product\LayeredNavigation\Builder\Attribute::build()` function is expecting the key to be the store id.

To reproduce:
1. Configure multiple store views where the IDs are not consecutive
2. Set different attribute labels for each store view
3. Use the following graphql query to fetch the aggregations:
```
query getProductFiltersByCategory {
    products(filter: { category_id: {eq: "2"} }) {
        aggregations {
            label
            count
            attribute_code
            options {
                label
                value
            }
        }
    }
}

```
(don't forget to change the category ID if you want to query a specific category filter list)

Also, you should set the specific store code when querying a store view

The expected result should include the correct store specific label, however, because of array key missmatch, we get labels from different stores.