### PR TITLE
improve composer configuration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         }
     ],
     "require": {
+        "php": "^7.3 | ^7.4",
         "magento/framework": ">=103.0.0",
         "magento/module-store": ">=101.1.0",
         "magento/module-backend": ">=102.0.0",

--- a/composer.json
+++ b/composer.json
@@ -50,20 +50,6 @@
         "magento/magento-composer-installer": "*",
         "elasticsearch/elasticsearch": "~6.7|~7.2"
     },
-    "replace": {
-        "smile/module-elasticsuite-core": "self.version",
-        "smile/module-elasticsuite-admin-notification": "self.version",
-        "smile/module-elasticsuite-analytics": "self.version",
-        "smile/module-elasticsuite-catalog": "self.version",
-        "smile/module-elasticsuite-catalog-graph-ql": "self.version",
-        "smile/module-elasticsuite-catalog-optimizer": "self.version",
-        "smile/module-elasticsuite-catalog-rule": "self.version",
-        "smile/module-elasticsuite-indices": "self.version",
-        "smile/module-elasticsuite-swatches": "self.version",
-        "smile/module-elasticsuite-thesaurus": "self.version",
-        "smile/module-elasticsuite-tracker": "self.version",
-        "smile/module-elasticsuite-virtual-category": "self.version"
-    },
     "require-dev": {
         "smile/magento2-smilelab-quality-suite": "~2.2.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,8 @@
     ],
     "require": {
         "php": "^7.3 | ^7.4",
+        "ext-json": "*",
+        "ext-mbstring": "*",
         "magento/framework": ">=103.0.0",
         "magento/module-store": ">=101.1.0",
         "magento/module-backend": ">=102.0.0",


### PR DESCRIPTION
- added allowed php versions (^7.3 | ^7.4) (see "magento/framework": ">=103.0.0 requirements)
- added ext-json and ext-mbstring as required extensions
- remove useless replaces