### PR TITLE
Fixed setup:di:compile in Magento 2.4.1

### DIFF
--- a/src/module-elasticsuite-catalog-graph-ql/Model/Resolver/Products/Query/Search.php
+++ b/src/module-elasticsuite-catalog-graph-ql/Model/Resolver/Products/Query/Search.php
@@ -82,7 +82,7 @@ class Search implements ProductQueryInterface
     /**
      * {@inheritDoc}
      */
-    public function getResult(array $args, ResolveInfo $info/*, ContextInterface $context*/): SearchResult
+    public function getResult(array $args, ResolveInfo $info, ContextInterface $context): SearchResult
     {
         $queryFields    = $this->fieldSelection->getProductsFieldSelection($info);
         $searchCriteria = $this->buildSearchCriteria($args, $info);


### PR DESCRIPTION
Magento 2.4.1 has fixed the issue with ContextInterface. Uncommenting the tricks has been done for 2.4.0.