### PR TITLE
Pass excluded categories by reference

### DIFF
--- a/src/module-elasticsuite-virtual-category/Api/Data/VirtualRuleInterface.php
+++ b/src/module-elasticsuite-virtual-category/Api/Data/VirtualRuleInterface.php
@@ -33,7 +33,7 @@ interface VirtualRuleInterface
      *
      * @return \Smile\ElasticsuiteCore\Search\Request\QueryInterface
      */
-    public function getCategorySearchQuery($category, $excludedCategories = []);
+    public function getCategorySearchQuery($category, &$excludedCategories = []);
 
     /**
      * Retrieve search queries of children categories.

--- a/src/module-elasticsuite-virtual-category/Model/Rule.php
+++ b/src/module-elasticsuite-virtual-category/Model/Rule.php
@@ -136,7 +136,7 @@ class Rule extends \Smile\ElasticsuiteCatalogRule\Model\Rule implements VirtualR
      *
      * @return QueryInterface|null
      */
-    public function getCategorySearchQuery($category, $excludedCategories = []): ?QueryInterface
+    public function getCategorySearchQuery($category, &$excludedCategories = []): ?QueryInterface
     {
         $query         = null;
 
@@ -247,7 +247,7 @@ class Rule extends \Smile\ElasticsuiteCatalogRule\Model\Rule implements VirtualR
      *
      * @return QueryInterface
      */
-    private function getStandardCategoryQuery(CategoryInterface $category, $excludedCategories = []): QueryInterface
+    private function getStandardCategoryQuery(CategoryInterface $category, &$excludedCategories = []): QueryInterface
     {
         return $this->getStandardCategoriesQuery([$category->getId()], $excludedCategories);
     }
@@ -260,7 +260,7 @@ class Rule extends \Smile\ElasticsuiteCatalogRule\Model\Rule implements VirtualR
      *
      * @return QueryInterface
      */
-    private function getStandardCategoriesQuery(array $categoryIds, $excludedCategories): QueryInterface
+    private function getStandardCategoriesQuery(array $categoryIds, &$excludedCategories): QueryInterface
     {
         $conditionsParams  = ['data' => ['attribute' => 'category_ids', 'operator' => '()', 'value' => $categoryIds]];
         $categoryCondition = $this->productConditionsFactory->create($conditionsParams);
@@ -279,7 +279,7 @@ class Rule extends \Smile\ElasticsuiteCatalogRule\Model\Rule implements VirtualR
      */
     private function getVirtualCategoryQuery(
         CategoryInterface $category,
-        $excludedCategories = [],
+        &$excludedCategories = [],
         $virtualCategoryRoot = null
     ): ?QueryInterface {
         $query          = $category->getVirtualRule()->getConditions()->getSearchQuery($excludedCategories, $virtualCategoryRoot);
@@ -309,7 +309,7 @@ class Rule extends \Smile\ElasticsuiteCatalogRule\Model\Rule implements VirtualR
      *
      * @return \Smile\ElasticsuiteCore\Search\Request\QueryInterface
      */
-    private function addChildrenQueries($query, CategoryInterface $category, $excludedCategories = []): QueryInterface
+    private function addChildrenQueries($query, CategoryInterface $category, &$excludedCategories = []): QueryInterface
     {
         $childrenCategories    = $this->getChildrenCategories($category, $excludedCategories);
         $childrenCategoriesIds = [];
@@ -348,7 +348,7 @@ class Rule extends \Smile\ElasticsuiteCatalogRule\Model\Rule implements VirtualR
      *
      * @return Collection
      */
-    private function getChildrenCategories(CategoryInterface $category, $excludedCategories = []): Collection
+    private function getChildrenCategories(CategoryInterface $category, &$excludedCategories = []): Collection
     {
         $storeId            = $category->getStoreId();
         $categoryCollection = $this->categoryCollectionFactory->create()->setStoreId($storeId);


### PR DESCRIPTION
We have a website where loading a category page in the admin is so slow it's practically unusable. Upon investigation it was discovered that this code was taking the vast majority of time. This change reduced page load time from ~9 minutes to ~15 seconds.

`Smile\ElasticsuiteVirtualCategory\Model\Rule::getCategorySearchQuery()` takes an array of category IDs that have already been processed, and therefore should be excluded next time. It adds any categories that have now been processed to this array to avoid infinite loops/recursion. However, because this parameter was not being passed by reference the additions were being thrown away and the same categories were being processed again the next time this is called.