### PR TITLE
Fix graphql pagination

### DIFF
--- a/src/module-elasticsuite-catalog-graph-ql/Model/Resolver/Products/Query/Search.php
+++ b/src/module-elasticsuite-catalog-graph-ql/Model/Resolver/Products/Query/Search.php
@@ -67,9 +67,9 @@ class Search implements ProductQueryInterface
     /**
      * @param SearchInterface       $search                Search Engine
      * @param SearchResultFactory   $searchResultFactory   Search Results Factory
-     * @param PageSizeProvider      $pageSize
+     * @param PageSizeProvider      $pageSize              PageSize Provider
      * @param FieldSelection        $fieldSelection        Field Selection
-     * @param ProductSearch         $productsProvider       Product Provider
+     * @param ProductSearch         $productsProvider      Product Provider
      * @param SearchCriteriaBuilder $searchCriteriaBuilder Search Criteria Builder
      */
     public function __construct(
@@ -98,7 +98,7 @@ class Search implements ProductQueryInterface
 
         $realPageSize = $searchCriteria->getPageSize();
         $realCurrentPage = $searchCriteria->getCurrentPage();
-        //Because of limitations of sort and pagination on search API we will query all IDS
+        // Because of limitations of sort and pagination on search API we will query all IDS.
         $pageSize = $this->pageSizeProvider->getMaxPageSize();
         $searchCriteria->setPageSize($pageSize);
         $searchCriteria->setCurrentPage(0);
@@ -107,13 +107,13 @@ class Search implements ProductQueryInterface
         $providerSearchCriteria = clone($searchCriteria);
         // Pass a dummy search criteria (no filter) to product provider : filtering is already done.
         $providerSearchCriteria->setFilterGroups([]);
-        //Address limitations of sort and pagination on search API apply original pagination from GQL query
+        // Address limitations of sort and pagination on search API apply original pagination from GQL query.
         $providerSearchCriteria->setPageSize($realPageSize);
         $providerSearchCriteria->setCurrentPage($realCurrentPage);
 
         $searchResults = $this->productsProvider->getList($providerSearchCriteria, $itemsResults, $queryFields, $context);
 
-        $totalPages = $realPageSize ? ((int)ceil($searchResults->getTotalCount() / $realPageSize)) : 0;
+        $totalPages = $realPageSize ? ((int) ceil($searchResults->getTotalCount() / $realPageSize)) : 0;
         $productArray    = [];
 
         /** @var \Magento\Catalog\Model\Product $product */


### PR DESCRIPTION
GraphQL pagination not working (Magento 2.4.0)

Based on [query request](https://github.com/Smile-SA/elasticsuite/blob/2.10.x/Resources/tests/graphql/category/query.gql) I've got an empty items array if `currentPage` is more than 1. So I updated Smile\ElasticsuiteCatalogGraphQl\Model\Resolver\Products\Query\Search class to be consistent with Magento\CatalogGraphQl\Model\Resolver\Products\Query\Search

Looks like the problem is [because of limitations of sort and pagination on search API](https://github.com/magento/magento2/blob/5daadaee54d523c9f6bb3939bcb2df70539d8795/app/code/Magento/CatalogGraphQl/Model/Resolver/Products/Query/Search.php#L99)
