### PR TITLE
Ignore multiselect attributes from plugin

### DIFF
--- a/src/module-elasticsuite-swatches/Model/Plugin/ProductImage.php
+++ b/src/module-elasticsuite-swatches/Model/Plugin/ProductImage.php
@@ -66,6 +66,9 @@ class ProductImage extends \Magento\Swatches\Model\Plugin\ProductImage
         $attributes = $this->eavConfig->getEntityAttributes(\Magento\Catalog\Model\Product::ENTITY, $product);
 
         foreach ($request as $code => $value) {
+            if(is_array($value)){
+                continue;
+            }    
             if (array_key_exists($code, $attributes)) {
                 $attribute = $attributes[$code];
                 if ($this->canReplaceImageWithSwatch($attribute)) {


### PR DESCRIPTION
Product listing page and search page shows empty area in product listing area when filter for a multiselect swatch attribute is applied.
\Smile\ElasticsuiteSwatches\Model\Plugin\ProductImage class has getFilterArray method. This method can return array of format [ "color" => [ "blue","red" ]  ]
This further causes array to string conversion in vendor/magento/module-swatches/Helper/Data.php on line 199
For reproducing the issue create color as a swatch attribute, filterable on product listing page. You will see 
Notice: Array to string conversion in vendor/magento/module-swatches/Helper/Data.php on line 199 in system.log