### PR TITLE
REFACTOR: `around` plugins should be avoided at any price

### DIFF
--- a/src/module-elasticsuite-catalog/Block/Plugin/Adminhtml/Product/Attribute/Edit/Tab/FrontPlugin.php
+++ b/src/module-elasticsuite-catalog/Block/Plugin/Adminhtml/Product/Attribute/Edit/Tab/FrontPlugin.php
@@ -90,10 +90,8 @@ class FrontPlugin
      *
      * @return Front
      */
-    public function aroundSetForm(Front $subject, \Closure $proceed, Form $form)
+    public function afterSetForm(Front $subject, Front $result, Form $form)
     {
-        $block = $proceed($form);
-
         $fieldset = $this->createFieldset($form, $subject);
 
         $this->moveOrginalFields($form);
@@ -109,7 +107,7 @@ class FrontPlugin
 
         $this->appendFieldsDependency($subject);
 
-        return $block;
+        return $result;
     }
 
     /**


### PR DESCRIPTION
[Around plugins should be avoided](https://devdocs.magento.com/guides/v2.4/coding-standards/technical-guidelines.html#4-interception) so this PR removes redundant one.