### PR TITLE
Bugfix: Magento does not support GTE, it should be GTEQ

### DIFF
--- a/src/module-elasticsuite-catalog/Model/Layer/Filter/DecimalFilterTrait.php
+++ b/src/module-elasticsuite-catalog/Model/Layer/Filter/DecimalFilterTrait.php
@@ -51,7 +51,7 @@ trait DecimalFilterTrait
                 list($fromValue, $toValue) = $filter;
                 $this->setCurrentValue(['from' => $fromValue, 'to' => $toValue]);
 
-                $bounds = array_filter(['gte' => $fromValue, 'lt' => $toValue]);
+                $bounds = array_filter(['gteq' => $fromValue, 'lt' => $toValue]);
 
                 $this->getLayer()->getProductCollection()->addFieldToFilter(
                     $this->getAttributeModel()->getAttributeCode(),


### PR DESCRIPTION
`GTE` condition in filters does not work correctly with Magento collections, although it works fine with raw Elasticsearch.
Magento collections should be filtered by `GTEQ`.