### PR TITLE
Make js compatible to merging with other files.

### DIFF
--- a/src/module-elasticsuite-tracker/view/frontend/web/js/user-consent.js
+++ b/src/module-elasticsuite-tracker/view/frontend/web/js/user-consent.js
@@ -15,4 +15,4 @@ define(['jquery', 'mage/cookies'], function ($) {
     return function(config) {
         return config.cookieRestrictionEnabled == false || $.mage.cookies.get(config.cookieRestrictionName) !== null;
     };
-})
+});


### PR DESCRIPTION
When merging this file using e.g. magepack, the missing semicolon may cause problems in the file that gets appended. It may try to call define() as a function.