### PR TITLE
#2163 Add Basic HTTP Authentication (encrypted) support for Open Distro

### DIFF
--- a/src/module-elasticsuite-core/Api/Client/ClientConfigurationInterface.php
+++ b/src/module-elasticsuite-core/Api/Client/ClientConfigurationInterface.php
@@ -59,6 +59,13 @@ interface ClientConfigurationInterface
     public function isHttpAuthEnabled();
 
     /**
+     * Indicates whether the HTTP Authorization header should be base64 encoded or not.
+     *
+     * @return boolean
+     */
+    public function isHttpAuthEncodingEnabled();
+
+    /**
      * Return the basic HTTP authentication user.
      *
      * @return string

--- a/src/module-elasticsuite-core/Client/ClientBuilder.php
+++ b/src/module-elasticsuite-core/Client/ClientBuilder.php
@@ -43,6 +43,7 @@ class ClientBuilder
         'enable_http_auth'      => false,
         'http_auth_user'        => null,
         'http_auth_pwd'         => null,
+        'http_auth_encrypted'   => null,
         'is_debug_mode_enabled' => false,
         'max_parallel_handles'  => 100, // As per default Elasticsearch Handler configuration.
     ];
@@ -99,6 +100,11 @@ class ClientBuilder
             $handlerParams = ['max_handles' => (int) $options['max_parallel_handles']];
             $handler = \Elasticsearch\ClientBuilder::defaultHandler($handlerParams);
             $clientBuilder->setHandler($handler);
+        }
+
+        if (!empty($options['http_auth_user']) && !empty($options['http_auth_pwd']) && $options['http_auth_encoded']) {
+            $authHeader = 'Basic ' . base64_encode($options['http_auth_user'] . ':' . $options['http_auth_pwd']);
+            $clientBuilder->setConnectionParams(['client' => ['headers' => ['Authorization' => [$authHeader]]]]);
         }
 
         if (null !== $this->selector) {

--- a/src/module-elasticsuite-core/Client/ClientBuilder.php
+++ b/src/module-elasticsuite-core/Client/ClientBuilder.php
@@ -43,7 +43,7 @@ class ClientBuilder
         'enable_http_auth'      => false,
         'http_auth_user'        => null,
         'http_auth_pwd'         => null,
-        'http_auth_encrypted'   => null,
+        'http_auth_encoded'     => false,
         'is_debug_mode_enabled' => false,
         'max_parallel_handles'  => 100, // As per default Elasticsearch Handler configuration.
     ];

--- a/src/module-elasticsuite-core/Client/ClientConfiguration.php
+++ b/src/module-elasticsuite-core/Client/ClientConfiguration.php
@@ -91,6 +91,16 @@ class ClientConfiguration implements ClientConfigurationInterface
     /**
      * {@inheritdoc}
      */
+    public function isHttpAuthEncodingEnabled()
+    {
+        $authEncodingEnabled = (bool) $this->getElasticsearchClientConfigParam('enable_http_auth_encoding');
+
+        return $authEncodingEnabled && $this->isHttpAuthEnabled() !== false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getHttpAuthUser()
     {
         return (string) $this->getElasticsearchClientConfigParam('http_auth_user');

--- a/src/module-elasticsuite-core/Client/ClientConfiguration.php
+++ b/src/module-elasticsuite-core/Client/ClientConfiguration.php
@@ -131,6 +131,7 @@ class ClientConfiguration implements ClientConfigurationInterface
             'servers'               => $this->getServerList(),
             'scheme'                => $this->getScheme(),
             'enable_http_auth'      => $this->isHttpAuthEnabled(),
+            'http_auth_encoded'     => $this->isHttpAuthEncodingEnabled(),
             'http_auth_user'        => $this->getHttpAuthUser(),
             'http_auth_pwd'         => $this->getHttpAuthPassword(),
             'is_debug_mode_enabled' => $this->isDebugModeEnabled(),

--- a/src/module-elasticsuite-core/etc/adminhtml/system.xml
+++ b/src/module-elasticsuite-core/etc/adminhtml/system.xml
@@ -44,6 +44,11 @@
                     <comment>Enable this option when your Elasticsearch server use basic HTTP authentication.</comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
+                <field id="enable_http_auth_encoding" translate="label comment" type="select" sortOrder="52" showInDefault="1" showInWebsite="0" showInStore="0">
+                    <label>Encode HTTP authorization headers</label>
+                    <comment>Enable this option when you want to base64 encode the Authorization headers. (Open Distro requires this)</comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
                 <field id="http_auth_user" translate="label comment" type="text" sortOrder="53" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Basic HTTP authentication user</label>
                     <depends>


### PR DESCRIPTION
Adds support for Basic HTTP Authentication using encoded/encrypted Authorization header. (Open Distro Basic HTTP Authentication requires this when you use the internal users authentication functionality.)

Implements https://github.com/Smile-SA/elasticsuite/issues/2163