### PR TITLE
adds a property <normsDisabled> to the elasticsuite_indices.xml for d…

### DIFF
--- a/src/module-elasticsuite-core/Index/Mapping.php
+++ b/src/module-elasticsuite-core/Index/Mapping.php
@@ -304,6 +304,12 @@ class Mapping implements MappingInterface
 
         if ($field->normsDisabled()) {
             $property['norms'] = false;
+            
+            if (isset($property['fields'])) {
+                foreach (array_keys($property['fields']) as $fieldName) {
+                    $property['fields'][$fieldName]['norms'] = false;
+                }
+            }
         }
 
         $fieldRoot[end($fieldPathArray)] = $property;

--- a/src/module-elasticsuite-core/Index/Mapping.php
+++ b/src/module-elasticsuite-core/Index/Mapping.php
@@ -302,6 +302,10 @@ class Mapping implements MappingInterface
             $copyToRoot['copy_to'] = $copyToProperties;
         }
 
+        if ($field->normsDisabled()) {
+            $property['norms'] = false;
+        }
+
         $fieldRoot[end($fieldPathArray)] = $property;
 
         return $properties;

--- a/src/module-elasticsuite-core/Index/Mapping.php
+++ b/src/module-elasticsuite-core/Index/Mapping.php
@@ -304,7 +304,7 @@ class Mapping implements MappingInterface
 
         if ($field->normsDisabled()) {
             $property['norms'] = false;
-            
+
             if (isset($property['fields'])) {
                 foreach (array_keys($property['fields']) as $fieldName) {
                     $property['fields'][$fieldName]['norms'] = false;

--- a/src/module-elasticsuite-core/Index/Mapping/Field.php
+++ b/src/module-elasticsuite-core/Index/Mapping/Field.php
@@ -69,6 +69,7 @@ class Field implements FieldInterface
         'search_weight'           => 1,
         'default_search_analyzer' => self::ANALYZER_STANDARD,
         'filter_logical_operator' => self::FILTER_LOGICAL_OPERATOR_OR,
+        'norms_disabled'          => false,
     ];
 
     /**
@@ -138,6 +139,14 @@ class Field implements FieldInterface
     public function isUsedInSpellcheck(): bool
     {
         return (bool) $this->config['is_used_in_spellcheck'] && (bool) $this->config['is_searchable'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function normsDisabled(): bool
+    {
+        return (bool) $this->config['norms_disabled'];
     }
 
     /**


### PR DESCRIPTION
This adds support for property <normsDisabled> to the elasticsuite_indices.xml mapping, which allows for disabling field length normalization on a given field, simply add

`<normsDisabled>true</normsDisabled>`

to a elasticsuite_indices.xml file.