### PR TITLE
Correct version comparsion to handle 7.10.0

### DIFF
--- a/src/module-elasticsuite-core/Plugin/Deprecation/Search/Request/QueryInterfacePlugin.php
+++ b/src/module-elasticsuite-core/Plugin/Deprecation/Search/Request/QueryInterfacePlugin.php
@@ -54,7 +54,7 @@ class QueryInterfacePlugin
      */
     public function afterGetCutoffFrequency(\Smile\ElasticsuiteCore\Search\Request\QueryInterface $subject, $result)
     {
-        if (strcmp($this->clusterInfo->getServerVersion(), "7.3.0") >= 0) {
+        if (version_compare($this->clusterInfo->getServerVersion(), "7.3.0") >= 0) {
             $result = 0; // Will be evaluated as false and discarded by the Query Builder.
         }
 


### PR DESCRIPTION
`strcmp` does a lexicographical comparison, it considers that '7.10.0' is less than '7.3.0'.
Fixed to use `version_compare` to make this plugin work for Elasticsearch 7.10.0