### PR TITLE
Fix #1933 multi word synonyms search

### DIFF
--- a/src/module-elasticsuite-thesaurus/Model/Index.php
+++ b/src/module-elasticsuite-thesaurus/Model/Index.php
@@ -96,6 +96,7 @@ class Index
      */
     public function getQueryRewrites(ContainerConfigurationInterface $containerConfig, $queryText)
     {
+        $queryText = str_replace(' ', '_', $queryText);
         $cacheKey  = $this->getCacheKey($containerConfig, $queryText);
         $cacheTags = $this->getCacheTags($containerConfig);
 


### PR DESCRIPTION
When synonyms are saved into a database in all multi-word expressions all spaces are converted to underscore characters.  
However, when a customer is using the search feature on a storefront the conversion does not occur there for it is not finding any results.

For example expression "red jacket" will be saved in the database as "red_jacket" but when searching it will be still looking for "red jacket".