### PR TITLE
bugfix for HasImage filter matching products having no_selection as image value

### DIFF
--- a/src/module-elasticsuite-catalog-rule/Model/Rule/Condition/Product/SpecialAttribute/HasImage.php
+++ b/src/module-elasticsuite-catalog-rule/Model/Rule/Condition/Product/SpecialAttribute/HasImage.php
@@ -66,11 +66,11 @@ class HasImage implements SpecialAttributeInterface
         $queryParams = [];
         $queryClause = 'must';
 
-        $queryParams[ $queryClause ][] = $this->queryFactory->create(QueryInterface::TYPE_EXISTS, ['field' => 'image']);
+        $queryParams[$queryClause][] = $this->queryFactory->create(QueryInterface::TYPE_EXISTS, ['field' => 'image']);
 
-        $queryParams[ $queryClause ][] = $this->queryFactory->create(QueryInterface::TYPE_NOT, [
+        $queryParams[$queryClause][] = $this->queryFactory->create(QueryInterface::TYPE_NOT, [
             'query' => $this->queryFactory->create(QueryInterface::TYPE_TERMS, ['field' => 'image', 'values' => ['no_selection']]),
-        ]);;
+        ]);
 
         return $this->queryFactory->create(QueryInterface::TYPE_BOOL, $queryParams);
     }

--- a/src/module-elasticsuite-catalog-rule/Model/Rule/Condition/Product/SpecialAttribute/HasImage.php
+++ b/src/module-elasticsuite-catalog-rule/Model/Rule/Condition/Product/SpecialAttribute/HasImage.php
@@ -63,7 +63,16 @@ class HasImage implements SpecialAttributeInterface
      */
     public function getSearchQuery(ProductCondition $condition)
     {
-        return $this->queryFactory->create(QueryInterface::TYPE_EXISTS, ['field' => 'image']);
+        $queryParams = [];
+        $queryClause = 'must';
+
+        $queryParams[ $queryClause ][] = $this->queryFactory->create(QueryInterface::TYPE_EXISTS, ['field' => 'image']);
+
+        $queryParams[ $queryClause ][] = $this->queryFactory->create(QueryInterface::TYPE_NOT, [
+            'query' => $this->queryFactory->create(QueryInterface::TYPE_TERMS, ['field' => 'image', 'values' => ['no_selection']]),
+        ]);;
+
+        return $this->queryFactory->create(QueryInterface::TYPE_BOOL, $queryParams);
     }
 
     /**


### PR DESCRIPTION
Fixes #2230 "Has Image" Rule for Optimizers does not work with images that have no_selection set

Fixed by adding a condition to the generated query that excludes no_selection in addition to the exists clause.
