### PR TITLE
Performance: Add ObjectCache to avoid redundant DB calls

### DIFF
--- a/src/module-elasticsuite-catalog/Model/ResourceModel/Product/FilterableAttribute/Category/Collection.php
+++ b/src/module-elasticsuite-catalog/Model/ResourceModel/Product/FilterableAttribute/Category/Collection.php
@@ -34,8 +34,8 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Product\Attribute\
 
     /**
      * Object Cache of getMaxPosition results
-     * @see self::getMaxPosition()
      * @var int[]
+     * @see self::getMaxPosition()
      */
     private $maxPosition = [];
 
@@ -167,7 +167,7 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Product\Attribute\
      */
     private function getMaxPosition()
     {
-        $categoryId = (int)$this->category->getId();
+        $categoryId = (int) $this->category->getId();
 
         if (!isset($this->maxPosition[$categoryId])) {
             $fullTableName = $this->getResource()->getTable(self::CATEGORY_FILTER_CONFIG_TABLE);
@@ -176,7 +176,7 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Product\Attribute\
                 ->columns(['category_max_position' => new \Zend_Db_Expr('MAX(position)')])
                 ->where($this->getConnection()->quoteInto('entity_id = ?', $categoryId));
 
-            $this->maxPosition[$categoryId] = (int)$this->getConnection()->fetchOne($categoryPositionSelect);
+            $this->maxPosition[$categoryId] = (int) $this->getConnection()->fetchOne($categoryPositionSelect);
         }
 
         return $this->maxPosition[$categoryId];

--- a/src/module-elasticsuite-catalog/Model/ResourceModel/Product/FilterableAttribute/Category/Collection.php
+++ b/src/module-elasticsuite-catalog/Model/ResourceModel/Product/FilterableAttribute/Category/Collection.php
@@ -33,6 +33,13 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Product\Attribute\
     private $category;
 
     /**
+     * Object Cache of getMaxPosition results
+     * @see self::getMaxPosition()
+     * @var int[]
+     */
+    private $maxPosition = [];
+
+    /**
      * @var array
      */
     private $overridenColumns = ['position', 'facet_max_size', 'facet_sort_order', 'facet_min_coverage_rate'];
@@ -160,13 +167,19 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Product\Attribute\
      */
     private function getMaxPosition()
     {
-        $fullTableName = $this->getResource()->getTable(self::CATEGORY_FILTER_CONFIG_TABLE);
-        $categoryPositionSelect = $this->getConnection()->select()
-            ->from($fullTableName, [])
-            ->columns(['category_max_position' => new \Zend_Db_Expr('MAX(position)')])
-            ->where($this->getConnection()->quoteInto('entity_id = ?', (int) $this->category->getId()));
+        $categoryId = (int)$this->category->getId();
 
-        return (int) $this->getConnection()->fetchOne($categoryPositionSelect);
+        if (!isset($this->maxPosition[$categoryId])) {
+            $fullTableName = $this->getResource()->getTable(self::CATEGORY_FILTER_CONFIG_TABLE);
+            $categoryPositionSelect = $this->getConnection()->select()
+                ->from($fullTableName, [])
+                ->columns(['category_max_position' => new \Zend_Db_Expr('MAX(position)')])
+                ->where($this->getConnection()->quoteInto('entity_id = ?', $categoryId));
+
+            $this->maxPosition[$categoryId] = (int)$this->getConnection()->fetchOne($categoryPositionSelect);
+        }
+
+        return $this->maxPosition[$categoryId];
     }
 
     /**


### PR DESCRIPTION
**Problem**
![image](https://user-images.githubusercontent.com/1639941/134986541-56fcb61d-1471-45f4-8ef5-a92e10468d33.png)

One of the most expensive calls (according to BlackFire profile), is a triple call for the same data, executed when the Category page is being loaded. To avoid such a situation, I use Object Cache to keep the result of the DB call during the execution.