### PR TITLE
allow for adding custom analyzers to mapping definition

### DIFF
--- a/src/module-elasticsuite-core/Api/Index/Mapping/FieldInterface.php
+++ b/src/module-elasticsuite-core/Api/Index/Mapping/FieldInterface.php
@@ -149,6 +149,13 @@ interface FieldInterface
     public function getDefaultSearchAnalyzer();
 
     /**
+     * Return custom search analyzers used for fulltext searches.
+     *
+     * @return array
+     */
+    public function getCustomSearchAnalyzers();
+
+    /**
      * Merge field config and return a new instance with the updated config.
      *
      * @param array $config field configuration to merge with existing.

--- a/src/module-elasticsuite-core/Index/Mapping.php
+++ b/src/module-elasticsuite-core/Index/Mapping.php
@@ -166,14 +166,41 @@ class Mapping implements MappingInterface
         }
 
         foreach ($fields as $field) {
-            $currentAnalyzer = $analyzer;
-            $canAddField     = $defaultField === null || $field->getSearchWeight() !== 1;
+            $canAddField = $defaultField === null || $field->getSearchWeight() !== 1;
+            $analyzers   = [];
 
             if ($analyzer === null) {
-                $currentAnalyzer = $field->getDefaultSearchAnalyzer();
-                $canAddField     = $canAddField || ($currentAnalyzer !== FieldInterface::ANALYZER_STANDARD);
+                $defaultAnalyzer = $field->getDefaultSearchAnalyzer();
+                $analyzers       = $field->getCustomSearchAnalyzers();
+                $analyzers[]     = $defaultAnalyzer;
+                $canAddField     = $canAddField || ($defaultAnalyzer !== FieldInterface::ANALYZER_STANDARD);
             }
 
+            if ($analyzer !== null) {
+                $analyzers[] = $analyzer;
+            }
+
+            $weightedFields = array_merge($weightedFields, $this->addWeightedFields($analyzers, $canAddField, $field, $boost));
+        }
+
+        return $weightedFields;
+    }
+
+    /**
+     * Add weighted fields for each analyzer
+     *
+     * @param array          $analyzers   Analyzers
+     * @param bool           $canAddField Field can be added
+     * @param FieldInterface $field       Fild
+     * @param int            $boost       Boost applieds
+     *
+     * @return array
+     */
+    private function addWeightedFields($analyzers, $canAddField, $field, $boost)
+    {
+        $weightedFields = [];
+
+        foreach ($analyzers as $currentAnalyzer) {
             $property = $field->getMappingProperty($currentAnalyzer);
 
             if ($property && $canAddField) {

--- a/src/module-elasticsuite-core/Index/Mapping/Field.php
+++ b/src/module-elasticsuite-core/Index/Mapping/Field.php
@@ -68,6 +68,7 @@ class Field implements FieldInterface
         'is_used_in_spellcheck'   => false,
         'search_weight'           => 1,
         'default_search_analyzer' => self::ANALYZER_STANDARD,
+        'custom_search_analyzers' => [],
         'filter_logical_operator' => self::FILTER_LOGICAL_OPERATOR_OR,
         'norms_disabled'          => false,
     ];
@@ -243,6 +244,18 @@ class Field implements FieldInterface
     /**
      * {@inheritDoc}
      */
+    public function getCustomSearchAnalyzers()
+    {
+        if (is_array($this->config['custom_search_analyzers'])) {
+            return $this->config['custom_search_analyzers'];
+        }
+
+        return json_decode($this->config['custom_search_analyzers'], true);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function mergeConfig(array $config = [])
     {
         $config = array_merge($this->config, $config);
@@ -358,6 +371,7 @@ class Field implements FieldInterface
         if ($this->isSearchable() && $this->getSearchWeight() > 1) {
             $analyzers[] = self::ANALYZER_WHITESPACE;
             $analyzers[] = self::ANALYZER_SHINGLE;
+            $analyzers   = array_merge($analyzers, $this->getCustomSearchAnalyzers());
         }
 
         if (empty($analyzers) || $this->isFilterable()) {


### PR DESCRIPTION
Allow for adding analyzers to field mappings in following format

```
<customSearchAnalyzers>["custom_analyzer"]</customSearchAnalyzers>
```