### PR TITLE
Fix missing category_uid attribute mapping

### DIFF
--- a/src/module-elasticsuite-catalog/Model/Search/Request/Field/Mapper.php
+++ b/src/module-elasticsuite-catalog/Model/Search/Request/Field/Mapper.php
@@ -29,6 +29,7 @@ class Mapper
     private $fieldNameMapping = [
         'category_ids' => 'category.category_id',
         'category_id' => 'category.category_id',
+        'category_uid' => 'category.category_id',
         'position' => 'category.position',
         'price' => 'price.price',
     ];

--- a/src/module-elasticsuite-catalog/etc/elasticsuite_indices.xml
+++ b/src/module-elasticsuite-catalog/etc/elasticsuite_indices.xml
@@ -57,6 +57,7 @@
 
                 <!-- Static fields handled by the "categories" datasource -->
                 <field name="category.category_id" type="integer" nestedPath="category" />
+                <field name="category.category_uid" type="integer" nestedPath="category" />
                 <field name="category.position" type="integer" nestedPath="category" />
                 <field name="category.is_parent" type="boolean" nestedPath="category" />
                 <field name="category.name" type="text" nestedPath="category">


### PR DESCRIPTION
Filtering products based on category ID in graphql results in a 500 error:

Request data:
```
{"operationName":null,"variables":{},"query":"{\n  products(filter: {category_uid: {eq: \"30\"}}) {\n    items {\n      name\n    }\n  }\n}\n"}
```

Exception:
```
[2021-10-25 08:26:33] .ERROR: Field category_uid does not exists in mapping {"exception":"[object] (GraphQL\\Error\\Error(code: 0): Field category_uid does not exists in mapping at /Sites/vendor/webonyx/graphql-php/src/Error/Error.php:174, LogicException(code: 0): Field category_uid does not exists in mapping at /Sites/vendor/smile/elasticsuite/src/module-elasticsuite-core/Index/Mapping.php:133)"} []
```

`category_uid` is added in Magento 2.4 (see https://devdocs.magento.com/guides/v2.4/graphql/queries/products.html#ProductFilterInput) and `category_id` is now deprecated. This PR will add `category_uid` to the field mappers.


