### PR TITLE
Update category_uid attribute mapping

### DIFF
--- a/src/module-elasticsuite-catalog/Model/Search/Request/Field/Mapper.php
+++ b/src/module-elasticsuite-catalog/Model/Search/Request/Field/Mapper.php
@@ -29,7 +29,7 @@ class Mapper
     private $fieldNameMapping = [
         'category_ids' => 'category.category_id',
         'category_id' => 'category.category_id',
-        'category_uid' => 'category.category_id',
+        'category_uid' => 'category.category_uid',
         'position' => 'category.position',
         'price' => 'price.price',
     ];

--- a/src/module-elasticsuite-catalog/etc/elasticsuite_indices.xml
+++ b/src/module-elasticsuite-catalog/etc/elasticsuite_indices.xml
@@ -57,7 +57,7 @@
 
                 <!-- Static fields handled by the "categories" datasource -->
                 <field name="category.category_id" type="integer" nestedPath="category" />
-                <field name="category.category_uid" type="integer" nestedPath="category" />
+                <field name="category.category_uid" type="text" nestedPath="category" />
                 <field name="category.position" type="integer" nestedPath="category" />
                 <field name="category.is_parent" type="boolean" nestedPath="category" />
                 <field name="category.name" type="text" nestedPath="category">

--- a/src/module-elasticsuite-virtual-category/Model/Rule/Condition/Product.php
+++ b/src/module-elasticsuite-virtual-category/Model/Rule/Condition/Product.php
@@ -129,6 +129,7 @@ class Product extends \Smile\ElasticsuiteCatalogRule\Model\Rule\Condition\Produc
 
     /**
      * Retrieve a query used to apply category filter rule.
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      *
      * @param array    $excludedCategories  Category excluded from the loading (avoid infinite loop in query
      *                                      building when circular references are present).


### PR DESCRIPTION
Update of https://github.com/Smile-SA/elasticsuite/pull/2315.

`category_uid` is the base64 encoded value of `category_id` and not a copy.

- https://devdocs.magento.com/guides/v2.4/graphql/queries/category-list.html
- https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/CatalogGraphQl/Model/Category/Hydrator.php#L66