### PR TITLE
Update category_uid attribute mapping

### DIFF
--- a/src/module-elasticsuite-catalog/Model/Product/Indexer/Fulltext/Datasource/CategoryData.php
+++ b/src/module-elasticsuite-catalog/Model/Product/Indexer/Fulltext/Datasource/CategoryData.php
@@ -14,7 +14,8 @@
 
 namespace Smile\ElasticsuiteCatalog\Model\Product\Indexer\Fulltext\Datasource;
 
-use Magento\Framework\GraphQl\Query\Uid;
+use Magento\Framework\App\ObjectManager;
+use Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Indexer\Fulltext\Datasource\Deprecation\Uid as Deprecation;
 use Smile\ElasticsuiteCore\Api\Index\DatasourceInterface;
 use Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Indexer\Fulltext\Datasource\CategoryData as ResourceModel;
 
@@ -38,18 +39,17 @@ class CategoryData implements DatasourceInterface
     private $resourceModel;
 
     /**
-     * @var Uid
+     * @var \Magento\Framework\GraphQl\Query\Uid|Deprecation
      */
     private $uidEncoder;
 
     /**
      * @param ResourceModel $resourceModel Resource model
-     * @param Uid           $uidEncoder    Encodes and decodes id and uid values
      */
-    public function __construct(ResourceModel $resourceModel, Uid $uidEncoder)
+    public function __construct(ResourceModel $resourceModel)
     {
         $this->resourceModel = $resourceModel;
-        $this->uidEncoder = $uidEncoder;
+        $this->uidEncoder = $this->getUidEncoder();
     }
 
     /**
@@ -102,5 +102,20 @@ class CategoryData implements DatasourceInterface
         }
 
         return $this->categoriesUid[$categoryId];
+    }
+
+    /**
+     * @deprecated To be removed when Magento v2.4.1 is no longer supported.
+     * @see \Magento\Framework\GraphQl\Query\Uid
+     *
+     * @return \Magento\Framework\GraphQl\Query\Uid|Deprecation
+     */
+    private function getUidEncoder()
+    {
+        return class_exists(\Magento\Framework\GraphQl\Query\Uid::class)
+            ? ObjectManager::getInstance()
+                ->get(\Magento\Framework\GraphQl\Query\Uid::class)
+            : ObjectManager::getInstance()
+                ->get(Deprecation::class);
     }
 }

--- a/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Indexer/Fulltext/Datasource/Deprecation/Uid.php
+++ b/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Indexer/Fulltext/Datasource/Deprecation/Uid.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade Smile ElasticSuite to newer
+ * versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\ElasticsuiteCatalog
+ * @copyright 2021 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+
+declare(strict_types=1);
+
+namespace Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Indexer\Fulltext\Datasource\Deprecation;
+
+/**
+ * Encodes and decodes id and uid values
+ *
+ * @deprecated To be removed when Magento v2.4.1 is no longer supported.
+ * @see \Magento\Framework\GraphQl\Query\Uid
+ */
+class Uid
+{
+    /**
+     * Encode ID value to UID
+     *
+     * @param string $id
+     * @return string
+     */
+    public function encode(string $id): string
+    {
+        return base64_encode($id);
+    }
+}


### PR DESCRIPTION
Update of #2315, #2326.

category_uid is the base64 encoded value of category_id and not a copy.

https://devdocs.magento.com/guides/v2.4/graphql/queries/category-list.html
https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/CatalogGraphQl/Model/Category/Hydrator.php#L66