### PR TITLE
Fix for missing server name definition

### DIFF
--- a/src/module-elasticsuite-tracker/Block/Variables/Page/Base.php
+++ b/src/module-elasticsuite-tracker/Block/Variables/Page/Base.php
@@ -142,7 +142,7 @@ class Base extends \Smile\ElasticsuiteTracker\Block\Variables\Page\AbstractBlock
     {
         return [
             'locale' => $this->localeResolver->getLocale(),
-            'domain' => $this->requestInterface->getServer('SERVER_ADDR')
+            'domain' => $this->requestInterface->getServer('SERVER_ADDR'),
         ];
     }
 

--- a/src/module-elasticsuite-tracker/Block/Variables/Page/Base.php
+++ b/src/module-elasticsuite-tracker/Block/Variables/Page/Base.php
@@ -38,15 +38,21 @@ class Base extends \Smile\ElasticsuiteTracker\Block\Variables\Page\AbstractBlock
     protected $localeResolver;
 
     /**
+     * @var \Magento\Framework\App\RequestInterface
+     */
+    protected $requestInterface;
+
+    /**
      * Set the default template for page variable blocks
      *
-     * @param Template\Context                               $context        The template context
-     * @param \Magento\Framework\Json\Helper\Data            $jsonHelper     The Magento's JSON Helper
-     * @param \Smile\ElasticsuiteTracker\Helper\Data         $trackerHelper  The Smile Tracker helper
-     * @param \Magento\Framework\Registry                    $registry       Magento Core Registry
-     * @param \Magento\Framework\View\Layout\PageType\Config $pageTypeConfig The page type configuration
-     * @param \Magento\Framework\Locale\ResolverInterface    $localeResolver Locale Resolver
-     * @param array                                          $data           The block data
+     * @param Template\Context                               $context          The template context
+     * @param \Magento\Framework\Json\Helper\Data            $jsonHelper       The Magento's JSON Helper
+     * @param \Smile\ElasticsuiteTracker\Helper\Data         $trackerHelper    The Smile Tracker helper
+     * @param \Magento\Framework\Registry                    $registry         Magento Core Registry
+     * @param \Magento\Framework\View\Layout\PageType\Config $pageTypeConfig   The page type configuration
+     * @param \Magento\Framework\Locale\ResolverInterface    $localeResolver   Locale Resolver
+     * @param \Magento\Framework\App\RequestInterface        $requestInterface RequestInterface
+     * @param array                                          $data             The block data
      */
     public function __construct(
         Template\Context $context,
@@ -55,10 +61,12 @@ class Base extends \Smile\ElasticsuiteTracker\Block\Variables\Page\AbstractBlock
         \Magento\Framework\Registry $registry,
         \Magento\Framework\View\Layout\PageType\Config $pageTypeConfig,
         \Magento\Framework\Locale\ResolverInterface $localeResolver,
+        \Magento\Framework\App\RequestInterface $requestInterface,
         array $data = []
     ) {
         $this->pageTypeConfig = $pageTypeConfig;
         $this->localeResolver = $localeResolver;
+        $this->requestInterface = $requestInterface;
 
         return parent::__construct($context, $jsonHelper, $trackerHelper, $registry, $data);
     }
@@ -134,7 +142,7 @@ class Base extends \Smile\ElasticsuiteTracker\Block\Variables\Page\AbstractBlock
     {
         return [
             'locale' => $this->localeResolver->getLocale(),
-            'domain' => $_SERVER['SERVER_NAME'],
+            'domain' => $this->requestInterface->getServer('SERVER_ADDR')
         ];
     }
 


### PR DESCRIPTION
In some environments (for example CI/CD) server name value is not set, resulting in:

```
Notice: Undefined index: SERVER_NAME in /var/www/html/vendor/smile/elasticsuite/src/module-elasticsuite-tracker/Block/Variables/Page/Base.php:137.
```

This change uses `requestInterface` to fetch server name if exists, returning empty string otherwise.