### PR TITLE
Add option to index child attributes or not

### DIFF
--- a/src/module-elasticsuite-catalog/Model/Eav/Indexer/Fulltext/Datasource/AbstractAttributeData.php
+++ b/src/module-elasticsuite-catalog/Model/Eav/Indexer/Fulltext/Datasource/AbstractAttributeData.php
@@ -18,6 +18,7 @@ use Magento\Eav\Model\Entity\Attribute\AttributeInterface;
 use Smile\ElasticsuiteCatalog\Model\ResourceModel\Eav\Indexer\Fulltext\Datasource\AbstractAttributeData as ResourceModel;
 use Smile\ElasticsuiteCore\Index\Mapping\FieldFactory;
 use Smile\ElasticsuiteCatalog\Helper\AbstractAttribute as AttributeHelper;
+use Smile\ElasticsuiteCatalog\Scope\Config;
 use Smile\ElasticsuiteCore\Api\Index\Mapping\FieldInterface;
 
 /**
@@ -43,6 +44,9 @@ abstract class AbstractAttributeData
      * @var \Smile\ElasticsuiteCatalog\Helper\AbstractAttribute
      */
     protected $attributeHelper;
+
+    /** @var Config */
+    protected $config;
 
     /**
      * @var \Smile\ElasticsuiteCatalog\Model\ResourceModel\Eav\Indexer\Fulltext\Datasource\AbstractAttributeData
@@ -75,17 +79,20 @@ abstract class AbstractAttributeData
     /**
      * Constructor
      *
+     * @param Config          $config               Configuration retriever
      * @param ResourceModel   $resourceModel        Resource model.
      * @param FieldFactory    $fieldFactory         Mapping field factory.
      * @param AttributeHelper $attributeHelper      Attribute helper.
      * @param array           $indexedBackendModels List of indexed backend models added to the default list.
      */
     public function __construct(
+        Config $config,
         ResourceModel $resourceModel,
         FieldFactory $fieldFactory,
         AttributeHelper $attributeHelper,
         array $indexedBackendModels = []
     ) {
+        $this->config          = $config;
         $this->resourceModel   = $resourceModel;
         $this->attributeHelper = $attributeHelper;
         $this->fieldFactory    = $fieldFactory;

--- a/src/module-elasticsuite-catalog/Model/Product/Indexer/Fulltext/Datasource/AttributeData.php
+++ b/src/module-elasticsuite-catalog/Model/Product/Indexer/Fulltext/Datasource/AttributeData.php
@@ -47,6 +47,10 @@ class AttributeData extends AbstractAttributeData implements DatasourceInterface
         $productIds   = array_keys($indexData);
         $indexData    = $this->addAttributeData($storeId, $productIds, $indexData);
 
+        if (!$this->config->isIncludeChildAttributes()) {
+            return $indexData;
+        }
+
         $relationsByChildId = $this->resourceModel->loadChildrens($productIds, $storeId);
 
         if (!empty($relationsByChildId)) {

--- a/src/module-elasticsuite-catalog/Scope/Config.php
+++ b/src/module-elasticsuite-catalog/Scope/Config.php
@@ -1,0 +1,26 @@
+<?php
+namespace Smile\ElasticsuiteCatalog\Scope;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Store\Model\ScopeInterface;
+
+class Config
+{
+    protected const INCLUDE_CHILD_ATTRIBUTES = 'smile_elasticsuite_catalogsearch_settings/catalogsearch/include_child_attributes';
+
+    protected $scopeConfig;
+
+    public function __construct(
+        ScopeConfigInterface $scopeConfig
+    ) {
+        $this->scopeConfig = $scopeConfig;
+    }
+
+    public function isIncludeChildAttributes(): bool
+    {
+        return $this->scopeConfig->isSetFlag(
+            self::INCLUDE_CHILD_ATTRIBUTES,
+            ScopeInterface::SCOPE_STORE
+        );
+    }
+}

--- a/src/module-elasticsuite-catalog/etc/adminhtml/system.xml
+++ b/src/module-elasticsuite-catalog/etc/adminhtml/system.xml
@@ -75,6 +75,11 @@
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <comment><![CDATA[If enabled, when necessary to support the presence of outlier values in the navigation context (for instance, a very high price amidst a majority of low prices), the price slider behavior changes so that the middle of the slider range corresponds to the median price instead of the price at the middle of the range.]]></comment>
                 </field>
+                <field id="include_child_attributes" translate="label comment" type="select" sortOrder="50" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                    <label>Include child attributes during indexing</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <comment><![CDATA[If enabled, attributes of associated child products will be included with their parents when indexing. This will impact what filters are shown in category pages. For example, if a child of a bundle product has a particular colour then its parent will have this colour associated with it. <br><strong>Note when changing this setting</strong>, it is recommended to perform a full reindex of the <q>Catalog Search</q> indexer.]]></comment>
+                </field>
             </group>
         </section>
     </system>

--- a/src/module-elasticsuite-catalog/etc/config.xml
+++ b/src/module-elasticsuite-catalog/etc/config.xml
@@ -38,6 +38,7 @@
                 <category_filter_use_url_rewrites>1</category_filter_use_url_rewrites>
                 <expanded_facets>3</expanded_facets>
                 <adaptive_slider_enabled>0</adaptive_slider_enabled>
+                <include_child_attributes>1</include_child_attributes>
             </catalogsearch>
         </smile_elasticsuite_catalogsearch_settings>
     </default>


### PR DESCRIPTION
While working with bundle products on a website, the merchant wants to only include attributes of the parent/bundle product not any of its options/children. This configuration option adds the ability for website administrators to make this decision. By default, the existing behaviour is preserved.