### PR TITLE
Make jQuery ajax request for autocomplete cacheable

### DIFF
--- a/src/module-elasticsuite-core/view/frontend/web/js/form-mini.js
+++ b/src/module-elasticsuite-core/view/frontend/web/js/form-mini.js
@@ -239,7 +239,9 @@ define([
                 this.currentRequest = $.ajax({
                     method: "GET",
                     url: this.options.url,
-                    data:{q: value},
+                    cache: true,
+                    dataType: 'json',
+                    data: {q: value},
                     // This function will ensure proper killing of the last Ajax call.
                     // In order to prevent requests of an old request to pop up later and replace results.
                     beforeSend: function() { if (this.currentRequest !== null) { this.currentRequest.abort(); }}.bind(this),


### PR DESCRIPTION
I've noticed on my magento installation 2.4.3 search requests are appended with `&_=[timestamp]` which makes requests slower than they could be.

[jQuery ajax documentation](https://api.jquery.com/jquery.ajax/#jQuery-ajax-settings) mentions a `cache` option for ajax calls, which controls this behaviour.

The ajax() funtction is called without `cache` parameter making it work kind of automatically as documentation says.
I'm not sure how that exactly is resolving to false - I guess it may be considering dataType beeing 'jsonp' or 'script'. Therefore, in this PR I'm adding a `cache: true` option to make sure the timestamp is not appended as well as I'm setting `dataType: 'json'` to make sure jQuery expects 'json' which is what is beeing returned.

This PR also adds extra space for style purposes.

Lastly here's a comparasion on my local machine with large database of products before and after changes:

With cache timestamp:

![Screenshot from 2022-03-04 12-54-42](https://user-images.githubusercontent.com/2505114/156759926-73cb3ad5-582a-4c4e-8aa7-b45c2e2e8511.png)

Without cache timestamp:

![Screenshot from 2022-03-04 12-55-16](https://user-images.githubusercontent.com/2505114/156759929-f4b439f2-cb0d-4f75-986e-1a275f0537d6.png)

