### PR TITLE
Fixes #2448 Allowing removal of query/field filter(s)

### DIFF
--- a/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Fulltext/Collection.php
+++ b/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Fulltext/Collection.php
@@ -289,11 +289,53 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Product\Collection
      *
      * @param QueryInterface $queryFilter Query filter.
      *
-     * @return $this
+     * @return \Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Fulltext\Collection
      */
     public function addQueryFilter(QueryInterface $queryFilter)
     {
         $this->queryFilters[] = $queryFilter;
+        $this->_isFiltersRendered = false;
+
+        return $this;
+    }
+
+    /**
+     * Remove a specific field filter.
+     *
+     * @param string $field Field to remove the filter for.
+     *
+     * @return \Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Fulltext\Collection
+     */
+    public function removeFieldFilter($field)
+    {
+        $field = $this->mapFieldName($field);
+        unset($this->filters[$field]);
+        $this->_isFiltersRendered = false;
+
+        return $this;
+    }
+
+    /**
+     * Remove all field filters.
+     *
+     * @return \Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Fulltext\Collection
+     */
+    public function removeFieldFilters()
+    {
+        $this->filters = [];
+        $this->_isFiltersRendered = false;
+
+        return $this;
+    }
+
+    /**
+     * Remove all previously added query filters.
+     *
+     * @return \Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Fulltext\Collection
+     */
+    public function removeQueryFilters()
+    {
+        $this->queryFilters = [];
         $this->_isFiltersRendered = false;
 
         return $this;


### PR DESCRIPTION
Field filters can be overwritten by using addFieldToFilter with an
identical field name but there might be some situation where removing
one or all field filters is required.
Query filters are stored without a reference but it is now possible to
remove them all on a cloned collection.