### PR TITLE
Feature #2431 Opt. zero product position indexing

### DIFF
--- a/src/module-elasticsuite-virtual-category/etc/di.xml
+++ b/src/module-elasticsuite-virtual-category/etc/di.xml
@@ -67,6 +67,8 @@
     <type name="Smile\ElasticsuiteCatalog\Model\Product\Indexer\Fulltext\Datasource\CategoryData">
         <arguments>
             <argument name="resourceModel" xsi:type="object">Smile\ElasticsuiteVirtualCategory\Model\ResourceModel\Product\Indexer\Fulltext\Datasource\CategoryData</argument>
+            <!-- Enforcing filtering out 0 positions since they are not supposed to happen with the specific merchandiser -->
+            <argument name="filterZeroPositions" xsi:type="boolean">true</argument>
         </arguments>
     </type>
 


### PR DESCRIPTION
For instance, when Smile_ElasticsuiteVirtualCategory is disabled and one
wants to keep products with a '0' position in category at the top of the
category.
Will require changing datasource argument through DI.