### PR TITLE
[FEATURE][GWSM2-985] - Fixes sort order case sensitivity.

### DIFF
--- a/src/module-elasticsuite-core/Index/Mapping/Field.php
+++ b/src/module-elasticsuite-core/Index/Mapping/Field.php
@@ -255,6 +255,8 @@ class Field implements FieldInterface
      */
     public function getSortMissing($direction = SortOrderInterface::SORT_ASC)
     {
+        $direction = strtolower($direction);
+
         // @codingStandardsIgnoreStart
         $missing = $direction === SortOrderInterface::SORT_ASC ? SortOrderInterface::MISSING_LAST : SortOrderInterface::MISSING_FIRST;
         // @codingStandardsIgnoreEnd


### PR DESCRIPTION
The sort order provided in `$direction` can be in uppercase, while the constant is in lowercase. This can create incorrect sort orders, which in our case led to manually sorted products being placed behind the automatically sorted products on virtual category pages. Note: The manually sorted products and automatically sorted products were correctly sorted within their respective groups, but the sort order of the groups was incorrect.

cc @MatthijsBreed