### PR TITLE
2.4.4 Support (#2494) - Adding base OpenSearch compatibility checks

### DIFF
--- a/src/module-elasticsuite-core/Api/Cluster/ClusterInfoInterface.php
+++ b/src/module-elasticsuite-core/Api/Cluster/ClusterInfoInterface.php
@@ -23,10 +23,20 @@ namespace Smile\ElasticsuiteCore\Api\Cluster;
  */
 interface ClusterInfoInterface
 {
+    public CONST DISTRO_ES = 'elasticsearch';
+    public CONST DISTRO_OS = 'opensearch';
+
     /**
      * Returns ElasticSearch server version.
      *
      * @return string
      */
     public function getServerVersion();
+
+    /**
+     * Returns if server is ElasticSearch or OpenSearch.
+     *
+     * @return string
+     */
+    public function getServerDistribution();
 }

--- a/src/module-elasticsuite-core/Api/Cluster/ClusterInfoInterface.php
+++ b/src/module-elasticsuite-core/Api/Cluster/ClusterInfoInterface.php
@@ -23,8 +23,8 @@ namespace Smile\ElasticsuiteCore\Api\Cluster;
  */
 interface ClusterInfoInterface
 {
-    public CONST DISTRO_ES = 'elasticsearch';
-    public CONST DISTRO_OS = 'opensearch';
+    public const DISTRO_ES = 'elasticsearch';
+    public const DISTRO_OS = 'opensearch';
 
     /**
      * Returns ElasticSearch server version.

--- a/src/module-elasticsuite-core/Cluster/ClusterInfo.php
+++ b/src/module-elasticsuite-core/Cluster/ClusterInfo.php
@@ -36,6 +36,11 @@ class ClusterInfo implements ClusterInfoInterface
     private $serverVersion;
 
     /**
+     * @var string
+     */
+    private $serverDistribution;
+
+    /**
      * Constructor.
      *
      * @param \Smile\ElasticsuiteCore\Api\Client\ClientInterface $client ElasticSearch client.

--- a/src/module-elasticsuite-core/Cluster/ClusterInfo.php
+++ b/src/module-elasticsuite-core/Cluster/ClusterInfo.php
@@ -56,4 +56,16 @@ class ClusterInfo implements ClusterInfoInterface
 
         return $this->serverVersion;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getServerDistribution()
+    {
+        if ($this->serverDistribution === null) {
+            $this->serverDistribution = $this->client->info()['version']['distribution'] ?? self::DISTRO_ES;
+        }
+
+        return $this->serverDistribution;
+    }
 }

--- a/src/module-elasticsuite-core/Plugin/Deprecation/Client/ClientPlugin.php
+++ b/src/module-elasticsuite-core/Plugin/Deprecation/Client/ClientPlugin.php
@@ -33,6 +33,11 @@ class ClientPlugin
     private $serverVersion;
 
     /**
+     * @var string
+     */
+    private $serverDistribution;
+
+    /**
      * @var \Smile\ElasticsuiteCore\Client\ClientBuilder
      */
     private $clientBuilder;
@@ -55,6 +60,7 @@ class ClientPlugin
         ClientBuilder $clientBuilder
     ) {
         $this->serverVersion       = $clusterInfo->getServerVersion();
+        $this->serverDistribution  = $clusterInfo->getServerDistribution();
         $this->clientBuilder       = $clientBuilder;
         $this->clientConfiguration = $clientConfiguration;
     }
@@ -73,7 +79,9 @@ class ClientPlugin
         $indexName,
         $mapping
     ) {
-        if (strcmp($this->serverVersion, "7") >= 0) {
+        if (strcmp($this->serverVersion, "7") >= 0
+            || $this->serverDistribution === ClusterInfoInterface::DISTRO_OS
+        ) {
             return $proceed($indexName, $mapping);
         }
 

--- a/src/module-elasticsuite-core/Plugin/Deprecation/Index/MappingPlugin.php
+++ b/src/module-elasticsuite-core/Plugin/Deprecation/Index/MappingPlugin.php
@@ -29,6 +29,11 @@ class MappingPlugin
     private $serverVersion;
 
     /**
+     * @var string
+     */
+    private $serverDistribution;
+
+    /**
      * Constructor.
      *
      * @param \Smile\ElasticsuiteCore\Api\Cluster\ClusterInfoInterface $clusterInfo Cluster information API.
@@ -36,6 +41,7 @@ class MappingPlugin
     public function __construct(\Smile\ElasticsuiteCore\Api\Cluster\ClusterInfoInterface $clusterInfo)
     {
         $this->serverVersion = $clusterInfo->getServerVersion();
+        $this->serverDistribution = $clusterInfo->getServerDistribution();
     }
 
     /**
@@ -50,7 +56,9 @@ class MappingPlugin
      */
     public function afterAsArray(MappingInterface $mapping, $result)
     {
-        if (strcmp($this->serverVersion, "6") < 0) {
+        if (strcmp($this->serverVersion, "6") < 0
+            && $this->serverDistribution == ClusterInfoInterface::DISTRO_ES
+        ) {
             $result['_all'] = ['enabled' => false];
         }
 


### PR DESCRIPTION
Adds checks to version comparison functions to support 1.x versioning for OpenSearch to help with 2.4.4 Compatibility - https://github.com/Smile-SA/elasticsuite/issues/2494

Follows some guidelines outlined here - https://github.com/opensearch-project/OpenSearch/issues/693

Checks for a distribution variable in version info returned by search service.