### PR TITLE
fallback to magento category product positions

### DIFF
--- a/src/module-elasticsuite-virtual-category/Model/ResourceModel/Product/Indexer/Fulltext/Datasource/CategoryData.php
+++ b/src/module-elasticsuite-virtual-category/Model/ResourceModel/Product/Indexer/Fulltext/Datasource/CategoryData.php
@@ -77,7 +77,7 @@ class CategoryData extends \Smile\ElasticsuiteCatalog\Model\ResourceModel\Produc
                 'product_id'     => 'cpi.product_id',
                 'is_parent'      => 'cpi.is_parent',
                 'is_virtual'     => new \Zend_Db_Expr('"false"'),
-                'position'       => 'p.position',
+                'position'       => 'COALESCE(p.position,cpi.position)',
                 'is_blacklisted' => 'p.is_blacklisted',
             ]);
 
@@ -112,7 +112,7 @@ class CategoryData extends \Smile\ElasticsuiteCatalog\Model\ResourceModel\Produc
                 'product_id'     => 'cpi.product_id',
                 'is_parent'      => 'cpi.is_parent',
                 'is_virtual'     => new \Zend_Db_Expr('"false"'),
-                'position'       => 'p.position',
+                'position'       => 'COALESCE(p.position,cpi.position)',
                 'is_blacklisted' => 'p.is_blacklisted',
             ]);
 
@@ -149,7 +149,7 @@ class CategoryData extends \Smile\ElasticsuiteCatalog\Model\ResourceModel\Produc
                     'product_id'     => 'p.product_id',
                     'is_parent'      => new \Zend_Db_Expr('0'),
                     'is_virtual'     => new \Zend_Db_Expr('"true"'),
-                    'position'       => 'p.position',
+                    'position'       => 'COALESCE(p.position,cpi.position)',
                     'is_blacklisted' => 'p.is_blacklisted',
                 ]
             );
@@ -187,7 +187,7 @@ class CategoryData extends \Smile\ElasticsuiteCatalog\Model\ResourceModel\Produc
                     'product_id'     => 'p.product_id',
                     'is_parent'      => new \Zend_Db_Expr('0'),
                     'is_virtual'     => new \Zend_Db_Expr('"true"'),
-                    'position'       => 'p.position',
+                    'position'       => 'COALESCE(p.position,cpi.position)',
                     'is_blacklisted' => 'p.is_blacklisted',
                 ]
             );


### PR DESCRIPTION
uses magento default product category position if non are set in elasticsuite table to respect position of migrations or imports