### PR TITLE
Fixed deprecation error in PHP 8.1

### DIFF
--- a/src/module-elasticsuite-virtual-category/Model/Url.php
+++ b/src/module-elasticsuite-virtual-category/Model/Url.php
@@ -208,7 +208,7 @@ class Url
      */
     public function getCategoryRewrite($categoryPath, $storeId)
     {
-        $categoryPath = str_replace($this->getCategoryUrlSuffix(), '', $categoryPath);
+        $categoryPath = str_replace($this->getCategoryUrlSuffix() ?? '', '', $categoryPath);
         $category = $this->loadCategoryByUrlKey($categoryPath);
         $rewrite  = null;
 


### PR DESCRIPTION
When no category URL suffix is defined, the get function returns NULL causing this error: Deprecated Functionality: str_replace(): Passing null to parameter #1 ($search) of type array|string is deprecated