### PR TITLE
Fix a deprecation warning (PHP 8.1 compatibility)

### DIFF
--- a/src/module-elasticsuite-catalog/Helper/AbstractAttribute.php
+++ b/src/module-elasticsuite-catalog/Helper/AbstractAttribute.php
@@ -246,7 +246,7 @@ abstract class AbstractAttribute extends Mapping
             $optionTextFieldName = $this->getOptionTextFieldName($attributeCode);
             $optionTextValues    = $this->getIndexOptionsText($attributeId, $storeId, $value);
             // Filter empty values. Not using array_filter here because it could remove "0" string from values.
-            $optionTextValues    = array_diff(array_map('trim', $optionTextValues), ['', null, false]);
+            $optionTextValues    = array_diff(array_map('trim', array_map('strval', $optionTextValues)), ['', null, false]);
             $optionTextValues    = array_values($optionTextValues);
             $values[$optionTextFieldName] = $optionTextValues;
         }


### PR DESCRIPTION
Sometimes one of the `$optionTextValues` could be `null`. And in PHP 8 `Passing null to parameter Smile-SA#1 ($string) of type string is deprecated`. So I suggest to explicitly cast all values to string.