### PR TITLE
Allow using values from config.xml

### DIFF
--- a/src/module-elasticsuite-analytics/etc/adminhtml/system.xml
+++ b/src/module-elasticsuite-analytics/etc/adminhtml/system.xml
@@ -23,7 +23,7 @@
 
             <group id="search_terms" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0">
                 <label>Search terms configuration</label>
-                <field id="max_size" translate="label comment" type="text" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="max_size" translate="label comment" type="text" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                     <label>Max search terms</label>
                     <validate>integer</validate>
                     <comment><![CDATA[Maximum number of search terms to display in the search usage report blocks.]]></comment>

--- a/src/module-elasticsuite-catalog/etc/adminhtml/system.xml
+++ b/src/module-elasticsuite-catalog/etc/adminhtml/system.xml
@@ -19,7 +19,7 @@
         <section id="smile_elasticsuite_autocomplete_settings">
             <group id="product_autocomplete" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Product Autocomplete</label>
-                <field id="max_size" translate="label comment" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="max_size" translate="label comment" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Max Size</label>
                     <validate>integer</validate>
                     <comment><![CDATA[Maximum number of products to display in autocomplete results.]]></comment>
@@ -27,7 +27,7 @@
             </group>
             <group id="product_attribute_autocomplete" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Product Attributes Autocomplete</label>
-                <field id="max_size" translate="label comment" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="max_size" translate="label comment" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Max Size</label>
                     <validate>integer</validate>
                     <comment><![CDATA[Maximum number of product attributes to display in autocomplete results.]]></comment>
@@ -35,7 +35,7 @@
             </group>
             <group id="category_autocomplete" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Category Autocomplete</label>
-                <field id="max_size" translate="label comment" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="max_size" translate="label comment" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Max Size</label>
                     <validate>integer</validate>
                     <comment><![CDATA[Maximum number of categories to display in autocomplete results.]]></comment>
@@ -50,27 +50,27 @@
 
             <group id="catalogsearch" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Catalog Search Configuration</label>
-                <field id="category_name_weight" translate="label comment" type="select" sortOrder="5" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="category_name_weight" translate="label comment" type="select" sortOrder="5" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                     <label>Category Name Weight</label>
                     <source_model>Magento\CatalogSearch\Model\Source\Weight</source_model>
                     <comment><![CDATA[The search weight of category names when used in fulltext search.]]></comment>
                 </field>
-                <field id="redirect_if_one_result" translate="label comment" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="redirect_if_one_result" translate="label comment" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Redirect to product page if only one result</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <comment><![CDATA[If there is only one product matching a given search query, the user will be redirect to this product page.]]></comment>
                 </field>
-                <field id="category_filter_use_url_rewrites" translate="label comment" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="category_filter_use_url_rewrites" translate="label comment" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Use URL Rewrites for Category Filter in category navigation</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <comment><![CDATA[When set to yes, users are redirected (and all filters are reset) to the chosen category page when they use the category filter in layered navigation.]]></comment>
                 </field>
-                <field id="expanded_facets" translate="label comment" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="expanded_facets" translate="label comment" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Expanded facets</label>
                     <validate>integer</validate>
                     <comment><![CDATA[Number of facets to display expanded by default.]]></comment>
                 </field>
-                <field id="adaptive_slider_enabled" translate="label" type="select" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="adaptive_slider_enabled" translate="label" type="select" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Enable adaptive slider</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <comment><![CDATA[If enabled, when necessary to support the presence of outlier values in the navigation context (for instance, a very high price amidst a majority of low prices), the price slider behavior changes so that the middle of the slider range corresponds to the median price instead of the price at the middle of the range.]]></comment>

--- a/src/module-elasticsuite-core/etc/adminhtml/system.xml
+++ b/src/module-elasticsuite-core/etc/adminhtml/system.xml
@@ -30,43 +30,43 @@
 
             <group id="es_client" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Elasticsearch Client</label>
-                <field id="servers" translate="label comment" type="text" sortOrder="51" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="servers" translate="label comment" type="text" sortOrder="51" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                     <label>Elasticsearch Servers List</label>
                     <comment>List of servers in [host]:[port] format separated by a comma (e.g. : "es-node1.fqdn:9200, es-node2.fqdn:9200")</comment>
                 </field>
-                <field id="enable_https_mode" translate="label comment" type="select" sortOrder="52" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="enable_https_mode" translate="label comment" type="select" sortOrder="52" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                     <label>Use HTTPS</label>
                     <comment>Select yes if you want to connect to your Elasticsearch server over HTTPS.</comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
-                <field id="enable_http_auth" translate="label comment" type="select" sortOrder="52" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="enable_http_auth" translate="label comment" type="select" sortOrder="52" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                     <label>Enable basic HTTP authentication</label>
                     <comment>Enable this option when your Elasticsearch server use basic HTTP authentication.</comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
-                <field id="enable_http_auth_encoding" translate="label comment" type="select" sortOrder="52" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="enable_http_auth_encoding" translate="label comment" type="select" sortOrder="52" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                     <label>Encode HTTP authorization headers</label>
                     <comment>Enable this option when you want to base64 encode the Authorization headers. (Open Distro requires this)</comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
-                <field id="http_auth_user" translate="label comment" type="text" sortOrder="53" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="http_auth_user" translate="label comment" type="text" sortOrder="53" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                     <label>Basic HTTP authentication user</label>
                     <depends>
                         <field id="enable_http_auth">1</field>
                     </depends>
                 </field>
-                <field id="http_auth_pwd" translate="label comment" type="text" sortOrder="54" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="http_auth_pwd" translate="label comment" type="text" sortOrder="54" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                     <label>Basic HTTP authentication password</label>
                     <depends>
                         <field id="enable_http_auth">1</field>
                     </depends>
                 </field>
-                <field id="enable_debug_mode" translate="label comment" type="select" sortOrder="55" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="enable_debug_mode" translate="label comment" type="select" sortOrder="55" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                     <label>Enable Debug Mode</label>
                     <comment>When enabled the module will produce logs through Magento logging system.</comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
-                <field id="connection_timeout" translate="label comment" type="text" sortOrder="56" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="connection_timeout" translate="label comment" type="text" sortOrder="56" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                     <label>Server Connection Timeout</label>
                     <comment>In seconds.</comment>
                     <frontend_class>validate-number</frontend_class>
@@ -75,17 +75,17 @@
 
             <group id="indices_settings" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Indices Settings</label>
-                <field id="alias" translate="label" type="text" sortOrder="57" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="alias" translate="label" type="text" sortOrder="57" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                     <label>Indices Alias Name</label>
                 </field>
-                <field id="indices_pattern" translate="label" type="text" sortOrder="58" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="indices_pattern" translate="label" type="text" sortOrder="58" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                     <label>Indices Name Pattern</label>
                 </field>
-                <field id="number_of_shards" translate="label" type="text" sortOrder="59" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="number_of_shards" translate="label" type="text" sortOrder="59" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                     <label>Number of Shards per Index</label>
                     <frontend_class>validate-number</frontend_class>
                 </field>
-                <field id="number_of_replicas" translate="label" type="text" sortOrder="60" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="number_of_replicas" translate="label" type="text" sortOrder="60" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                     <label>Number of Replicas per Index</label>
                     <frontend_class>validate-number</frontend_class>
                 </field>
@@ -100,7 +100,7 @@
 
             <group id="term_autocomplete" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Popular Term Autocomplete</label>
-                <field id="max_size" translate="label comment" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="max_size" translate="label comment" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Max Size</label>
                     <validate>integer</validate>
                     <comment><![CDATA[Maximum number of popular search terms to display in autocomplete results.]]></comment>
@@ -115,7 +115,7 @@
 
             <group id="footer_settings" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Footer Settings</label>
-                <field id="enable_es_link" translate="label comment" type="select" sortOrder="61" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="enable_es_link" translate="label comment" type="select" sortOrder="61" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                     <label>Display ElasticSuite link</label>
                     <comment>Select Yes if you want to display an ElasticSuite copyright link in the footer.</comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>

--- a/src/module-elasticsuite-indices/etc/adminhtml/system.xml
+++ b/src/module-elasticsuite-indices/etc/adminhtml/system.xml
@@ -22,7 +22,7 @@
             <resource>Magento_Backend::smile_elasticsuite_indices</resource>
             <group id="indices_mapping" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0">
                 <label>Indices Mapping</label>
-                <field id="mapping" translate="label" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="mapping" translate="label" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Mapping</label>
                     <frontend_model>Smile\ElasticsuiteIndices\Block\Adminhtml\Form\Field\Mapping</frontend_model>
                     <backend_model>Magento\Config\Model\Config\Backend\Serialized\ArraySerialized</backend_model>

--- a/src/module-elasticsuite-tracker/etc/adminhtml/system.xml
+++ b/src/module-elasticsuite-tracker/etc/adminhtml/system.xml
@@ -22,11 +22,11 @@
             <resource>Magento_Backend::smile_elasticsuite_tracker</resource>
             <group id="general" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="0">
                 <label>Global Configuration</label>
-                <field id="enabled" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="0">
+                <field id="enabled" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
                     <label>Enabled</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
-                <field id="retention_delay" translate="label comment" type="text" sortOrder="20" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="retention_delay" translate="label comment" type="text" sortOrder="20" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                     <label>Retention delay</label>
                     <validate>integer validate-greater-than-zero</validate>
                     <comment><![CDATA[In months (default is 12 months.).<br /> Tracking data older than this will be removed each day.]]></comment>
@@ -37,18 +37,18 @@
             </group>
             <group id="session" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="0" showInStore="0">
                 <label>Session Configuration</label>
-                <field id="visit_cookie_name" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="visit_cookie_name" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                     <label>Visit Cookie Name</label>
                 </field>
-                <field id="visit_cookie_lifetime" translate="label comment" type="text" sortOrder="20" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="visit_cookie_lifetime" translate="label comment" type="text" sortOrder="20" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                     <label>Visit Cookie Lifetime</label>
                     <validate>integer validate-greater-than-zero</validate>
                     <comment><![CDATA[In seconds. (Default is 3600 sec.)<br /> Without any activity under this delay we start a new visit.]]></comment>
                 </field>
-                <field id="visitor_cookie_name" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="visitor_cookie_name" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                     <label>Visitor Cookie Name</label>
                 </field>
-                <field id="visitor_cookie_lifetime" translate="label comment" type="text" sortOrder="40" showInDefault="1" showInWebsite="0" showInStore="0">
+                <field id="visitor_cookie_lifetime" translate="label comment" type="text" sortOrder="40" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                     <label>Visitor Cookie Lifetime</label>
                     <validate>integer validate-greater-than-zero</validate>
                     <comment><![CDATA[In days. (Default is 365 days.)<br /> This cookie will be stick to the customer to allow multiple session aggregation.]]></comment>
@@ -56,11 +56,11 @@
             </group>
             <group id="anonymization" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="0">
                 <label>Tracking Anonymization</label>
-                <field id="enabled" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="0">
+                <field id="enabled" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
                     <label>Anonymize customer data after a delay.</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
-                <field id="delay" translate="label comment" type="text" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="0">
+                <field id="delay" translate="label comment" type="text" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
                     <label>Anonymization Delay</label>
                     <validate>integer validate-greater-than-zero</validate>
                     <comment><![CDATA[In days. (Default is 365 days.)<br /> Tracked customer related data will be anonymized after this delay.]]></comment>
@@ -76,7 +76,7 @@
             <resource>Magento_Backend::smile_elasticsuite_telemetry</resource>
             <group id="telemetry" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="0">
                 <label>Telemetry</label>
-                <field id="enabled" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="0">
+                <field id="enabled" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
                     <label>Enable telemetry</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>


### PR DESCRIPTION
Many settings in this module lack a 'use system value' or 'use default value' check-boxes. There are suitable settings in `etc/config.xml` for these, but the same values are being set in the `core_config_data` table in the database unnecessarily, especially when changing only one value at a store view to also have all settings copied / overridden at that scope. This is misleading when later changing a value at a parent scope as the value at the more specific scope won't change too.

This pull request fixes this problem by allowing these values to be inherited normally.

https://devdocs.magento.com/guides/v2.4/config-guide/prod/config-reference-systemxml.html#field-attribute-reference