### PR TITLE
[BUGFIX][GWSM2-1070] Change categoryfilter back to filter behaviour i…

### DIFF
--- a/src/module-elasticsuite-catalog/Model/Layer/Filter/Category.php
+++ b/src/module-elasticsuite-catalog/Model/Layer/Filter/Category.php
@@ -216,6 +216,11 @@ class Category extends \Magento\CatalogSearch\Model\Layer\Filter\Category
      */
     protected function useUrlRewrites()
     {
+        /** If within search context, always make categories behave as filter */
+        if ($this->searchContext->getCurrentSearchQuery()) {
+            return false;
+        }
+        
         return $this->useUrlRewrites;
     }
 

--- a/src/module-elasticsuite-catalog/Model/Layer/Filter/Category.php
+++ b/src/module-elasticsuite-catalog/Model/Layer/Filter/Category.php
@@ -220,7 +220,7 @@ class Category extends \Magento\CatalogSearch\Model\Layer\Filter\Category
         if ($this->searchContext->getCurrentSearchQuery()) {
             return false;
         }
-        
+
         return $this->useUrlRewrites;
     }
 


### PR DESCRIPTION
…n searchcontext

Currently, when 'use URL rewrites' is on in the configuration, the category-filter behaves not as a filter, but as a hard link to the categories. This is expected - and wanted - behaviour within category context, but this behaviour does not make sense when searching.

After all, when searching, the user doesn't expect to get sent from the catalogsearch page to a categorypage when using the categoryfilter.

Another option would be to add this to the configuration ("Use URL Rewrites within Catalog Search"), but I don't think there's a good use-case for this.