### PR TITLE
[GraphQL] Translation support for category, price filter labels

### DIFF
--- a/src/module-elasticsuite-catalog-graph-ql/DataProvider/Product/LayeredNavigation/Builder/Category.php
+++ b/src/module-elasticsuite-catalog-graph-ql/DataProvider/Product/LayeredNavigation/Builder/Category.php
@@ -13,6 +13,7 @@
 
 namespace Smile\ElasticsuiteCatalogGraphQl\DataProvider\Product\LayeredNavigation\Builder;
 
+use Magento\Catalog\Model\Product\Attribute\Repository as AttributeRepository;
 use Magento\CatalogGraphQl\DataProvider\Category\Query\CategoryAttributeQuery;
 use Magento\CatalogGraphQl\DataProvider\CategoryAttributesMapper;
 use Magento\CatalogGraphQl\DataProvider\Product\LayeredNavigation\Formatter\LayerFormatter;
@@ -73,24 +74,40 @@ class Category implements LayerBuilderInterface
     private $layerFormatter;
 
     /**
+     * @var AttributeRepository
+     */
+    private $attributeRepository;
+
+    /**
+     * @var string
+     */
+    private $attributeCode;
+
+    /**
      * @param CategoryAttributeQuery   $categoryAttributeQuery   Category Attribute Query
      * @param CategoryAttributesMapper $categoryAttributesMapper Category Attributes Mapper
      * @param RootCategoryProvider     $rootCategoryProvider     Root Category Provider
      * @param LayerFormatter           $layerFormatter           Layer Formatter
      * @param ResourceConnection       $resourceConnection       Resource Connection
+     * @param AttributeRepository      $attributeRepository      Product attribute repository
+     * @param string                   $attributeCode            Product attribute code used to load the localized frontend label
      */
     public function __construct(
         CategoryAttributeQuery $categoryAttributeQuery,
         CategoryAttributesMapper $categoryAttributesMapper,
         RootCategoryProvider $rootCategoryProvider,
         LayerFormatter $layerFormatter,
-        ResourceConnection $resourceConnection
+        ResourceConnection $resourceConnection,
+        AttributeRepository $attributeRepository,
+        string $attributeCode = 'category_ids'
     ) {
         $this->categoryAttributeQuery = $categoryAttributeQuery;
         $this->attributesMapper       = $categoryAttributesMapper;
         $this->rootCategoryProvider   = $rootCategoryProvider;
         $this->layerFormatter         = $layerFormatter;
         $this->resourceConnection     = $resourceConnection;
+        $this->attributeRepository    = $attributeRepository;
+        $this->attributeCode          = $attributeCode;
     }
 
     /**
@@ -128,8 +145,12 @@ class Category implements LayerBuilderInterface
             return [];
         }
 
+        $label = __(self::$bucketMap[self::CATEGORY_BUCKET]['label']);
+        if ($frontendLabel = $this->getFrontendLabel($storeId)) {
+            $label = $frontendLabel;
+        }
         $result = $this->layerFormatter->buildLayer(
-            self::$bucketMap[self::CATEGORY_BUCKET]['label'],
+            $label,
             \count($categoryIds),
             self::$bucketMap[self::CATEGORY_BUCKET]['request_name']
         );
@@ -159,5 +180,35 @@ class Category implements LayerBuilderInterface
     private function isBucketEmpty(?BucketInterface $bucket): bool
     {
         return null === $bucket || !$bucket->getValues();
+    }
+
+    /**
+     * Return the frontend label of the configured attribute for the given store, if available.
+     *
+     * @param int|null $storeId Store ID.
+     *
+     * @return string|null
+     */
+    private function getFrontendLabel(?int $storeId): ?string
+    {
+        $label = null;
+
+        try {
+            $attribute  = $this->attributeRepository->get($this->attributeCode);
+            $label      = $attribute->getDefaultFrontendLabel();
+            $frontendLabels = array_filter(
+                $attribute->getFrontendLabels(),
+                function ($frontendLabel) use ($storeId) {
+                    return $frontendLabel->getStoreId() == $storeId;
+                }
+            );
+            if (!empty($frontendLabels)) {
+                $label = reset($frontendLabels)->getLabel();
+            }
+        } catch (\Magento\Framework\Exception\NoSuchEntityException $exception) {
+            ;
+        }
+
+        return $label;
     }
 }

--- a/src/module-elasticsuite-catalog-graph-ql/DataProvider/Product/LayeredNavigation/Builder/Price.php
+++ b/src/module-elasticsuite-catalog-graph-ql/DataProvider/Product/LayeredNavigation/Builder/Price.php
@@ -13,10 +13,12 @@
 
 namespace Smile\ElasticsuiteCatalogGraphQl\DataProvider\Product\LayeredNavigation\Builder;
 
+use Magento\Catalog\Model\Product\Attribute\Repository as AttributeRepository;
 use Magento\CatalogGraphQl\DataProvider\Product\LayeredNavigation\LayerBuilderInterface;
 use Magento\Framework\Api\Search\AggregationInterface;
 use Magento\Framework\Api\Search\BucketInterface;
 use Magento\CatalogGraphQl\DataProvider\Product\LayeredNavigation\Formatter\LayerFormatter;
+use Magento\Framework\Phrase;
 
 /**
  * Layered Navigation Builder for Price items.
@@ -38,6 +40,16 @@ class Price implements LayerBuilderInterface
     private $layerFormatter;
 
     /**
+     * @var AttributeRepository
+     */
+    private $attributeRepository;
+
+    /**
+     * @var string
+     */
+    private $attributeCode;
+
+    /**
      * @var array
      */
     private static $bucketMap = [
@@ -48,11 +60,18 @@ class Price implements LayerBuilderInterface
     ];
 
     /**
-     * @param LayerFormatter $layerFormatter Layer Formatter
+     * @param LayerFormatter      $layerFormatter      Layer Formatter
+     * @param AttributeRepository $attributeRepository Attribute Repository
+     * @param string              $attributeCode       Attribute code used to load the localized frontend label
      */
-    public function __construct(LayerFormatter $layerFormatter)
-    {
+    public function __construct(
+        LayerFormatter $layerFormatter,
+        AttributeRepository $attributeRepository,
+        string $attributeCode = 'price'
+    ) {
         $this->layerFormatter = $layerFormatter;
+        $this->attributeRepository = $attributeRepository;
+        $this->attributeCode = $attributeCode;
     }
 
     /**
@@ -66,8 +85,12 @@ class Price implements LayerBuilderInterface
             return [];
         }
 
+        $label = __(self::$bucketMap[self::PRICE_BUCKET]['label']);
+        if ($frontendLabel = $this->getFrontendLabel($storeId)) {
+            $label = $frontendLabel;
+        }
         $result = $this->layerFormatter->buildLayer(
-            self::$bucketMap[self::PRICE_BUCKET]['label'],
+            $label,
             \count($bucket->getValues()),
             self::$bucketMap[self::PRICE_BUCKET]['request_name']
         );
@@ -94,5 +117,35 @@ class Price implements LayerBuilderInterface
     private function isBucketEmpty(?BucketInterface $bucket): bool
     {
         return null === $bucket || !$bucket->getValues();
+    }
+
+    /**
+     * Return the frontend label of the configured attribute for the given store, if available.
+     *
+     * @param int|null $storeId Store ID.
+     *
+     * @return string|null
+     */
+    private function getFrontendLabel(?int $storeId): ?string
+    {
+        $label = null;
+
+        try {
+            $attribute  = $this->attributeRepository->get($this->attributeCode);
+            $label      = $attribute->getDefaultFrontendLabel();
+            $frontendLabels = array_filter(
+                $attribute->getFrontendLabels(),
+                function ($frontendLabel) use ($storeId) {
+                    return $frontendLabel->getStoreId() == $storeId;
+                }
+            );
+            if (!empty($frontendLabels)) {
+                $label = reset($frontendLabels)->getLabel();
+            }
+        } catch (\Magento\Framework\Exception\NoSuchEntityException $exception) {
+            ;
+        }
+
+        return $label;
     }
 }


### PR DESCRIPTION
Replaces PR #2146 considering that i18n+GraphQL+multiple store views of different locales seems to be a bit wonky.
New approach is to pull frontend labels of the `category_ids` and `price` product attributes so it does not require additional translation strings.
**But** it is also possible to fallback to the pure i18n approach by injecting through the DI empty strings as arguments  
```
    <type name="Smile\ElasticsuiteCatalogGraphQl\DataProvider\Product\LayeredNavigation\Builder\Category">
        <arguments>
            <argument name="attributeCode" xsi:type="string"></argument>
        </arguments>
    </type>

    <type name="Smile\ElasticsuiteCatalogGraphQl\DataProvider\Product\LayeredNavigation\Builder\Price">
        <arguments>
            <argument name="attributeCode" xsi:type="string"></argument>
        </arguments>
    </type>
```

PS: @romainruaud there is a bit of a copy/paste, I could probably centralize the code (which is also pretty close to the one used for the "Attribute" filter in a helper ...
