### PR TITLE
Fix for wrong type casting in Adminhtml of Special Price attribute

### DIFF
--- a/src/module-elasticsuite-catalog-rule/Model/Rule/Condition/Product.php
+++ b/src/module-elasticsuite-catalog-rule/Model/Rule/Condition/Product.php
@@ -168,7 +168,7 @@ class Product extends \Magento\Rule\Model\Condition\Product\AbstractProduct
                 $inputType = 'category';
             } elseif (in_array($frontendInput, ['select', 'multiselect'])) {
                 $inputType = 'multiselect';
-            } elseif (in_array($frontendClass, ['validate-digits', 'validate-number'])) {
+            } elseif (in_array($frontendClass, ['validate-digits', 'validate-number']) || $frontendInput === 'price') {
                 $inputType = 'numeric';
             } elseif ($frontendInput === 'date') {
                 $inputType = 'date';


### PR DESCRIPTION
Currently, only the 'price' attribute itself is seen as numeric (and those with input-validation). This means all other attributes put on the 'decimal'/'price' type are seen as a string instead of as a 'numeric'.

This adds an extra check on the frontendInput === 'price'