### PR TITLE
Add "IsSaleable" special attribute for optimizers

### DIFF
--- a/src/module-elasticsuite-catalog-rule/Model/Rule/Condition/Product/SpecialAttribute/IsSaleable.php
+++ b/src/module-elasticsuite-catalog-rule/Model/Rule/Condition/Product/SpecialAttribute/IsSaleable.php
@@ -13,39 +13,37 @@
  */
 namespace Smile\ElasticsuiteCatalogRule\Model\Rule\Condition\Product\SpecialAttribute;
 
-use Magento\Config\Model\Config\Source\Yesno;
+use Magento\Config\Model\Config\Source\Yesno\Magento\Config\Model\Config\Source\Yesno;
 use Smile\ElasticsuiteCatalogRule\Api\Rule\Condition\Product\SpecialAttributeInterface;
 use Smile\ElasticsuiteCatalogRule\Model\Rule\Condition\Product as ProductCondition;
 use Smile\ElasticsuiteCore\Search\Request\QueryInterface;
 use Smile\ElasticsuiteCore\Search\Request\Query\QueryFactory;
 
 /**
- * Special "is_in_stock" attribute class.
+ * Special "is_saleable" attribute class.
  *
  * @category Smile
  * @package  Smile\ElasticsuiteCatalogRule
- * @author   Romain Ruaud <romain.ruaud@smile.fr>
  */
-class IsInStock implements SpecialAttributeInterface
+class IsSaleable implements SpecialAttributeInterface
 {
     /**
      * @var Yesno
      */
     private $booleanSource;
+
     /**
      * @var QueryFactory
      */
     private QueryFactory $queryFactory;
 
     /**
-     * IsInStock constructor.
+     * IsSaleable constructor.
      *
      * @param Yesno $booleanSource Boolean Source
      */
-    public function __construct(
-        Yesno $booleanSource,
-        QueryFactory $queryFactory
-    )
+    public function __construct(Yesno $booleanSource,
+    QueryFactory $queryFactory)
     {
         $this->booleanSource = $booleanSource;
         $this->queryFactory   = $queryFactory;
@@ -56,7 +54,7 @@ class IsInStock implements SpecialAttributeInterface
      */
     public function getAttributeCode()
     {
-        return 'stock.is_in_stock';
+        return 'is_saleable';
     }
 
     /**
@@ -65,18 +63,8 @@ class IsInStock implements SpecialAttributeInterface
      */
     public function getSearchQuery(ProductCondition $condition)
     {
-        $queryParams = [];
-
-        $queryParams[] = $this->queryFactory->create(QueryInterface::TYPE_RANGE, [
-            'bounds' => ['gt' => (float) 0], 'field' => 'stock.qty'
-        ]);
-
-        $queryParams[] = $this->queryFactory->create(QueryInterface::TYPE_TERM, [
+        return $this->queryFactory->create(QueryInterface::TYPE_TERM, [
             'value' => true, 'field' => 'stock.is_in_stock'
-        ]);
-
-        return $this->queryFactory->create(QueryInterface::TYPE_BOOL, [
-            'must' => $queryParams
         ]);
     }
 
@@ -135,6 +123,6 @@ class IsInStock implements SpecialAttributeInterface
      */
     public function getLabel()
     {
-        return __('Only in stock products');
+        return __('Only saleable products');
     }
 }

--- a/src/module-elasticsuite-catalog-rule/Model/Rule/Condition/Product/SpecialAttribute/IsSaleable.php
+++ b/src/module-elasticsuite-catalog-rule/Model/Rule/Condition/Product/SpecialAttribute/IsSaleable.php
@@ -13,7 +13,7 @@
  */
 namespace Smile\ElasticsuiteCatalogRule\Model\Rule\Condition\Product\SpecialAttribute;
 
-use Magento\Config\Model\Config\Source\Yesno\Magento\Config\Model\Config\Source\Yesno;
+use Magento\Config\Model\Config\Source\Yesno;
 use Smile\ElasticsuiteCatalogRule\Api\Rule\Condition\Product\SpecialAttributeInterface;
 use Smile\ElasticsuiteCatalogRule\Model\Rule\Condition\Product as ProductCondition;
 use Smile\ElasticsuiteCore\Search\Request\QueryInterface;

--- a/src/module-elasticsuite-catalog-rule/Model/Rule/Condition/Product/SpecialAttribute/IsSaleable.php
+++ b/src/module-elasticsuite-catalog-rule/Model/Rule/Condition/Product/SpecialAttribute/IsSaleable.php
@@ -42,8 +42,10 @@ class IsSaleable implements SpecialAttributeInterface
      *
      * @param Yesno $booleanSource Boolean Source
      */
-    public function __construct(Yesno $booleanSource,
-    QueryFactory $queryFactory)
+    public function __construct(
+        Yesno $booleanSource,
+        QueryFactory $queryFactory
+    )
     {
         $this->booleanSource = $booleanSource;
         $this->queryFactory   = $queryFactory;

--- a/src/module-elasticsuite-catalog-rule/etc/di.xml
+++ b/src/module-elasticsuite-catalog-rule/etc/di.xml
@@ -22,6 +22,7 @@
         <arguments>
             <argument name="attributes" xsi:type="array">
                 <item name="has_image" xsi:type="object">Smile\ElasticsuiteCatalogRule\Model\Rule\Condition\Product\SpecialAttribute\HasImage</item>
+                <item name="is_saleable" xsi:type="object">Smile\ElasticsuiteCatalogRule\Model\Rule\Condition\Product\SpecialAttribute\IsSaleable</item>
                 <item name="stock.is_in_stock" xsi:type="object">Smile\ElasticsuiteCatalogRule\Model\Rule\Condition\Product\SpecialAttribute\IsInStock</item>
                 <item name="price.is_discount" xsi:type="object">Smile\ElasticsuiteCatalogRule\Model\Rule\Condition\Product\SpecialAttribute\IsDiscount</item>
                 <item name="is_bundle" xsi:type="object">isBundleProduct</item>

--- a/src/module-elasticsuite-catalog/etc/elasticsuite_indices.xml
+++ b/src/module-elasticsuite-catalog/etc/elasticsuite_indices.xml
@@ -40,6 +40,7 @@
                 <field name="children_ids" type="integer" />
                 <field name="configurable_attributes" type="keyword" />
                 <field name="indexed_attributes" type="keyword" />
+                <field name="is_saleable" type="integer" />
 
                 <!-- Static fields handled by the "prices" datasource -->
                 <field name="price.price" type="double" nestedPath="price" />


### PR DESCRIPTION
Resolves #2618 .

Currently if you use the "Only in stock products" rule in an optimizer when you have backorders enabled, you don't get the expected results.

To be able to backorder a product it needs to be set to "In Stock" even if the quantity is 0.

This means that products which are available to order but not physically in stock are currently prioritised in the optimizer and there is no way to prioritise ONLY product which are physically in stock and ready to ship.

This PR achieves two things:

* Modify `IsInStock` special attribute to return products which are both set to "In Stock" and have a `qty` greater than `0`.
* Add new `IsSaleable` special attribute which returns all "In Stock" products regardless of qty.