### PR TITLE
Fix calls to setRequestPath on rewrites that may not exist

### DIFF
--- a/src/module-elasticsuite-virtual-category/Model/Url.php
+++ b/src/module-elasticsuite-virtual-category/Model/Url.php
@@ -219,7 +219,9 @@ class Url
                 UrlRewrite::ENTITY_TYPE => 'category',
             ]);
 
-            $rewrite->setRequestPath($rewrite->getTargetPath());
+            if ($rewrite) {
+                $rewrite->setRequestPath($rewrite->getTargetPath());
+            }
         }
 
         return $rewrite;


### PR DESCRIPTION
Accessing a url that is same as url key for category that exists in
another store will return no rewrite in
`Smile\ElasticsuiteVirtualCategory\Model\Url::getCategoryRewrite`, therefore calling on setRequestPath results in critical error.

This commit checks if rewrite exists before calling setRequestPath.

Resolves #2623