### PR TITLE
Fixes #2687 Prevent laminas/laminas-mail upgrade

### DIFF
--- a/.github/workflows/20-integration.yml
+++ b/.github/workflows/20-integration.yml
@@ -206,7 +206,7 @@ jobs:
                 composer remove magento/module-configurable-sample-data-venia --no-update --no-interaction
                 composer remove magento/sample-data-media-venia --no-update --no-interaction
                 composer remove smile/elasticsuite --no-update --no-interaction
-                composer install --no-interaction --ignore-platform-reqs
+                composer update --no-interaction --ignore-platform-reqs magento/module-catalog-sample-data-venia magento/module-configurable-sample-data-venia magento/sample-data-media-venia smile/elasticsuite
                 composer config discard-changes false
 
             - name: "[Init] Install proper version of Magento through Composer"
@@ -287,7 +287,7 @@ jobs:
                   composer require magento/module-catalog-sample-data-venia:dev-master@dev --no-update --no-interaction --ignore-platform-reqs
                   composer require magento/module-configurable-sample-data-venia:dev-master@dev --no-update --no-interaction --ignore-platform-reqs
                   composer require magento/sample-data-media-venia:dev-master@dev --no-update --no-interaction --ignore-platform-reqs
-                  composer install --no-interaction --ignore-platform-reqs
+                  composer update --no-interaction --ignore-platform-reqs magento/module-catalog-sample-data-venia magento/module-configurable-sample-data-venia magento/sample-data-media-venia
                 fi
 
             - name: "[Test] Data : Require for Magento >=2.4.2"
@@ -301,7 +301,7 @@ jobs:
                   composer require magento/module-catalog-sample-data-venia --no-update --no-interaction --ignore-platform-reqs
                   composer require magento/module-configurable-sample-data-venia --no-update --no-interaction --ignore-platform-reqs
                   composer require magento/sample-data-media-venia --no-update --no-interaction --ignore-platform-reqs
-                  composer install --no-interaction --ignore-platform-reqs
+                  composer update --no-interaction --ignore-platform-reqs magento/module-catalog-sample-data-venia magento/module-configurable-sample-data-venia magento/sample-data-media-venia
                 fi
 
             - name: "[Init] Data : Prepare for Magento >= 2.4.4"


### PR DESCRIPTION
to 2.17.0 which no longer supports PHP 7.3 and PHP 7.4
by limiting the scope of composer update