### PR TITLE
Fixes to preview and sorting in admin if prices are with too many signs.

### DIFF
--- a/src/module-elasticsuite-catalog/view/adminhtml/web/css/source/_module.less
+++ b/src/module-elasticsuite-catalog/view/adminhtml/web/css/source/_module.less
@@ -93,12 +93,17 @@
                 clear: both;
             }
 
+            .info-wrapper {
+                position: absolute;
+                bottom: 0;
+            }
+
             .info {
                 position: relative;
                 background: rgba(44, 44, 44, 0.75);
-                margin-top: -51px;
                 color: #FFF;
                 padding: 4px;
+                overflow: hidden;
 
                 p {
                     display: inline-block;

--- a/src/module-elasticsuite-catalog/view/adminhtml/web/template/form/element/product-sorter.html
+++ b/src/module-elasticsuite-catalog/view/adminhtml/web/template/form/element/product-sorter.html
@@ -53,20 +53,22 @@
 
                     <div class="product-image"><img data-bind="attr: { src: getImageUrl() }" /></div>
 
-                    <div class="info">
-                        <h1><span data-bind="text: getName(), attr: {title: getName()}"></span></h1>
-                        <p class="sku" data-bind="text: getSku()"></p>
-                        <p class="price" data-bind="text: getFormattedPrice()"></p>
-                        <p class="stock" data-bind="text: getStockLabel()"></p>
-                    </div>
+                    <div class="info-wrapper">
+                        <div class="info">
+                            <h1><span data-bind="text: getName(), attr: {title: getName()}"></span></h1>
+                            <p class="sku" data-bind="text: getSku()"></p>
+                            <p class="price" data-bind="text: getFormattedPrice()"></p>
+                            <p class="stock" data-bind="text: getStockLabel()"></p>
+                        </div>
 
-                    <div class="admin__actions-switch" data-role="switcher" data-bind="click: $parent.toggleSortType.bind($parent)">
-                        <input type="checkbox" class="admin__actions-switch-checkbox" simple-checked="hasPosition()" ko-value="hasPosition()" />
-                        <label class="admin__actions-switch-label">
-                            <span class="admin__actions-switch-text"
-                                  attr="'data-text-on': $parent.messages.manualSort, 'data-text-off': $parent.messages.automaticSort">
-                              </span>
-                        </label>
+                        <div class="admin__actions-switch" data-role="switcher" data-bind="click: $parent.toggleSortType.bind($parent)">
+                            <input type="checkbox" class="admin__actions-switch-checkbox" simple-checked="hasPosition()" ko-value="hasPosition()" />
+                            <label class="admin__actions-switch-label">
+                                <span class="admin__actions-switch-text"
+                                      attr="'data-text-on': $parent.messages.manualSort, 'data-text-off': $parent.messages.automaticSort">
+                                  </span>
+                            </label>
+                        </div>
                     </div>
                 </li>
             </ul>


### PR DESCRIPTION
Description:
When prices are with more than 6 signs and/or products are out of stock (or depends on language with long label) info box growing and break layout.

Actual Results:
![image](https://user-images.githubusercontent.com/1854269/186386020-2c273df4-1d24-4ef9-ba11-839cabd04540.png)

Expected Results:
![image](https://user-images.githubusercontent.com/1854269/186386394-1e5fff3f-467a-42d5-8de0-5b649bb63392.png)
