### PR TITLE
Allow for Configuring Number of Request Retries to Perform

### DIFF
--- a/src/module-elasticsuite-core/Api/Client/ClientConfigurationInterface.php
+++ b/src/module-elasticsuite-core/Api/Client/ClientConfigurationInterface.php
@@ -87,11 +87,11 @@ interface ClientConfigurationInterface
     public function getMaxParallelHandles();
 
     /**
-     * Get the number of HTTP curl request retries the client will make
+     * Get the maximum number of HTTP curl request retries the client will make
      *
      * @return int
      */
-    public function getRetries();
+    public function getMaxRetries();
 
     /**
      * Client config options.

--- a/src/module-elasticsuite-core/Api/Client/ClientConfigurationInterface.php
+++ b/src/module-elasticsuite-core/Api/Client/ClientConfigurationInterface.php
@@ -87,6 +87,13 @@ interface ClientConfigurationInterface
     public function getMaxParallelHandles();
 
     /**
+     * Get the number of HTTP curl request retries the client will make
+     *
+     * @return int
+     */
+    public function getRetries();
+
+    /**
      * Client config options.
      *
      * @return array

--- a/src/module-elasticsuite-core/Client/ClientBuilder.php
+++ b/src/module-elasticsuite-core/Client/ClientBuilder.php
@@ -46,7 +46,7 @@ class ClientBuilder
         'http_auth_encoded'     => false,
         'is_debug_mode_enabled' => false,
         'max_parallel_handles'  => 100, // As per default Elasticsearch Handler configuration.
-        'retries'               => 2,
+        'max_retries'           => 2,
     ];
 
     /**
@@ -103,20 +103,21 @@ class ClientBuilder
             $clientBuilder->setHandler($handler);
         }
 
-        if (!empty($options['http_auth_user']) && !empty($options['http_auth_pwd']) && $options['http_auth_encoded']) {
-            $authHeader = 'Basic ' . base64_encode($options['http_auth_user'] . ':' . $options['http_auth_pwd']);
-            $clientBuilder->setConnectionParams(['client' => ['headers' => ['Authorization' => [$authHeader]]]]);
+        $connectionParams = $this->getConnectionParams($options);
+
+        if (!empty($connectionParams)) {
+            $this->clientBuilder->setConnectionParams($connectionParams);
         }
 
-        if (intval($options['num_retries']) > 0) {
-            $clientBuilder->setRetries($options['retries']);
+        if ($options['max_retries'] > 0) {
+            $clientBuilder->setRetries((int) $options['max_retries']);
         }
 
         if (null !== $this->selector) {
-            $selector = $this->selector;
-            if (count($hosts) <= 1) {
-                $selector = StickyRoundRobinSelector::class;
-            }
+            $selector = (count($hosts) > 1)
+                ? $this->selector
+                : StickyRoundRobinSelector::class;
+
             $clientBuilder->setSelector($selector);
         }
 
@@ -157,5 +158,28 @@ class ClientBuilder
         }
 
         return $hosts;
+    }
+
+    /**
+     * Return HTTP Authentication parameters used to connect to the cluster if any
+     *
+     * @param $options
+     * @return array|array[]
+     */
+    private function getConnectionParams($options)
+    {
+        return (
+            !empty($options['http_auth_user']) &&
+            !empty($options['http_auth_pwd']) &&
+            $options['http_auth_encoded']
+        ) ? [
+            'client' => [
+                'headers' => [
+                    'Authorization' => [
+                        'Basic ' . base64_encode($options['http_auth_user'] . ':' . $options['http_auth_pwd']),
+                    ],
+                ],
+            ],
+        ] : [];
     }
 }

--- a/src/module-elasticsuite-core/Client/ClientBuilder.php
+++ b/src/module-elasticsuite-core/Client/ClientBuilder.php
@@ -46,6 +46,7 @@ class ClientBuilder
         'http_auth_encoded'     => false,
         'is_debug_mode_enabled' => false,
         'max_parallel_handles'  => 100, // As per default Elasticsearch Handler configuration.
+        'retries'               => 2,
     ];
 
     /**
@@ -105,6 +106,10 @@ class ClientBuilder
         if (!empty($options['http_auth_user']) && !empty($options['http_auth_pwd']) && $options['http_auth_encoded']) {
             $authHeader = 'Basic ' . base64_encode($options['http_auth_user'] . ':' . $options['http_auth_pwd']);
             $clientBuilder->setConnectionParams(['client' => ['headers' => ['Authorization' => [$authHeader]]]]);
+        }
+
+        if (!empty($options['retries']) && is_int($options['retries']) && $options['retries'] > 0) {
+            $clientBuilder->setRetries($options['retries']);
         }
 
         if (null !== $this->selector) {

--- a/src/module-elasticsuite-core/Client/ClientBuilder.php
+++ b/src/module-elasticsuite-core/Client/ClientBuilder.php
@@ -108,7 +108,7 @@ class ClientBuilder
             $clientBuilder->setConnectionParams(['client' => ['headers' => ['Authorization' => [$authHeader]]]]);
         }
 
-        if (!empty($options['retries']) && is_int($options['retries']) && $options['retries'] > 0) {
+        if (intval($options['num_retries']) > 0) {
             $clientBuilder->setRetries($options['retries']);
         }
 

--- a/src/module-elasticsuite-core/Client/ClientBuilder.php
+++ b/src/module-elasticsuite-core/Client/ClientBuilder.php
@@ -114,10 +114,7 @@ class ClientBuilder
         }
 
         if (null !== $this->selector) {
-            $selector = (count($hosts) > 1)
-                ? $this->selector
-                : StickyRoundRobinSelector::class;
-
+            $selector = (count($hosts) > 1) ? $this->selector : StickyRoundRobinSelector::class;
             $clientBuilder->setSelector($selector);
         }
 
@@ -163,8 +160,8 @@ class ClientBuilder
     /**
      * Return HTTP Authentication parameters used to connect to the cluster if any
      *
-     * @param $options
-     * @return array|array[]
+     * @param array $options Client options. See self::defaultOptions for available options.
+     * @return array
      */
     private function getConnectionParams($options)
     {

--- a/src/module-elasticsuite-core/Client/ClientConfiguration.php
+++ b/src/module-elasticsuite-core/Client/ClientConfiguration.php
@@ -125,9 +125,9 @@ class ClientConfiguration implements ClientConfigurationInterface
     /**
      * {@inheritdoc}
      */
-    public function getRetries()
+    public function getMaxRetries()
     {
-        return (int) $this->getElasticsearchClientConfigParam('retries');
+        return (int) $this->getElasticsearchClientConfigParam('max_retries');
     }
 
     /**
@@ -144,7 +144,7 @@ class ClientConfiguration implements ClientConfigurationInterface
             'http_auth_pwd'         => $this->getHttpAuthPassword(),
             'is_debug_mode_enabled' => $this->isDebugModeEnabled(),
             'max_parallel_handles'  => $this->getMaxParallelHandles(),
-            'retries'               => $this->getRetries(),
+            'max_retries'           => $this->getMaxRetries(),
         ];
 
         return $options;

--- a/src/module-elasticsuite-core/Client/ClientConfiguration.php
+++ b/src/module-elasticsuite-core/Client/ClientConfiguration.php
@@ -123,6 +123,14 @@ class ClientConfiguration implements ClientConfigurationInterface
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function getRetries()
+    {
+        return (int) $this->getElasticsearchClientConfigParam('retries');
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function getOptions()
@@ -136,6 +144,7 @@ class ClientConfiguration implements ClientConfigurationInterface
             'http_auth_pwd'         => $this->getHttpAuthPassword(),
             'is_debug_mode_enabled' => $this->isDebugModeEnabled(),
             'max_parallel_handles'  => $this->getMaxParallelHandles(),
+            'retries'               => $this->getRetries(),
         ];
 
         return $options;

--- a/src/module-elasticsuite-core/etc/adminhtml/system.xml
+++ b/src/module-elasticsuite-core/etc/adminhtml/system.xml
@@ -71,9 +71,9 @@
                     <comment>In seconds.</comment>
                     <frontend_class>validate-number</frontend_class>
                 </field>
-                <field id="retries" translate="label comment" type="text" sortOrder="56" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
-                    <label>Elasticsearch Client Number of Retries</label>
-                    <comment>Number of times to retry connection when there is a connection failure</comment>
+                <field id="max_retries" translate="label comment" type="text" sortOrder="56" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
+                    <label>Elasticsearch Client Maximum Number of Retries</label>
+                    <comment>Maximum number of times to retry connection when there is a connection failure</comment>
                     <frontend_class>validate-number</frontend_class>
                 </field>
             </group>

--- a/src/module-elasticsuite-core/etc/adminhtml/system.xml
+++ b/src/module-elasticsuite-core/etc/adminhtml/system.xml
@@ -71,6 +71,11 @@
                     <comment>In seconds.</comment>
                     <frontend_class>validate-number</frontend_class>
                 </field>
+                <field id="retries" translate="label comment" type="text" sortOrder="56" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
+                    <label>Elasticsearch Client Number of Retries</label>
+                    <comment>Number of times to retry connection when there is a connection failure</comment>
+                    <frontend_class>validate-number</frontend_class>
+                </field>
             </group>
 
             <group id="indices_settings" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">

--- a/src/module-elasticsuite-core/etc/config.xml
+++ b/src/module-elasticsuite-core/etc/config.xml
@@ -24,6 +24,7 @@
                 <connection_timeout>1</connection_timeout>
                 <timeout>30</timeout>
                 <max_parallel_handles>10</max_parallel_handles>
+                <retries>2</retries>
             </es_client>
             <indices_settings>
                 <alias>magento2</alias>

--- a/src/module-elasticsuite-core/etc/config.xml
+++ b/src/module-elasticsuite-core/etc/config.xml
@@ -24,7 +24,7 @@
                 <connection_timeout>1</connection_timeout>
                 <timeout>30</timeout>
                 <max_parallel_handles>10</max_parallel_handles>
-                <retries>2</retries>
+                <max_retries>2</max_retries>
             </es_client>
             <indices_settings>
                 <alias>magento2</alias>


### PR DESCRIPTION
Allow the configuration of the elasticsearch client to set how many times Curl should retry requests before failing