### PR TITLE
Add the option to configure the maximum number of request retries for the elasticsearch client

### DIFF
--- a/src/module-elasticsuite-core/Api/Client/ClientConfigurationInterface.php
+++ b/src/module-elasticsuite-core/Api/Client/ClientConfigurationInterface.php
@@ -87,6 +87,13 @@ interface ClientConfigurationInterface
     public function getMaxParallelHandles();
 
     /**
+     * Get the maximum number of HTTP curl request retries the client will make
+     *
+     * @return int
+     */
+    public function getMaxRetries();
+
+    /**
      * Client config options.
      *
      * @return array

--- a/src/module-elasticsuite-core/Client/ClientConfiguration.php
+++ b/src/module-elasticsuite-core/Client/ClientConfiguration.php
@@ -123,6 +123,14 @@ class ClientConfiguration implements ClientConfigurationInterface
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function getMaxRetries()
+    {
+        return (int) $this->getElasticsearchClientConfigParam('max_retries');
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function getOptions()
@@ -136,6 +144,7 @@ class ClientConfiguration implements ClientConfigurationInterface
             'http_auth_pwd'         => $this->getHttpAuthPassword(),
             'is_debug_mode_enabled' => $this->isDebugModeEnabled(),
             'max_parallel_handles'  => $this->getMaxParallelHandles(),
+            'max_retries'           => $this->getMaxRetries(),
         ];
 
         return $options;

--- a/src/module-elasticsuite-core/etc/adminhtml/system.xml
+++ b/src/module-elasticsuite-core/etc/adminhtml/system.xml
@@ -71,6 +71,11 @@
                     <comment>In seconds.</comment>
                     <frontend_class>validate-number</frontend_class>
                 </field>
+                <field id="max_retries" translate="label comment" type="text" sortOrder="56" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
+                    <label>Elasticsearch Client Maximum Number of Retries</label>
+                    <comment>Maximum number of times to retry connection when there is a connection failure</comment>
+                    <frontend_class>validate-number</frontend_class>
+                </field>
             </group>
 
             <group id="indices_settings" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">

--- a/src/module-elasticsuite-core/etc/config.xml
+++ b/src/module-elasticsuite-core/etc/config.xml
@@ -24,6 +24,7 @@
                 <connection_timeout>1</connection_timeout>
                 <timeout>30</timeout>
                 <max_parallel_handles>10</max_parallel_handles>
+                <max_retries>2</max_retries>
             </es_client>
             <indices_settings>
                 <alias>magento2</alias>


### PR DESCRIPTION
Allow for the core client configuration to include configuring the maximum number of retries for requests - this is particularly useful for indexing purposes