### PR TITLE
Replace deprecated .bind method with .on (jQuery)

### DIFF
--- a/src/module-elasticsuite-catalog/view/frontend/web/js/range-slider-widget.js
+++ b/src/module-elasticsuite-catalog/view/frontend/web/js/range-slider-widget.js
@@ -53,7 +53,7 @@ define([
 
             this._createSlider();
             this._refreshDisplay();
-            this.element.find(this.options.applyButton).bind('click', this._applyRange.bind(this));
+            this.element.find(this.options.applyButton).on('click', this._applyRange.bind(this));
         },
 
         _initSliderValues: function () {


### PR DESCRIPTION
I'm working on [breezefront integration](https://github.com/breezefront/module-breeze-smile-elasticsuite) and trying to reuse your js files. This file will be fully compatible with breeze with this tiny change.

Here is the bind documentation: https://api.jquery.com/bind/

Thanks!