### PR TITLE
Use 2x image size to prevent blurry images in search dropdown

### DIFF
--- a/src/module-elasticsuite-catalog/etc/view.xml
+++ b/src/module-elasticsuite-catalog/etc/view.xml
@@ -19,8 +19,8 @@
     <media>
         <images module="Magento_Catalog">
             <image id="smile_elasticsuite_autocomplete_product_image" type="thumbnail">
-                <width>45</width>
-                <height>45</height>
+                <width>90</width>
+                <height>90</height>
             </image>
             <image id="smile_elasticsuite_product_sorter_image" type="small_image">
                 <width>150</width>


### PR DESCRIPTION
This PR fixes blurry images on HiDPI screens.

Here is the screenshot before/after:

<img src="https://user-images.githubusercontent.com/306080/212837738-49a722a2-513c-4264-84d7-952a769bb72e.png" width="532" />
