### PR TITLE
Fixes #2829 Only set applied category if one is available

### DIFF
--- a/src/module-elasticsuite-virtual-category/Controller/Router.php
+++ b/src/module-elasticsuite-virtual-category/Controller/Router.php
@@ -93,7 +93,7 @@ class Router implements RouterInterface
     public function match(RequestInterface $request): ?ActionInterface
     {
         $condition = new DataObject([
-            'identifier' => trim($request->getPathInfo(), '/')
+            'identifier' => trim($request->getPathInfo(), '/'),
         ]);
 
         $this->eventManager->dispatch(

--- a/src/module-elasticsuite-virtual-category/Controller/Router.php
+++ b/src/module-elasticsuite-virtual-category/Controller/Router.php
@@ -92,13 +92,16 @@ class Router implements RouterInterface
      */
     public function match(RequestInterface $request): ?ActionInterface
     {
-        $identifier = trim($request->getPathInfo(), '/');
-        $condition = new DataObject(['identifier' => $identifier]);
+        $condition = new DataObject([
+            'identifier' => trim($request->getPathInfo(), '/')
+        ]);
+
         $this->eventManager->dispatch(
             'smile_elasticsuite_virtualcategory_controller_router_match_before',
             ['router' => $this, 'condition' => $condition]
         );
 
+        $identifier = $condition->getIdentifier();
         $appliedRoot = $this->getAppliedVirtualCategoryRoot($identifier);
         if (!$appliedRoot || !$appliedRoot->getId()) {
             $this->virtualCategoryRoot->setAppliedRootCategory($appliedRoot);

--- a/src/module-elasticsuite-virtual-category/Controller/Router.php
+++ b/src/module-elasticsuite-virtual-category/Controller/Router.php
@@ -102,7 +102,9 @@ class Router implements RouterInterface
         );
 
         $appliedRoot = $this->getAppliedVirtualCategoryRoot($identifier);
-        $this->virtualCategoryRoot->setAppliedRootCategory($appliedRoot);
+        if (!$appliedRoot || !$appliedRoot->getId()) {
+            $this->virtualCategoryRoot->setAppliedRootCategory($appliedRoot);
+        }
 
         $productRewrite = $this->getProductRewrite($identifier);
         if ($productRewrite) {
@@ -110,10 +112,6 @@ class Router implements RouterInterface
             $request->setPathInfo('/' . $productRewrite->getTargetPath());
 
             return $this->actionFactory->create('Magento\Framework\App\Action\Forward');
-        }
-
-        if (!$appliedRoot || !$appliedRoot->getId()) {
-            return null;
         }
 
         $categoryRewrite = $this->getCategoryRewrite($identifier);

--- a/src/module-elasticsuite-virtual-category/Controller/Router.php
+++ b/src/module-elasticsuite-virtual-category/Controller/Router.php
@@ -103,7 +103,7 @@ class Router implements RouterInterface
 
         $identifier = $condition->getIdentifier();
         $appliedRoot = $this->getAppliedVirtualCategoryRoot($identifier);
-        if (!$appliedRoot || !$appliedRoot->getId()) {
+        if ($appliedRoot && $appliedRoot->getId()) {
             $this->virtualCategoryRoot->setAppliedRootCategory($appliedRoot);
         }
 

--- a/src/module-elasticsuite-virtual-category/Controller/Router.php
+++ b/src/module-elasticsuite-virtual-category/Controller/Router.php
@@ -96,13 +96,12 @@ class Router implements RouterInterface
 
         $identifier = trim($request->getPathInfo(), '/');
         $condition = new DataObject(['identifier' => $identifier]);
-        $appliedRoot = $this->getAppliedVirtualCategoryRoot($identifier);
-
         $this->eventManager->dispatch(
             'smile_elasticsuite_virtualcategory_controller_router_match_before',
             ['router' => $this, 'condition' => $condition]
         );
 
+        $appliedRoot = $this->getAppliedVirtualCategoryRoot($identifier);
         $this->virtualCategoryRoot->setAppliedRootCategory($appliedRoot);
 
         $productRewrite = $this->getProductRewrite($identifier);

--- a/src/module-elasticsuite-virtual-category/Controller/Router.php
+++ b/src/module-elasticsuite-virtual-category/Controller/Router.php
@@ -92,8 +92,6 @@ class Router implements RouterInterface
      */
     public function match(RequestInterface $request): ?ActionInterface
     {
-        $action = null;
-
         $identifier = trim($request->getPathInfo(), '/');
         $condition = new DataObject(['identifier' => $identifier]);
         $this->eventManager->dispatch(
@@ -122,7 +120,7 @@ class Router implements RouterInterface
             return $this->actionFactory->create('Magento\Framework\App\Action\Forward');
         }
 
-        return $action;
+        return null;
     }
 
     /**


### PR DESCRIPTION
Made two changes to the router matcher.

1. Only set the applied category if one is available
2. Make use of the identifier passed in the `smile_elasticsuite_virtualcategory_controller_router_match_before` event, otherwise I see no point in dispatching this event since the data is never used. Also moved this logic before fetching the applied category

This PR fixes #2829