### PR TITLE
Prevent adding null queryFilters on ProductsListPlugin

### DIFF
--- a/src/module-elasticsuite-virtual-category/Plugin/Widget/ProductsListPlugin.php
+++ b/src/module-elasticsuite-virtual-category/Plugin/Widget/ProductsListPlugin.php
@@ -161,7 +161,10 @@ class ProductsListPlugin
                             foreach ($categoryIds as $categoryId) {
                                 try {
                                     $category = $this->categoryRepository->get($categoryId, $storeId);
-                                    $filterQueries[] = $this->filterProvider->getQueryFilter($category);
+                                    $queryFilter = $this->filterProvider->getQueryFilter($category);
+                                    if ($queryFilter !== null) {
+                                        $filterQueries[] = $queryFilter;
+                                    }
                                 } catch (NoSuchEntityException $exception) {
                                     continue;
                                 }


### PR DESCRIPTION
## Description
Fixes a bug where null queryFilters get added to collection. Building such query will fail:

```
Argument 1 passed to Smile\ElasticsuiteCore\Search\Adapter\Elasticsuite\Request\Query\Builder::buildQuery() must implement interface Smile\ElasticsuiteCore\Search\Request\QueryInterface, null given
```

## How to reproduce
1. Add Products content with PageBuilder
2. Create a condition "category" is one of 
3. Select a category which is not active
4. Save the content

### Expected result 
Product grid or carousel should load. I guess wisest would be to keep the current collection as it is without adding null filters.

### Actual result
PageBuilder outputs "An unknown error occurred. Please try again". Exception prevents storefront page from loading. 