### PR TITLE
Fix issue #2853 - Add additional logic to map parent and child ids.

### DIFF
--- a/src/module-elasticsuite-catalog/Model/Product/Indexer/Fulltext/Datasource/PriceData.php
+++ b/src/module-elasticsuite-catalog/Model/Product/Indexer/Fulltext/Datasource/PriceData.php
@@ -107,18 +107,19 @@ class PriceData implements DatasourceInterface
 
             $isDiscount    = $price < $originalPrice;
 
-            if ($this->isComputeChildDiscountEnabled()) {
-                if (in_array($productTypeId, $this->attributeResourceModel->getCompositeTypes())) {
-                    $isDiscount    = false;
-                    $priceModifier = $this->getPriceDataReader('default');
-                    foreach ($childPriceData as $childPrice) {
-                        foreach ($allChildrenIds[$childPrice['entity_id']] as $childIdsData) {
-                            if ($childIdsData['parent_id'] === $productId
-                                && $childPrice['customer_group_id'] == $priceDataRow['customer_group_id']
-                                && $priceModifier->getPrice($childPrice) < $priceModifier->getOriginalPrice($childPrice)) {
-                                $isDiscount = true;
-                                break 2;
-                            }
+            if ($this->isComputeChildDiscountEnabled() &&
+                in_array($productTypeId, $this->attributeResourceModel->getCompositeTypes())
+            ) {
+                $isDiscount = false;
+                $priceModifier = $this->getPriceDataReader('default');
+                foreach ($childPriceData as $childPrice) {
+                    foreach ($allChildrenIds[$childPrice['entity_id']] as $childIdsData) {
+                        if ($childIdsData['parent_id'] === $productId
+                            && $childPrice['customer_group_id'] == $priceDataRow['customer_group_id']
+                            && $priceModifier->getPrice($childPrice) < $priceModifier->getOriginalPrice($childPrice)
+                        ) {
+                            $isDiscount = true;
+                            break 2;
                         }
                     }
                 }

--- a/src/module-elasticsuite-catalog/Model/Product/Indexer/Fulltext/Datasource/PriceData.php
+++ b/src/module-elasticsuite-catalog/Model/Product/Indexer/Fulltext/Datasource/PriceData.php
@@ -116,8 +116,8 @@ class PriceData implements DatasourceInterface
                             if ($childIdsData['parent_id'] === $productId &&
                                 $childPrice['customer_group_id'] == $priceDataRow['customer_group_id']
                             ) {
-                                if ($priceModifier->getPrice($childPrice) <
-                                    $priceModifier->getOriginalPrice($childPrice)) {
+                                if ($priceModifier->getPrice($childPrice)
+                                     < $priceModifier->getOriginalPrice($childPrice)) {
                                     $isDiscount = true;
                                     break;
                                 }

--- a/src/module-elasticsuite-catalog/Model/Product/Indexer/Fulltext/Datasource/PriceData.php
+++ b/src/module-elasticsuite-catalog/Model/Product/Indexer/Fulltext/Datasource/PriceData.php
@@ -17,9 +17,9 @@ namespace Smile\ElasticsuiteCatalog\Model\Product\Indexer\Fulltext\Datasource;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\ObjectManager;
 use Magento\Store\Model\ScopeInterface;
-use Smile\ElasticsuiteCore\Api\Index\DatasourceInterface;
-use Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Indexer\Fulltext\Datasource\PriceData as ResourceModel;
 use Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Indexer\Fulltext\Datasource\AttributeData as AttributeResourceModel;
+use Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Indexer\Fulltext\Datasource\PriceData as ResourceModel;
+use Smile\ElasticsuiteCore\Api\Index\DatasourceInterface;
 
 /**
  * Datasource used to append prices data to product during indexing.
@@ -113,13 +113,11 @@ class PriceData implements DatasourceInterface
                     $priceModifier = $this->getPriceDataReader('default');
                     foreach ($childPriceData as $childPrice) {
                         foreach ($allChildrenIds[$childPrice['entity_id']] as $childIdsData) {
-                            if ($childIdsData['parent_id'] === $productId &&
-                                $childPrice['customer_group_id'] == $priceDataRow['customer_group_id']
-                            ) {
-                                if ($priceModifier->getPrice($childPrice) < $priceModifier->getOriginalPrice($childPrice)) {
-                                    $isDiscount = true;
-                                    break 2;
-                                }
+                            if ($childIdsData['parent_id'] === $productId
+                                && $childPrice['customer_group_id'] == $priceDataRow['customer_group_id']
+                                && $priceModifier->getPrice($childPrice) < $priceModifier->getOriginalPrice($childPrice)) {
+                                $isDiscount = true;
+                                break 2;
                             }
                         }
                     }

--- a/src/module-elasticsuite-catalog/Model/Product/Indexer/Fulltext/Datasource/PriceData.php
+++ b/src/module-elasticsuite-catalog/Model/Product/Indexer/Fulltext/Datasource/PriceData.php
@@ -116,10 +116,9 @@ class PriceData implements DatasourceInterface
                             if ($childIdsData['parent_id'] === $productId &&
                                 $childPrice['customer_group_id'] == $priceDataRow['customer_group_id']
                             ) {
-                                if ($priceModifier->getPrice($childPrice)
-                                     < $priceModifier->getOriginalPrice($childPrice)) {
+                                if ($priceModifier->getPrice($childPrice) < $priceModifier->getOriginalPrice($childPrice)) {
                                     $isDiscount = true;
-                                    break;
+                                    break 2;
                                 }
                             }
                         }

--- a/src/module-elasticsuite-catalog/Model/Product/Indexer/Fulltext/Datasource/PriceData.php
+++ b/src/module-elasticsuite-catalog/Model/Product/Indexer/Fulltext/Datasource/PriceData.php
@@ -112,10 +112,15 @@ class PriceData implements DatasourceInterface
                     $isDiscount    = false;
                     $priceModifier = $this->getPriceDataReader('default');
                     foreach ($childPriceData as $childPrice) {
-                        if ($childPrice['customer_group_id'] == $priceDataRow['customer_group_id']) {
-                            if ($priceModifier->getPrice($childPrice) < $priceModifier->getOriginalPrice($childPrice)) {
-                                $isDiscount = true;
-                                break;
+                        foreach ($allChildrenIds[$childPrice['entity_id']] as $childIdsData) {
+                            if ($childIdsData['parent_id'] === $productId &&
+                                $childPrice['customer_group_id'] == $priceDataRow['customer_group_id']
+                            ) {
+                                if ($priceModifier->getPrice($childPrice)
+                                    < $priceModifier->getOriginalPrice($childPrice)) {
+                                    $isDiscount = true;
+                                    break;
+                                }
                             }
                         }
                     }

--- a/src/module-elasticsuite-catalog/Model/Product/Indexer/Fulltext/Datasource/PriceData.php
+++ b/src/module-elasticsuite-catalog/Model/Product/Indexer/Fulltext/Datasource/PriceData.php
@@ -67,7 +67,7 @@ class PriceData implements DatasourceInterface
      * @param ResourceModel                        $resourceModel          Resource model
      * @param AttributeResourceModel               $attributeResourceModel Attribute Resource model
      * @param PriceData\PriceDataReaderInterface[] $priceReaderPool        Price modifiers pool.
-     * @param ScopeConfigInterface                 $scopeConfig            Scope Config.
+     * @param ScopeConfigInterface|null            $scopeConfig            Scope Config.
      */
     public function __construct(
         ResourceModel $resourceModel,
@@ -116,8 +116,8 @@ class PriceData implements DatasourceInterface
                             if ($childIdsData['parent_id'] === $productId &&
                                 $childPrice['customer_group_id'] == $priceDataRow['customer_group_id']
                             ) {
-                                if ($priceModifier->getPrice($childPrice)
-                                    < $priceModifier->getOriginalPrice($childPrice)) {
+                                if ($priceModifier->getPrice($childPrice) <
+                                    $priceModifier->getOriginalPrice($childPrice)) {
                                     $isDiscount = true;
                                     break;
                                 }


### PR DESCRIPTION
In the original PR we get child ids and check they are with discount or not, but without relation with parent product (and it works fine, if parent product and his child products are created after each other). 

Resolve #2853