### PR TITLE
Fix cron error "Deprecation functionality: creation of dynamic property"

### DIFF
--- a/src/module-elasticsuite-tracker/Model/IndexResolver.php
+++ b/src/module-elasticsuite-tracker/Model/IndexResolver.php
@@ -38,6 +38,10 @@ class IndexResolver
      */
     private $indexSettings;
 
+    /**
+     * @var \Smile\ElasticsuiteTracker\Model\IndexManager
+     */
+    private $indexManager;
 
     /**
      * Constructor.
@@ -49,7 +53,7 @@ class IndexResolver
     public function __construct(
         \Smile\ElasticsuiteCore\Api\Index\IndexSettingsInterface $indexSettings,
         \Smile\ElasticsuiteCore\Api\Index\IndexInterfaceFactory $indexFactory,
-        IndexManager $indexManager
+        \Smile\ElasticsuiteTracker\Model\IndexManager $indexManager
     ) {
         $this->indexFactory  = $indexFactory;
         $this->indexSettings = $indexSettings;


### PR DESCRIPTION
Magento 2.4.6, PHP 8.2.3. When you trying to run cron job manually from the list in admin panel, you can see follow error and its description:

![15 110048ducqr$s](https://user-images.githubusercontent.com/8590020/225661169-2ca2029d-672f-47b3-ab98-38ffada426e7.png)

This is the fix for the issue.