### PR TITLE
Fix numerical-only synonims

### DIFF
--- a/src/module-elasticsuite-thesaurus/Plugin/QueryRewrite.php
+++ b/src/module-elasticsuite-thesaurus/Plugin/QueryRewrite.php
@@ -126,10 +126,8 @@ class QueryRewrite
         }
 
         foreach ($queryText as $currentQueryText) {
-            $rewrites = array_merge(
-                $rewrites,
-                $this->index->getQueryRewrites($containerConfig, $currentQueryText, $originalBoost)
-            );
+            // Use + instead of array_merge because $queryText can be purely numeric and would be casted to 0 by array_merge.
+            $rewrites = $rewrites + $this->index->getQueryRewrites($containerConfig, $currentQueryText, $originalBoost);
         }
 
         return $rewrites;


### PR DESCRIPTION
This resolves the issue #2891

A simple testing scenario for reproducing the issue would be:
Provided that project has a product with SKU `2097402` and the module is configured with the following synonyms:

```
097402,2097402
```

Doing a search for query `097402` will not return any results.