### PR TITLE
Allow to deal with elasticsearch/elasticsearch-php v8.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,9 @@
         "magento/module-inventory-sales": ">=1.1.0",
         "magento/module-inventory-indexer": ">=2.0.0",
         "magento/magento-composer-installer": "*",
-        "elasticsearch/elasticsearch": "~7.17.0 || ~8.5.0"
+        "elasticsearch/elasticsearch": "~7.17.0 || ~8.5.0",
+        "opensearch-project/opensearch-php": "^1.0 || ^2.0, <2.0.1",
+        "php-http/guzzle7-adapter": "~1.0.0"
     },
     "replace": {
         "smile/module-elasticsuite-core": "self.version",

--- a/src/module-elasticsuite-core/Index/AsyncIndexOperation.php
+++ b/src/module-elasticsuite-core/Index/AsyncIndexOperation.php
@@ -111,6 +111,11 @@ class AsyncIndexOperation extends IndexOperation implements AsyncIndexOperationI
 
         /** @var \GuzzleHttp\Ring\Future\FutureArray $futureBulkResponse */
         foreach ($this->futureBulks as $futureBulkResponse) {
+            // Actually I don't know how to let all the future response resolve when using Guzzle7.
+            if ($futureBulkResponse instanceof \Http\Adapter\Guzzle7\Promise) {
+                $futureBulkResponse = $futureBulkResponse->wait();
+            }
+
             $resolvedResponse = [
                 'items'  => $futureBulkResponse['items'],  // Implicit resolution of the promise.
                 'errors' => $futureBulkResponse['errors'], // Implicit resolution of the promise.


### PR DESCRIPTION
- Different namespaces to deal with
- Different exceptions to deal with
- How to reproduce the old "parallel/async" mode ?
- ~The logger with client v8 is not as verbose as previously, how to improve ?~ it's just that now the content of queries is in debug.log instead of system.log. Impossible to change :/