### PR TITLE
Fix filter rendering

### DIFF
--- a/src/module-elasticsuite-catalog/Block/Navigation/FilterRenderer.php
+++ b/src/module-elasticsuite-catalog/Block/Navigation/FilterRenderer.php
@@ -47,7 +47,7 @@ class FilterRenderer extends AbstractBlock implements FilterRendererInterface
         $html = '';
 
         foreach ($this->getChildNames() as $childName) {
-            if ($html === '') {
+            if (trim((string) $html) === '') {
                 $renderer = $this->getChildBlock($childName);
                 $html = $renderer->render($this->getFilter());
             }


### PR DESCRIPTION
This fix prevents wrong behaviour when adding a new filter type on hyva theme / hyva compatibility module. (And I think when html minification is ON)
(May be with luma too, I did not try)