### PR TITLE
Smile_ElasticsuiteTracker: Only Add Frontend Tracker Blocks If Config Enabled

### DIFF
--- a/src/module-elasticsuite-tracker/view/frontend/layout/catalogsearch_result_index.xml
+++ b/src/module-elasticsuite-tracker/view/frontend/layout/catalogsearch_result_index.xml
@@ -16,10 +16,11 @@
  */
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
-
     <body>
         <referenceContainer name="before.body.end">
-            <block class="Smile\ElasticsuiteTracker\Block\Variables\Page\Search" name="smile.tracker.page.search" />
+            <block class="Smile\ElasticsuiteTracker\Block\Variables\Page\Search"
+                   name="smile.tracker.page.search"
+                   ifconfig="smile_elasticsuite_tracker/general/enabled"/>
         </referenceContainer>
     </body>
 </page>

--- a/src/module-elasticsuite-tracker/view/frontend/layout/checkout_onepage_success.xml
+++ b/src/module-elasticsuite-tracker/view/frontend/layout/checkout_onepage_success.xml
@@ -16,10 +16,11 @@
  */
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
-
     <body>
         <referenceContainer name="before.body.end">
-            <block class="Smile\ElasticsuiteTracker\Block\Variables\Page\Order" name="smile.tracker.page.order" />
+            <block class="Smile\ElasticsuiteTracker\Block\Variables\Page\Order"
+                   name="smile.tracker.page.order"
+                   ifconfig="smile_elasticsuite_tracker/general/enabled"/>
         </referenceContainer>
     </body>
 </page>

--- a/src/module-elasticsuite-tracker/view/frontend/layout/cms_page_view.xml
+++ b/src/module-elasticsuite-tracker/view/frontend/layout/cms_page_view.xml
@@ -18,7 +18,9 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="content">
-            <block class="Smile\ElasticsuiteTracker\Block\Variables\Page\Cms" name="smile.tracker.page.cms"/>
+            <block class="Smile\ElasticsuiteTracker\Block\Variables\Page\Cms"
+                   name="smile.tracker.page.cms"
+                   ifconfig="smile_elasticsuite_tracker/general/enabled"/>
         </referenceContainer>
     </body>
 </page>

--- a/src/module-elasticsuite-tracker/view/frontend/layout/default.xml
+++ b/src/module-elasticsuite-tracker/view/frontend/layout/default.xml
@@ -21,7 +21,10 @@
     </head>
     <body>
         <referenceBlock name="head.additional">
-            <block template="Smile_ElasticsuiteTracker::config.phtml" class="Smile\ElasticsuiteTracker\Block\Config" name="smile.tracker.config">
+            <block template="Smile_ElasticsuiteTracker::config.phtml"
+                   class="Smile\ElasticsuiteTracker\Block\Config"
+                   name="smile.tracker.config"
+                   ifconfig="smile_elasticsuite_tracker/general/enabled">
                 <arguments>
                     <argument name="userConsentScript" xsi:type="string">Smile_ElasticsuiteTracker/js/user-consent</argument>
                     <argument name="userConsentConfig" xsi:type="array">
@@ -32,8 +35,12 @@
             </block>
         </referenceBlock>
         <referenceContainer name="before.body.end">
-            <block class="Smile\ElasticsuiteTracker\Block\Variables\Page\Base" name="smile.tracker.page.base" />
-            <block class="Smile\ElasticsuiteTracker\Block\Variables\Page\Catalog" name="smile.tracker.page.catalog" />
+            <block class="Smile\ElasticsuiteTracker\Block\Variables\Page\Base"
+                   name="smile.tracker.page.base"
+                   ifconfig="smile_elasticsuite_tracker/general/enabled"/>
+            <block class="Smile\ElasticsuiteTracker\Block\Variables\Page\Catalog"
+                   name="smile.tracker.page.catalog"
+                   ifconfig="smile_elasticsuite_tracker/general/enabled"/>
         </referenceContainer>
     </body>
 </page>


### PR DESCRIPTION
# Description
This is a commonly disabled feature so it would be nice to use `ifconfig` layout XML property to optionally include frontend `Smile_ElasticsuiteTracker` blocks.

# Reviewer Notes
I was torn between using `smile_elasticsuite_tracker/general/enabled` and `smile_elasticsuite_telemetry/telemetry/enabled`. If there's a preference for the latter then I'm happy to edit these changes to reflect that.
