### PR TITLE
[Spellchecker] Re-enable spelling type cache

### DIFF
--- a/src/module-elasticsuite-core/Search/Adapter/Elasticsuite/Spellchecker.php
+++ b/src/module-elasticsuite-core/Search/Adapter/Elasticsuite/Spellchecker.php
@@ -68,7 +68,7 @@ class Spellchecker implements SpellcheckerInterface
 
         $spellingType = $this->cacheHelper->loadCache($cacheKey);
 
-        if (true || $spellingType === false) {
+        if ($spellingType === false) {
             $spellingType = $this->loadSpellingType($request);
             $this->cacheHelper->saveCache($cacheKey, $spellingType, [$request->getIndex(), ScopePool::CACHE_TAG]);
         }


### PR DESCRIPTION
disabled by error when introducing support of standard_edge_ngram fields in the term vectors request.