### PR TITLE
fix typo

### DIFF
--- a/src/module-elasticsuite-catalog/i18n/de_DE.csv
+++ b/src/module-elasticsuite-catalog/i18n/de_DE.csv
@@ -50,7 +50,7 @@ OK,OK
 "Show less","Weniger zeigen"
 "No value matching the search <b>%s</b>.","Keine Ergebnisse für die Suche <b>%s</b>."
 "Search (%s)","Suche (%s)"
-"Product Autocomplete",">Autovervollständigung Produkte"
+"Product Autocomplete","Autovervollständigung Produkte"
 "Max Size","Maximale Größe"
 "Maximum number of products to display in autocomplete results.","Maximale Anzahl angezeigter Produkte in den Ergebnissen der Autovervollständigung."
 "Product Attributes Autocomplete","Autovervollständigung Produktattribute"


### PR DESCRIPTION
The `>` in the German string is unnecessary, therefore it is removed.