### PR TITLE
Added configuration for ssl verification

### DIFF
--- a/src/module-elasticsuite-core/Client/ClientBuilder.php
+++ b/src/module-elasticsuite-core/Client/ClientBuilder.php
@@ -47,6 +47,7 @@ class ClientBuilder
         'is_debug_mode_enabled' => false,
         'max_parallel_handles'  => 100, // As per default Elasticsearch Handler configuration.
         'max_retries'           => 2,
+        'verify'                => true
     ];
 
     /**
@@ -111,6 +112,10 @@ class ClientBuilder
 
         if ($options['max_retries'] > 0) {
             $clientBuilder->setRetries((int) $options['max_retries']);
+        }
+
+        if (array_key_exists('verify', $options)){
+            $clientBuilder->setSSLVerification($options['verify']);
         }
 
         if (null !== $this->selector) {

--- a/src/module-elasticsuite-core/Client/ClientBuilder.php
+++ b/src/module-elasticsuite-core/Client/ClientBuilder.php
@@ -47,7 +47,7 @@ class ClientBuilder
         'is_debug_mode_enabled' => false,
         'max_parallel_handles'  => 100, // As per default Elasticsearch Handler configuration.
         'max_retries'           => 2,
-        'verify'                => true
+        'verify'                => true,
     ];
 
     /**
@@ -114,7 +114,7 @@ class ClientBuilder
             $clientBuilder->setRetries((int) $options['max_retries']);
         }
 
-        if (array_key_exists('verify', $options)){
+        if (array_key_exists('verify', $options)) {
             $clientBuilder->setSSLVerification($options['verify']);
         }
 

--- a/src/module-elasticsuite-core/Client/ClientConfiguration.php
+++ b/src/module-elasticsuite-core/Client/ClientConfiguration.php
@@ -130,6 +130,9 @@ class ClientConfiguration implements ClientConfigurationInterface
         return (int) $this->getElasticsearchClientConfigParam('max_retries');
     }
 
+    /**
+     * @return bool
+     */
     public function getVerify()
     {
         return (bool) $this->getElasticsearchClientConfigParam('enable_certificate_validation');
@@ -150,7 +153,7 @@ class ClientConfiguration implements ClientConfigurationInterface
             'is_debug_mode_enabled' => $this->isDebugModeEnabled(),
             'max_parallel_handles'  => $this->getMaxParallelHandles(),
             'max_retries'           => $this->getMaxRetries(),
-            'verify'                => $this->getVerify()
+            'verify'                => $this->getVerify(),
         ];
 
         return $options;

--- a/src/module-elasticsuite-core/Client/ClientConfiguration.php
+++ b/src/module-elasticsuite-core/Client/ClientConfiguration.php
@@ -130,6 +130,11 @@ class ClientConfiguration implements ClientConfigurationInterface
         return (int) $this->getElasticsearchClientConfigParam('max_retries');
     }
 
+    public function getVerify()
+    {
+        return (bool) $this->getElasticsearchClientConfigParam('enable_certificate_validation');
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -145,6 +150,7 @@ class ClientConfiguration implements ClientConfigurationInterface
             'is_debug_mode_enabled' => $this->isDebugModeEnabled(),
             'max_parallel_handles'  => $this->getMaxParallelHandles(),
             'max_retries'           => $this->getMaxRetries(),
+            'verify'                => $this->getVerify()
         ];
 
         return $options;

--- a/src/module-elasticsuite-core/Client/ClientConfiguration.php
+++ b/src/module-elasticsuite-core/Client/ClientConfiguration.php
@@ -133,7 +133,7 @@ class ClientConfiguration implements ClientConfigurationInterface
     /**
      * @return bool
      */
-    public function getVerify()
+    public function isVerifyEnabled()
     {
         return (bool) $this->getElasticsearchClientConfigParam('enable_certificate_validation');
     }
@@ -153,7 +153,7 @@ class ClientConfiguration implements ClientConfigurationInterface
             'is_debug_mode_enabled' => $this->isDebugModeEnabled(),
             'max_parallel_handles'  => $this->getMaxParallelHandles(),
             'max_retries'           => $this->getMaxRetries(),
-            'verify'                => $this->getVerify(),
+            'verify'                => $this->isVerifyEnabled(),
         ];
 
         return $options;

--- a/src/module-elasticsuite-core/etc/adminhtml/system.xml
+++ b/src/module-elasticsuite-core/etc/adminhtml/system.xml
@@ -39,6 +39,11 @@
                     <comment>Select yes if you want to connect to your Elasticsearch server over HTTPS.</comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
+                <field id="enable_certificate_validation" translate="label comment" type="select" sortOrder="52" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
+                    <label>Use SSL certificate Validation</label>
+                    <comment>Select no if you are using opensearch.</comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
                 <field id="enable_http_auth" translate="label comment" type="select" sortOrder="52" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                     <label>Enable basic HTTP authentication</label>
                     <comment>Enable this option when your Elasticsearch server use basic HTTP authentication.</comment>

--- a/src/module-elasticsuite-core/etc/config.xml
+++ b/src/module-elasticsuite-core/etc/config.xml
@@ -25,6 +25,7 @@
                 <timeout>30</timeout>
                 <max_parallel_handles>10</max_parallel_handles>
                 <max_retries>2</max_retries>
+                <enable_certificate_validation>1</enable_certificate_validation>
             </es_client>
             <indices_settings>
                 <alias>magento2</alias>


### PR DESCRIPTION
Added configuration, default value for it, and elasticsearch call option for SSL Verification. This allows to turn it off, for ES clients like opensearch, on local environments.