### PR TITLE
Replace the Elasticsearch client by the Opensearch client.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "magento/module-inventory-sales": ">=1.1.0",
         "magento/module-inventory-indexer": ">=2.0.0",
         "magento/magento-composer-installer": "*",
-        "elasticsearch/elasticsearch": "~7.17.0 || ~8.5.0"
+        "opensearch-project/opensearch-php": "^1.0 || ^2.0, <2.0.1"
     },
     "replace": {
         "smile/module-elasticsuite-core": "self.version",

--- a/src/module-elasticsuite-core/Client/Client.php
+++ b/src/module-elasticsuite-core/Client/Client.php
@@ -14,7 +14,7 @@
 
 namespace Smile\ElasticsuiteCore\Client;
 
-use Elasticsearch\Common\Exceptions\Missing404Exception;
+use OpenSearch\Common\Exceptions\Missing404Exception;
 use Smile\ElasticsuiteCore\Api\Client\ClientConfigurationInterface;
 use Smile\ElasticsuiteCore\Api\Client\ClientInterface;
 
@@ -30,7 +30,7 @@ use Smile\ElasticsuiteCore\Api\Client\ClientInterface;
 class Client implements ClientInterface
 {
     /**
-     * @var \Elasticsearch\Client
+     * @var \OpenSearch\Client
      */
     private $esClient = null;
 
@@ -160,7 +160,7 @@ class Client implements ClientInterface
         $indices = [];
         try {
             $indices = $this->getEsClient()->indices()->getMapping(['index' => $indexAlias]);
-        } catch (\Elasticsearch\Common\Exceptions\Missing404Exception $e) {
+        } catch (\OpenSearch\Common\Exceptions\Missing404Exception $e) {
             ;
         }
 
@@ -262,9 +262,9 @@ class Client implements ClientInterface
     }
 
     /**
-     * @return \Elasticsearch\Client
+     * @return \OpenSearch\Client
      */
-    private function getEsClient(): \Elasticsearch\Client
+    private function getEsClient(): \OpenSearch\Client
     {
         if ($this->esClient === null) {
             $this->esClient = $this->clientBuilder->build($this->clientConfiguration->getOptions());

--- a/src/module-elasticsuite-core/Client/ClientBuilder.php
+++ b/src/module-elasticsuite-core/Client/ClientBuilder.php
@@ -14,7 +14,7 @@
 
 namespace Smile\ElasticsuiteCore\Client;
 
-use Elasticsearch\ConnectionPool\Selectors\StickyRoundRobinSelector;
+use OpenSearch\ConnectionPool\Selectors\StickyRoundRobinSelector;
 
 /**
  * ElasticSearch client builder.
@@ -26,7 +26,7 @@ use Elasticsearch\ConnectionPool\Selectors\StickyRoundRobinSelector;
 class ClientBuilder
 {
     /**
-     * @var \Elasticsearch\ClientBuilder
+     * @var \OpenSearch\ClientBuilder
      */
     private $clientBuilder;
 
@@ -58,14 +58,14 @@ class ClientBuilder
     /**
      * Constructor.
      *
-     * @param \Elasticsearch\ClientBuilder $clientBuilder Client builder.
-     * @param \Psr\Log\LoggerInterface     $logger        Logger.
-     * @param string                       $selector      Node Selector.
+     * @param \OpenSearch\ClientBuilder $clientBuilder Client builder.
+     * @param \Psr\Log\LoggerInterface  $logger        Logger.
+     * @param string                    $selector      Node Selector.
      */
     public function __construct(
-        \Elasticsearch\ClientBuilder $clientBuilder,
+        \OpenSearch\ClientBuilder $clientBuilder,
         \Psr\Log\LoggerInterface $logger,
-        $selector = StickyRoundRobinSelector::class
+        string $selector = StickyRoundRobinSelector::class
     ) {
         $this->clientBuilder = $clientBuilder;
         $this->logger        = $logger;
@@ -75,13 +75,24 @@ class ClientBuilder
     /**
      * Build an ES client from options.
      *
+     * We decided to use the OpenSearch client because he is versatile and can work with :
+     *
+     * - Elasticsearch 7.x
+     * - Elasticsearch 8.x
+     * - Opensearch 1.x
+     * - Opensearch 2.x
+     *
+     * At least, for now...
+     *
+     * The Elasticsearch client had a change in FQCN between v7 and v8 that would require a huge rework.
+     *
      * @SuppressWarnings(PHPMD.StaticAccess)
      *
      * @param array $options Client options. See self::defaultOptions for available options.
      *
-     * @return \Elasticsearch\Client
+     * @return \OpenSearch\Client
      */
-    public function build($options = [])
+    public function build(array $options = []): \OpenSearch\Client
     {
         $options       = array_merge($this->defaultOptions, $options);
 
@@ -100,7 +111,7 @@ class ClientBuilder
 
         if ($options['max_parallel_handles']) {
             $handlerParams = ['max_handles' => (int) $options['max_parallel_handles']];
-            $handler = \Elasticsearch\ClientBuilder::defaultHandler($handlerParams);
+            $handler = \OpenSearch\ClientBuilder::defaultHandler($handlerParams);
             $clientBuilder->setHandler($handler);
         }
 
@@ -133,7 +144,7 @@ class ClientBuilder
      *
      * @return array
      */
-    private function getHosts($options)
+    private function getHosts(array $options): array
     {
         $hosts = [];
 
@@ -166,9 +177,10 @@ class ClientBuilder
      * Return HTTP Authentication parameters used to connect to the cluster if any
      *
      * @param array $options Client options. See self::defaultOptions for available options.
+     *
      * @return array
      */
-    private function getConnectionParams($options)
+    private function getConnectionParams(array $options): array
     {
         return (
             !empty($options['http_auth_user']) &&

--- a/src/module-elasticsuite-core/Test/Unit/Index/IndexOperationTest.php
+++ b/src/module-elasticsuite-core/Test/Unit/Index/IndexOperationTest.php
@@ -32,7 +32,7 @@ class IndexOperationTest extends \PHPUnit\Framework\TestCase
     private $indexOperation;
 
     /**
-     * @var \Elasticsearch\Client|\\PHPUnit\Framework\MockObject\MockObject
+     * @var \OpenSearch\Client|\\PHPUnit\Framework\MockObject\MockObject
      */
     private $clientMock;
 

--- a/src/module-elasticsuite-core/etc/di.xml
+++ b/src/module-elasticsuite-core/etc/di.xml
@@ -548,7 +548,7 @@
     <!-- Async Operations -->
     <virtualType name="elasticsuiteAsyncClientBuilder" type="Smile\ElasticsuiteCore\Client\ClientBuilder">
         <arguments>
-            <argument name="selector" xsi:type="string">\Elasticsearch\ConnectionPool\Selectors\RoundRobinSelector</argument>
+            <argument name="selector" xsi:type="string">\OpenSearch\ConnectionPool\Selectors\RoundRobinSelector</argument>
         </arguments>
     </virtualType>
 


### PR DESCRIPTION
This should probably replace #2910 

The Opensearch 2.0 client has been tested working with : 

- ES 7
- ES 8
- Opensearch 2
- ~~Opensearch 1.~~ : tested OK but not supported by Magento as per https://experienceleague.adobe.com/docs/commerce-operations/installation-guide/system-requirements.html

By using the Opensearch client, we are preserved from the FQCN change in the Elasticsearch PHP client, between v7 and v8.

On top of that, the Opensearch client is basically identical to the ES Client, so we're still familiar with it.