### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/02-phpstan.yml
+++ b/.github/workflows/02-phpstan.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: "[Init] Determine composer cache directory"
         id: composer-cache-directory
-        run: "echo \"directory=$(composer config cache-dir)\"" >> $GITHUB_OUTPUT
+        run: "echo \"directory=$(composer config cache-dir)\"" >> "$GITHUB_OUTPUT"
 
       - name: "[Init] Cache Composer cache"
         id: composer-cache

--- a/.github/workflows/02-phpstan.yml
+++ b/.github/workflows/02-phpstan.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: "[Init] Determine composer cache directory"
         id: composer-cache-directory
-        run: "echo \"::set-output name=directory::$(composer config cache-dir)\""
+        run: "echo \"directory=$(composer config cache-dir)\"" >> $GITHUB_OUTPUT
 
       - name: "[Init] Cache Composer cache"
         id: composer-cache

--- a/.github/workflows/20-integration.yml
+++ b/.github/workflows/20-integration.yml
@@ -120,7 +120,7 @@ jobs:
 
             - name: "[Init] Determine composer cache directory"
               id: composer-cache-directory
-              run: "echo \"::set-output name=directory::$(composer config cache-dir)\""
+              run: "echo \"directory=$(composer config cache-dir)\"" >> $GITHUB_OUTPUT
 
             - name: "[Init] Cache Composer cache"
               id: composer-cache

--- a/.github/workflows/20-integration.yml
+++ b/.github/workflows/20-integration.yml
@@ -120,7 +120,7 @@ jobs:
 
             - name: "[Init] Determine composer cache directory"
               id: composer-cache-directory
-              run: "echo \"directory=$(composer config cache-dir)\"" >> $GITHUB_OUTPUT
+              run: "echo \"directory=$(composer config cache-dir)\"" >> "$GITHUB_OUTPUT"
 
             - name: "[Init] Cache Composer cache"
               id: composer-cache


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter

