### PR TITLE
Fixes #3148 Replacing _term agg sort order by _key

### DIFF
--- a/src/module-elasticsuite-catalog/Model/Attribute/Source/FilterSortOrder.php
+++ b/src/module-elasticsuite-catalog/Model/Attribute/Source/FilterSortOrder.php
@@ -35,7 +35,7 @@ class FilterSortOrder implements OptionSourceInterface
         return [
             ['value' => BucketInterface::SORT_ORDER_COUNT, 'label' => __('Result count')],
             ['value' => BucketInterface::SORT_ORDER_MANUAL, 'label' => __('Admin sort')],
-            ['value' => BucketInterface::SORT_ORDER_TERM, 'label' => __('Name')],
+            ['value' => BucketInterface::SORT_ORDER_TERM_DEPRECATED, 'label' => __('Name')],
             ['value' => BucketInterface::SORT_ORDER_RELEVANCE, 'label' => __('Relevance')],
         ];
     }

--- a/src/module-elasticsuite-core/Search/Adapter/Elasticsuite/Request/Aggregation/Builder/Term.php
+++ b/src/module-elasticsuite-core/Search/Adapter/Elasticsuite/Request/Aggregation/Builder/Term.php
@@ -48,7 +48,7 @@ class Term implements BuilderInterface
             $aggregation['terms']['order'] = $bucket->getSortOrder();
         } elseif (in_array($bucket->getSortOrder(), [$bucket::SORT_ORDER_COUNT, $bucket::SORT_ORDER_MANUAL])) {
             $aggregation['terms']['order'] = [$bucket::SORT_ORDER_COUNT => SortOrderInterface::SORT_DESC];
-        } elseif ($bucket->getSortOrder() == $bucket::SORT_ORDER_TERM) {
+        } elseif (in_array($bucket->getSortOrder(), [$bucket::SORT_ORDER_TERM, $bucket::SORT_ORDER_TERM_DEPRECATED])) {
             $aggregation['terms']['order'] = [$bucket::SORT_ORDER_TERM => SortOrderInterface::SORT_ASC];
         } elseif ($bucket->getSortOrder() == $bucket::SORT_ORDER_RELEVANCE && !$bucket->isNested()) {
             $aggregation['aggregations']['termRelevance'] = ['avg' => ['script' => $bucket::SORT_ORDER_RELEVANCE]];

--- a/src/module-elasticsuite-core/Search/Request/BucketInterface.php
+++ b/src/module-elasticsuite-core/Search/Request/BucketInterface.php
@@ -35,9 +35,10 @@ interface BucketInterface extends \Magento\Framework\Search\Request\BucketInterf
     const TYPE_METRIC           = 'metricBucket';
 
     const SORT_ORDER_COUNT     = '_count';
-    const SORT_ORDER_TERM      = '_term';
+    const SORT_ORDER_TERM      = '_key';
     const SORT_ORDER_RELEVANCE = "_score";
     const SORT_ORDER_MANUAL    = "_manual";
+    const SORT_ORDER_TERM_DEPRECATED = '_term';
 
     /**
      * @var integer

--- a/src/module-elasticsuite-core/Test/Unit/Search/Adapter/Elasticsuite/Request/Aggregation/Builder/TermTest.php
+++ b/src/module-elasticsuite-core/Test/Unit/Search/Adapter/Elasticsuite/Request/Aggregation/Builder/TermTest.php
@@ -53,7 +53,46 @@ class TermTest extends \PHPUnit\Framework\TestCase
     public function testAplhabeticSortOrderTermAggregationBuild()
     {
         $aggBuilder = $this->getAggregationBuilder();
-        $termBucket = new TermBucket('aggregationName', 'fieldName', [], [], [], null, null, null, 1, TermBucket::SORT_ORDER_TERM);
+        $termBucket = new TermBucket(
+            'aggregationName',
+            'fieldName',
+            [],
+            [],
+            [],
+            null,
+            null,
+            null,
+            1,
+            TermBucket::SORT_ORDER_TERM
+        );
+
+        $aggregation = $aggBuilder->buildBucket($termBucket);
+
+        $this->assertArrayHasKey('terms', $aggregation);
+        $this->assertEquals('fieldName', $aggregation['terms']['field']);
+        $this->assertEquals([TermBucket::SORT_ORDER_TERM => SortOrderInterface::SORT_ASC], $aggregation['terms']['order']);
+    }
+
+    /**
+     * Test the standard term aggregation building sorted by alphabetic order using the deprecated sort order.
+     *
+     * @return void
+     */
+    public function testAplhabeticSortOrderTermDeprecatedAggregationBuild()
+    {
+        $aggBuilder = $this->getAggregationBuilder();
+        $termBucket = new TermBucket(
+            'aggregationName',
+            'fieldName',
+            [],
+            [],
+            [],
+            null,
+            null,
+            null,
+            1,
+            TermBucket::SORT_ORDER_TERM_DEPRECATED
+        );
 
         $aggregation = $aggBuilder->buildBucket($termBucket);
 


### PR DESCRIPTION
Deprecated since Elasticsearch 6.0.0 but finally removed in 8.11