### PR TITLE
Fix: Add isActiveFilter to prevent disabled categories from being found

### DIFF
--- a/src/module-elasticsuite-virtual-category/Model/Url.php
+++ b/src/module-elasticsuite-virtual-category/Model/Url.php
@@ -265,7 +265,8 @@ class Url
     {
         $collection = $this->categoryCollectionFactory->create();
 
-        $collection->setStoreId($this->storeManager->getStore()->getId())
+        $collection->addIsActiveFilter()
+            ->setStoreId($this->storeManager->getStore()->getId())
             ->addAttributeToFilter('url_key', ['eq' => $requestPath]);
 
         return $collection->getFirstItem();
@@ -282,7 +283,8 @@ class Url
     private function loadVirtualCategoryByUrlPath($requestPath): DataObject
     {
         $collection = $this->categoryCollectionFactory->create();
-        $collection->setStoreId($this->storeManager->getStore()->getId())
+        $collection->addIsActiveFilter()
+            ->setStoreId($this->storeManager->getStore()->getId())
             ->addAttributeToFilter('url_path', ['eq' => $requestPath])
             ->addAttributeToFilter('is_virtual_category', ['eq' => 1]);
 


### PR DESCRIPTION
Hi guys,

I'm presenting you this PR because of an issue we found out in a store of ours.

The issue; in a store we had a virtual category which had a virtual root category set. However the production environment returned a 404 for a specific category within that virtual category.

After a long debug session we narrowed it down to how the category was fetched from the collection. And eventually I found out that if there are multiple categories inside set root category with the same `url_key` the first one will always be fetched. In this particular case we had a category which was disabled and was not intended to be fetched.

So I've added an `addIsActiveFilter()` to the category collection. This helps to fetch only active categories. 
This doesn't entirely solve the issue where you might have duplicate `url_key` which you are trying to match, but this prevents the finding of a disabled category and trying to return that category.

I've also added the `addIsActiveFilter` to the `loadVirtualCategoryByUrlPath`, to check if the fetched virtual category is active, because it also can be disabled.