### PR TITLE
added missing form name in product conditions

### DIFF
--- a/src/module-elasticsuite-catalog-rule/Block/Product/Conditions.php
+++ b/src/module-elasticsuite-catalog-rule/Block/Product/Conditions.php
@@ -176,6 +176,7 @@ class Conditions extends Template implements RendererInterface
     private function setConditionFormName(\Magento\Rule\Model\Condition\AbstractCondition $conditions, $formName)
     {
         $conditions->setJsFormObject($formName);
+        $conditions->setData('form_name', $formName);
 
         if ($conditions->getConditions() && is_array($conditions->getConditions())) {
             foreach ($conditions->getConditions() as $condition) {

--- a/src/module-elasticsuite-catalog-rule/Controller/Adminhtml/Product/Rule/Conditions.php
+++ b/src/module-elasticsuite-catalog-rule/Controller/Adminhtml/Product/Rule/Conditions.php
@@ -79,6 +79,7 @@ class Conditions extends Action
         $result = '';
         if ($model instanceof AbstractCondition) {
             $model->setJsFormObject($this->getRequest()->getParam('form'));
+            $model->setData('form_name', $this->getRequest()->getParam('form'));
             $model->setData('url_params', $this->getRequest()->getParams());
             $result = $model->asHtmlRecursive();
         }


### PR DESCRIPTION
When using the product conditions outside your module .. for example in widgets configuration the form name have to exist to make it work.