### PR TITLE
allow exact match for strings

### DIFF
--- a/src/module-elasticsuite-catalog-rule/Model/Rule/Condition/Product.php
+++ b/src/module-elasticsuite-catalog-rule/Model/Rule/Condition/Product.php
@@ -265,7 +265,7 @@ class Product extends \Magento\Rule\Model\Condition\Product\AbstractProduct
     {
         if (null === $this->_defaultOperatorInputByType) {
             $this->_defaultOperatorInputByType = [
-                'string'      => ['{}', '!{}'],
+                'string'      => ['{}', '!{}', '=='],
                 'numeric'     => ['==', '!=', '>=', '>', '<=', '<'],
                 'date'        => ['==', '>=', '>', '<=', '<'],
                 'select'      => ['==', '!='],


### PR DESCRIPTION
Sometimes you are in need to make an exact match instead of like in strings. For example I have a string with values "5", "50". With like I have no possibility to get only the value "5".