### PR TITLE
Fix #3157 by ensuring store_id is numeric.

### DIFF
--- a/src/module-elasticsuite-tracker/Model/EventIndex.php
+++ b/src/module-elasticsuite-tracker/Model/EventIndex.php
@@ -75,7 +75,7 @@ class EventIndex implements EventIndexInterface
         $indices = [];
 
         foreach ($events as $event) {
-            if (isset($event['page']['store_id'])) {
+            if (isset($event['page']['store_id']) && is_numeric($event['page']['store_id'])) {
                 // Previous "date" column has been renamed to "created_at" in db_schema.xml.
                 if (!isset($event['date'])) {
                     $event['date'] = $event['created_at'];

--- a/src/module-elasticsuite-tracker/Model/ResourceModel/EventQueue.php
+++ b/src/module-elasticsuite-tracker/Model/ResourceModel/EventQueue.php
@@ -148,9 +148,12 @@ class EventQueue extends AbstractDb
     protected function isEventInvalid($data)
     {
         $isEventInvalid = true;
-        if (array_key_exists('session', $data)) {
-            if (array_key_exists('uid', $data['session']) && array_key_exists('vid', $data['session'])) {
-                $isEventInvalid = false;
+
+        if (isset($data['page']['store_id']) && is_numeric($data['page']['store_id'])) {
+            if (array_key_exists('session', $data)) {
+                if (array_key_exists('uid', $data['session']) && array_key_exists('vid', $data['session'])) {
+                    $isEventInvalid = false;
+                }
             }
         }
 


### PR DESCRIPTION
Belt & Suspenders approach, ensuring the event will be flagged as invalid and not be indexed (but it's implied by the invalid) if store_id is not numeric.