### PR TITLE
Fix tracking image 404

### DIFF
--- a/src/module-elasticsuite-tracker/Helper/Data.php
+++ b/src/module-elasticsuite-tracker/Helper/Data.php
@@ -139,7 +139,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
      */
     public function getBaseUrl()
     {
-        return trim($this->urlBuilder->getUrl('elasticsuite/tracker/hit', ['image' => 'h.png']), '/');
+        return trim($this->urlBuilder->getUrl('elasticsuite/tracker/hit', ['image' => 'hit.png']), '/');
     }
 
     /**


### PR DESCRIPTION
The tracking image URL was h.png and not hit.png as per the image in the module.