### PR TITLE
Remove hardcoded SKU from query builder since new options should allo…

### DIFF
--- a/src/module-elasticsuite-core/Search/Request/Query/Fulltext/QueryBuilder.php
+++ b/src/module-elasticsuite-core/Search/Request/Query/Fulltext/QueryBuilder.php
@@ -121,7 +121,7 @@ class QueryBuilder
     private function getCutoffFrequencyQuery(ContainerConfigurationInterface $containerConfig, $queryText)
     {
         $relevanceConfig = $containerConfig->getRelevanceConfig();
-        $fields          = array_fill_keys([MappingInterface::DEFAULT_SEARCH_FIELD, 'sku'], 1);
+        $fields          = array_fill_keys([MappingInterface::DEFAULT_SEARCH_FIELD], 1);
 
         if ($containerConfig->getRelevanceConfig()->isUsingDefaultAnalyzerInExactMatchFilter()) {
             $nonStandardSearchableFieldFilter = $this->fieldFilters['nonStandardSearchableFieldFilter'];


### PR DESCRIPTION
"it works on my Luma".

At least, if I enable the new setting in the Back-Office (which might be enabled by default, no ?) that allows to explicitely target fields having a non-default analyzer for exact queries, I can still have the sku being added into the filter part.

I'm not sure what could cause the removing of the "sku^1" (that was always here) in the filter part, could possibly cause as side effect.