### PR TITLE
[Tracker] Use config defined cookie domain

### DIFF
--- a/src/module-elasticsuite-tracker/view/frontend/web/js/tracking.js
+++ b/src/module-elasticsuite-tracker/view/frontend/web/js/tracking.js
@@ -46,9 +46,13 @@ const smileTracker = (function () {
         return null;
     }
 
-    function setCookie(cookieName, cookieValue, expiresAt, path) {
+    function setCookie(cookieName, cookieValue, expiresAt, path, domain) {
         const expires = "expires=" + expiresAt.toUTCString();
-        document.cookie = cookieName + "=" + cookieValue + "; " + expires + "; path=" + path;
+        let cookieParams = cookieName + "=" + cookieValue + "; " + expires + "; path=" + path;
+        if (domain !== false) {
+            cookieParams += "; domain=" + domain;
+        }
+        document.cookie = cookieParams;
     }
 
     // Retrieve values for a param into URL
@@ -287,19 +291,20 @@ const smileTracker = (function () {
             const config   = this.config.sessionConfig;
             const expireAt = new Date();
             const path     = config['path'] || '/';
+            const domain   = config['domain'] || false;
 
             if (!this.sessionInitialized) {
                 if (getCookie(config['visit_cookie_name']) === null) {
                     expireAt.setSeconds(expireAt.getSeconds() + parseInt(config['visit_cookie_lifetime'], 10));
-                    setCookie(config['visit_cookie_name'], guid(), expireAt, path);
+                    setCookie(config['visit_cookie_name'], guid(), expireAt, path, domain);
                 } else {
                     expireAt.setSeconds(expireAt.getSeconds() + parseInt(config['visit_cookie_lifetime'], 10));
-                    setCookie(config['visit_cookie_name'], getCookie(config['visit_cookie_name']), expireAt, path);
+                    setCookie(config['visit_cookie_name'], getCookie(config['visit_cookie_name']), expireAt, path, domain);
                 }
 
                 if (getCookie(config['visitor_cookie_name']) === null) {
                     expireAt.setDate(expireAt.getDate() + parseInt(config['visitor_cookie_lifetime'], 10));
-                    setCookie(config['visitor_cookie_name'], guid(), expireAt, path);
+                    setCookie(config['visitor_cookie_name'], guid(), expireAt, path, domain);
                 }
                 this.sessionInitialized = true;
             }


### PR DESCRIPTION
If you are on a setup with a custom frontend theme on "www.domain.tld" and using Magento Rest and GraphQL API available on "api.domain.tld", the domain used to create the tracker cookies (named by default STUID - tracking session cookie - and STVID - tracking visitor cookie) **needs to be .domain.tld**.
Otherwise, your visitors browsers 
* will be able to read the previously cookies created for "www.domain.tld" 
* but will not be allowed to send them to "api.domain.tld" when requesting the tracker image or executing the tracker REST call

**Hence, you'll end up with visitor-less and session-less invalid tracker events** and not effectively tracking your visitors.

On a Luma, the sessionConfig object passed to the tracker already contains a "domain" value which comes from Magento session configuration.
It will contain the Stores Configuration defined value for "General > Web > Default Cookie Settings > Cookie Domain" OR if not defined, the HTTP Host as seen from the backend.
Obviously, if you are on setup with a custom frontend them as described above, you will want to set up a value for "General > Web > Default Cookie Settings > Cookie Domain" to ".domain.tld".

This PR uses that sessionConfig.domain value, if provided to the tracking script, to set up the tracker cookies.
Please note that if your site is already live and visitors already got tracking cookies with the invalid domain (www.domain.tld) : 
* the session cookie (STUID by default), will be correctly "re-set" on the correct domain
  * because the tracking script renews that cookie at each page hit / tracker call
* but the visitor cookie (STVID by default), is created only if it does not exist yet 
  * and so will not be re-created / updated to the correct cookie domain

**So to take those changes into account**, you would also need **to change the name of that cookie** (for instance from "STVID" to "STWID") which is provided by sessionConfig.visitor_cookie_name and defined **in Magento Stores Configuration in "Elasticsuite > Tracking > Session Configuration > Visitor Cookie Name"**.