### PR TITLE
Change opensearch deps to make it compatible with magento 2.4.7-beta3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "magento/module-inventory-sales": ">=1.1.0",
         "magento/module-inventory-indexer": ">=2.0.0",
         "magento/magento-composer-installer": "*",
-        "opensearch-project/opensearch-php": "^1.0 || ^2.0, <2.0.1"
+        "opensearch-project/opensearch-php": "^1.0 || ^2.0"
     },
     "replace": {
         "smile/module-elasticsuite-core": "self.version",


### PR DESCRIPTION
I'm not sure why these limitation was set for version below 2.0.1, but this reflects to critical errors in magento 2.4.7-beta3 (and probably the final release).

I put the same requirements as they are in the Opensearch module in Magento https://github.com/magento/magento2/blob/b2286ecfb014dbe05a45004526541aa8250259c2/app/code/Magento/OpenSearch/composer.json#L12