### PR TITLE
add untouched analyzer for text  promo rules & exact match rule conditions

### DIFF
--- a/src/module-elasticsuite-catalog-rule/Model/Rule/Condition/Product.php
+++ b/src/module-elasticsuite-catalog-rule/Model/Rule/Condition/Product.php
@@ -265,7 +265,7 @@ class Product extends \Magento\Rule\Model\Condition\Product\AbstractProduct
     {
         if (null === $this->_defaultOperatorInputByType) {
             $this->_defaultOperatorInputByType = [
-                'string'      => ['{}', '!{}'],
+                'string'      => ['==', '!=', '{}', '!{}'],
                 'numeric'     => ['==', '!=', '>=', '>', '<=', '<'],
                 'date'        => ['==', '>=', '>', '<=', '<'],
                 'select'      => ['==', '!='],

--- a/src/module-elasticsuite-catalog/Helper/AbstractAttribute.php
+++ b/src/module-elasticsuite-catalog/Helper/AbstractAttribute.php
@@ -138,6 +138,10 @@ abstract class AbstractAttribute extends Mapping
             $options['is_filterable'] = true;
         }
 
+        if ($attribute->getIsUsedForPromoRules()) {
+            $options['is_used_for_promo_rules'] = true;
+        }
+
         if ($attribute->getUsedForSortBy()) {
             $options['sort_order_asc_missing']  = $attribute->getSortOrderAscMissing();
             $options['sort_order_desc_missing'] = $attribute->getSortOrderDescMissing();

--- a/src/module-elasticsuite-core/Api/Index/Mapping/FieldInterface.php
+++ b/src/module-elasticsuite-core/Api/Index/Mapping/FieldInterface.php
@@ -98,6 +98,11 @@ interface FieldInterface
     public function isFilterable();
 
     /**
+     * Is the attribute used for promo rules.
+     */
+    public function isUsedForPromoRules();
+
+    /**
      * Is the attribute used in sorting.
      */
     public function isUsedForSortBy();

--- a/src/module-elasticsuite-core/Index/Mapping/Field.php
+++ b/src/module-elasticsuite-core/Index/Mapping/Field.php
@@ -66,6 +66,7 @@ class Field implements FieldInterface
         'is_filterable'           => true,
         'is_used_for_sort_by'     => false,
         'is_used_in_spellcheck'   => false,
+        'is_used_for_promo_rules' => false,
         'search_weight'           => 1,
         'default_search_analyzer' => self::ANALYZER_STANDARD,
         'filter_logical_operator' => self::FILTER_LOGICAL_OPERATOR_OR,

--- a/src/module-elasticsuite-core/Index/Mapping/Field.php
+++ b/src/module-elasticsuite-core/Index/Mapping/Field.php
@@ -145,6 +145,14 @@ class Field implements FieldInterface
     /**
      * {@inheritDoc}
      */
+    public function isUsedForPromoRules(): bool
+    {
+        return (bool) $this->config['is_used_for_promo_rules'];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function isUsedForSortBy(): bool
     {
         return (bool) $this->config['is_used_for_sort_by'];
@@ -388,7 +396,7 @@ class Field implements FieldInterface
             $analyzers[] = self::ANALYZER_SHINGLE;
         }
 
-        if (empty($analyzers) || $this->isFilterable()) {
+        if (empty($analyzers) || $this->isFilterable() || $this->isUsedForPromoRules()) {
             // For filterable fields or fields without analyzer : append the untouched analyzer.
             $analyzers[] = self::ANALYZER_UNTOUCHED;
         }


### PR DESCRIPTION
Hey there,

I already have an open pull request and an open issue, but since they are related here is a combined one.

When having a text attribute which is only used for promo rules there is no exact match possible. I use it in a custom collection ['eq' => '..'] and in promo rules via admin.

By default it is not possible do use a rule condition "is" or "is not" .. so I added these two. To make it work I added an untouched analyzer if used in promo rules is enabled.

https://github.com/Smile-SA/elasticsuite/pull/3168
https://github.com/Smile-SA/elasticsuite/issues/3171

Regards
Marcus