### PR TITLE
Wrong cast order

### DIFF
--- a/src/module-elasticsuite-virtual-category/Model/Rule.php
+++ b/src/module-elasticsuite-virtual-category/Model/Rule.php
@@ -177,7 +177,7 @@ class Rule extends \Smile\ElasticsuiteCatalogRule\Model\Rule implements VirtualR
     public function getCategorySearchQuery($category, $excludedCategories = []): ?QueryInterface
     {
         \Magento\Framework\Profiler::start('ES:Virtual Rule ' . __FUNCTION__);
-        $categoryId = (int) !is_object($category) ? $category : $category->getId();
+        $categoryId = (int)(!is_object($category) ? $category : $category->getId());
         $cacheKey = implode(
             '|',
             [


### PR DESCRIPTION
Since last update: https://github.com/Smile-SA/elasticsuite/commit/9811ee78c0cd430ce2a55fd3e61aaf03db887553#diff-e3d9752e99ca84e5f77b8490a15d16e677f3d2b87e8ce6114cb85513ebb0bc16R180

On lastests: 2.11.6 & 2.10.20

The wrong cast order has a critical impact because it's not the result of the ternary operation that is casted to int bu the condition.

It has a critical impact because it's not possible anymore to use the category condition:

```

[2024-04-23T14:16:34.685022+00:00] report.CRITICAL: TypeError: Smile\ElasticsuiteVirtualCategory\Model\Rule::getFromLocalCache(): Argument #1 ($categoryId) must be of type int, string given, called in /app/fi4jxviizr2zw/vendor/smile/elasticsuite/src/module-elasticsuite-virtual-category/Model/Rule.php on line 191 and defined in /app/fi4jxviizr2zw/vendor/smile/elasticsuite/src/module-elasticsuite-virtual-category/Model/Rule.php:542
Stack trace:
#0 /app/fi4jxviizr2zw/vendor/smile/elasticsuite/src/module-elasticsuite-virtual-category/Model/Rule.php(191): Smile\ElasticsuiteVirtualCategory\Model\Rule->getFromLocalCache()
#1 /app/fi4jxviizr2zw/vendor/smile/elasticsuite/src/module-elasticsuite-virtual-category/Model/Rule/Condition/Product.php(153): Smile\ElasticsuiteVirtualCategory\Model\Rule->getCategorySearchQuery()
#2 /app/fi4jxviizr2zw/vendor/smile/elasticsuite/src/module-elasticsuite-virtual-category/Model/Rule/Condition/Product.php(104): Smile\ElasticsuiteVirtualCategory\Model\Rule\Condition\Product->getCategorySearchQuery()
#3 /app/fi4jxviizr2zw/vendor/smile/elasticsuite/src/module-elasticsuite-virtual-category/Model/Rule/Condition/Combine.php(49): Smile\ElasticsuiteVirtualCategory\Model\Rule\Condition\Product->getSearchQuery()
#4 /app/fi4jxviizr2zw/vendor/smile/elasticsuite/src/module-elasticsuite-virtual-category/Model/Rule.php(419): Smile\ElasticsuiteVirtualCategory\Model\Rule\Condition\Combine->getSearchQuery()
#5 /app/fi4jxviizr2zw/vendor/smile/elasticsuite/src/module-elasticsuite-virtual-category/Model/Rule.php(306): Smile\ElasticsuiteVirtualCategory\Model\Rule->getVirtualCategoryQuery()
#6 /app/fi4jxviizr2zw/vendor/smile/elasticsuite/src/module-elasticsuite-virtual-category/Model/Rule.php(205): Smile\ElasticsuiteVirtualCategory\Model\Rule->buildCategorySearchQuery()
#7 /app/fi4jxviizr2zw/vendor/smile/elasticsuite/src/module-elasticsuite-virtual-category/Model/Preview.php(117): Smile\ElasticsuiteVirtualCategory\Model\Rule->getCategorySearchQuery()
#8 /app/fi4jxviizr2zw/vendor/smile/elasticsuite/src/module-elasticsuite-virtual-category/Model/Preview.php(87): Smile\ElasticsuiteVirtualCategory\Model\Preview->getQueryFilter()
#9 /app/fi4jxviizr2zw/vendor/smile/elasticsuite/src/module-elasticsuite-catalog/Model/ProductSorter/AbstractPreview.php(158): Smile\ElasticsuiteVirtualCategory\Model\Preview->prepareProductCollection()
#10 /app/fi4jxviizr2zw/vendor/smile/elasticsuite/src/module-elasticsuite-catalog/Model/ProductSorter/AbstractPreview.php(199): Smile\ElasticsuiteCatalog\Model\ProductSorter\AbstractPreview->getProductCollection()
#11 /app/fi4jxviizr2zw/vendor/smile/elasticsuite/src/module-elasticsuite-catalog/Model/ProductSorter/AbstractPreview.php(101): Smile\ElasticsuiteCatalog\Model\ProductSorter\AbstractPreview->getUnsortedProductData()
#12 /app/fi4jxviizr2zw/vendor/smile/elasticsuite/src/module-elasticsuite-virtual-category/Controller/Adminhtml/Category/Virtual/Preview.php(70): Smile\ElasticsuiteCatalog\Model\ProductSorter\AbstractPreview->getData()
#13 /app/fi4jxviizr2zw/vendor/magento/framework/Interception/Interceptor.php(58): Smile\ElasticsuiteVirtualCategory\Controller\Adminhtml\Category\Virtual\Preview->execute()
#14 /app/fi4jxviizr2zw/vendor/magento/framework/Interception/Interceptor.php(138): Smile\ElasticsuiteVirtualCategory\Controller\Adminhtml\Category\Virtual\Preview\Interceptor->___callParent()
#15 /app/fi4jxviizr2zw/vendor/magento/framework/Interception/Interceptor.php(153): Smile\ElasticsuiteVirtualCategory\Controller\Adminhtml\Category\Virtual\Preview\Interceptor->Magento\Framework\Interception\{closure}()
#16 /app/fi4jxviizr2zw/generated/code/Smile/ElasticsuiteVirtualCategory/Controller/Adminhtml/Category/Virtual/Preview/Interceptor.php(23): Smile\ElasticsuiteVirtualCategory\Controller\Adminhtml\Category\Virtual\Preview\Interceptor->___callPlugins()
#17 /app/fi4jxviizr2zw/vendor/magento/framework/App/Action/Action.php(111): Smile\ElasticsuiteVirtualCategory\Controller\Adminhtml\Category\Virtual\Preview\Interceptor->execute()
#18 /app/fi4jxviizr2zw/vendor/magento/module-backend/App/AbstractAction.php(151): Magento\Framework\App\Action\Action->dispatch()
#19 /app/fi4jxviizr2zw/vendor/magento/framework/Interception/Interceptor.php(58): Magento\Backend\App\AbstractAction->dispatch()
#20 /app/fi4jxviizr2zw/vendor/magento/framework/Interception/Interceptor.php(138): Smile\ElasticsuiteVirtualCategory\Controller\Adminhtml\Category\Virtual\Preview\Interceptor->___callParent()
#21 /app/fi4jxviizr2zw/vendor/weltpixel/m2-weltpixel-backend/Plugin/Utility.php(76): Smile\ElasticsuiteVirtualCategory\Controller\Adminhtml\Category\Virtual\Preview\Interceptor->Magento\Framework\Interception\{closure}()
#22 /app/fi4jxviizr2zw/vendor/magento/framework/Interception/Interceptor.php(135): WeltPixel\Backend\Plugin\Utility->aroundDispatch()
#23 /app/fi4jxviizr2zw/vendor/magento/module-backend/App/Action/Plugin/Authentication.php(145): Smile\ElasticsuiteVirtualCategory\Controller\Adminhtml\Category\Virtual\Preview\Interceptor->Magento\Framework\Interception\{closure}()
#24 /app/fi4jxviizr2zw/vendor/magento/framework/Interception/Interceptor.php(135): Magento\Backend\App\Action\Plugin\Authentication->aroundDispatch()
#25 /app/fi4jxviizr2zw/vendor/magento/framework/Interception/Interceptor.php(153): Smile\ElasticsuiteVirtualCategory\Controller\Adminhtml\Category\Virtual\Preview\Interceptor->Magento\Framework\Interception\{closure}()
#26 /app/fi4jxviizr2zw/generated/code/Smile/ElasticsuiteVirtualCategory/Controller/Adminhtml/Category/Virtual/Preview/Interceptor.php(32): Smile\ElasticsuiteVirtualCategory\Controller\Adminhtml\Category\Virtual\Preview\Interceptor->___callPlugins()
#27 /app/fi4jxviizr2zw/vendor/magento/framework/App/FrontController.php(245): Smile\ElasticsuiteVirtualCategory\Controller\Adminhtml\Category\Virtual\Preview\Interceptor->dispatch()
#28 /app/fi4jxviizr2zw/vendor/magento/framework/App/FrontController.php(212): Magento\Framework\App\FrontController->getActionResponse()
#29 /app/fi4jxviizr2zw/vendor/magento/framework/App/FrontController.php(147): Magento\Framework\App\FrontController->processRequest()
#30 /app/fi4jxviizr2zw/vendor/magento/framework/Interception/Interceptor.php(58): Magento\Framework\App\FrontController->dispatch()
#31 /app/fi4jxviizr2zw/vendor/magento/framework/Interception/Interceptor.php(138): Magento\Framework\App\FrontController\Interceptor->___callParent()
#32 /app/fi4jxviizr2zw/vendor/magento/framework/Interception/Interceptor.php(153): Magento\Framework\App\FrontController\Interceptor->Magento\Framework\Interception\{closure}()
#33 /app/fi4jxviizr2zw/generated/code/Magento/Framework/App/FrontController/Interceptor.php(23): Magento\Framework\App\FrontController\Interceptor->___callPlugins()
#34 /app/fi4jxviizr2zw/vendor/magento/framework/App/Http.php(116): Magento\Framework\App\FrontController\Interceptor->dispatch()
#35 /app/fi4jxviizr2zw/vendor/magento/framework/App/Bootstrap.php(264): Magento\Framework\App\Http->launch()
#36 /app/fi4jxviizr2zw/pub/index.php(30): Magento\Framework\App\Bootstrap->run()
#37 {main} [] []
```