### PR TITLE
[Tracker] Fix inline script execution on Checkout page according to CSP restrictions

### DIFF
--- a/src/module-elasticsuite-tracker/view/frontend/templates/config.phtml
+++ b/src/module-elasticsuite-tracker/view/frontend/templates/config.phtml
@@ -14,27 +14,47 @@
  * @license   Open Software License ("OSL") v. 3.0
  */
 ?>
-<?php /** @var $block Smile\ElasticsuiteTracker\Block\Config **/ ?>
-<?php $jsonHelper = $block->getJsonHelper(); ?>
-<?php if ($block->isEnabled()) : ?>
-<script>
+<?php
+/**
+ * @var $block Smile\ElasticsuiteTracker\Block\Config
+ * @var $secureRenderer Magento\Framework\View\Helper\SecureHtmlRenderer
+ */
+?>
+<?php
+$jsonHelper = $block->getJsonHelper();
+if ($block->isEnabled()) {
+$beaconUrl = $this->escapeJsQuote($block->getBeaconUrl());
+$telemetryUrl = $this->escapeJsQuote($block->getTelemetryUrl());
+$telemetryEnabled = $this->escapeJsQuote($block->isTelemetryEnabled());
+$sessionConfig = $jsonHelper->jsonEncode($block->getCookieConfig());
+
+$scriptString = "
 //<![CDATA[
 try {
-    let trackerConfig = {
-        beaconUrl        : '<?= /* @noEscape */ $this->escapeJsQuote($block->getBeaconUrl()); ?>',
-        telemetryUrl     : '<?= /* @noEscape */ $this->escapeJsQuote($block->getTelemetryUrl()); ?>',
-        telemetryEnabled : '<?= /* @noEscape */ $this->escapeJsQuote($block->isTelemetryEnabled()); ?>',
-        sessionConfig    : <?= /* @noEscape */ $jsonHelper->jsonEncode($block->getCookieConfig()); ?>,
-    };
-<?php if ($block->isUsingAPI()): ?>
-    trackerConfig.endpointUrl = '<?= /* @noEscape */ $this->escapeJsQuote($block->getEndpointUrl()); ?>';
-<?php endif; ?>
-    smileTracker.setConfig(trackerConfig);
+    smileTracker.setConfig({
+        beaconUrl: '{$beaconUrl}',
+        telemetryUrl: '{$telemetryUrl}',
+        telemetryEnabled: '{$telemetryEnabled}',
+        sessionConfig: '{$sessionConfig}'
+    });
+";
 
-    smileTracker.addPageVar('store_id', '<?= /* @noEscape */ $this->escapeJsQuote($block->getStoreId());?>');
+if ($block->isUsingAPI()) {
+    $endpointUrl = $this->escapeJsQuote($block->getEndpointUrl());
+    $scriptString .= "
+    trackerConfig.endpointUrl = '{$endpointUrl}';
+    ";
+}
 
-    require(['<?= /* @noEscape */ $block->getUserConsentScript() ?>'], function (userConsent) {
-        if (userConsent(<?= /* @noEscape */ $jsonHelper->jsonEncode($block->getUserConsentConfig()); ?>)) {
+$storeId = $this->escapeJsQuote($block->getStoreId());
+$userConsentScript = $this->escapeJsQuote($block->getUserConsentScript());
+$userConsentConfig = $jsonHelper->jsonEncode($block->getUserConsentConfig());
+
+$scriptString .= "
+    smileTracker.addPageVar('store_id', '{$storeId}');
+
+    require(['{$userConsentScript}'], function (userConsent) {
+        if (userConsent({$userConsentConfig})) {
             smileTracker.sendTag();
         }
     });
@@ -42,6 +62,8 @@ try {
     ;
 }
 //]]>
-</script>
+";
 
-<?php endif; ?>
+echo /* @noEscape */ $secureRenderer->renderTag('script', [], $scriptString, false);
+}
+?>

--- a/src/module-elasticsuite-tracker/view/frontend/templates/variables/page.phtml
+++ b/src/module-elasticsuite-tracker/view/frontend/templates/variables/page.phtml
@@ -14,18 +14,32 @@
  * @license   Open Software License ("OSL") v. 3.0
  */
 ?>
-<?php /** @var $block Smile\ElasticsuiteTracker\Block\Variables\AbstractBlock **/ ?>
-<?php $variables = $block->getVariables(); ?>
-<?php if (!empty($variables)) : ?>
-    <script>
-    <!--
-    try {
-    <?php foreach ($variables as $varName => $value) : ?>
-        smileTracker.addPageVar('<?php /* @noEscape */ echo $this->escapeJsQuote($varName)?>', '<?php /* @noEscape */ echo $block->stripTags($this->escapeJsQuote($value), null, true) ?>')
-    <?php endforeach; ?>
-    } catch (err) {
-        ;
-    }
-    //-->
-    </script>
-<?php endif; ?>
+<?php
+/**
+ * @var $block Smile\ElasticsuiteTracker\Block\Variables\AbstractBlock
+ * @var $secureRenderer Magento\Framework\View\Helper\SecureHtmlRenderer
+ */ ?>
+<?php
+$variables = $block->getVariables();
+if (!empty($variables)) {
+$scriptString = "
+//<![CDATA[
+try {
+";
+
+foreach ($variables as $varName => $value) {
+    $escapedVarName = $this->escapeJsQuote($varName);
+    $escapedValue = $block->stripTags($this->escapeJsQuote($value), null, true);
+    $scriptString .= "smileTracker.addPageVar('{$escapedVarName}', '{$escapedValue}');\n";
+}
+
+$scriptString .= "
+} catch (err) {
+    ;
+}
+//]]>
+";
+
+echo /* @noEscape */ $secureRenderer->renderTag('script', [], $scriptString, false);
+}
+?>


### PR DESCRIPTION
According to the CSP updates:
>The default CSP configuration for payment pages for Commerce Admin and storefront areas is now restrict mode. For all other pages, the default configuration is report-only mode. In releases prior to 2.4.7, CSP was configured in report-only mode for all pages.

now an inline scripts should be wrapped using `$secureRenderer` variable in the `.phtml` templates, but for some reason this blocks the work of our Tracker script on Checkout page.

See more:
- https://developer.adobe.com/commerce/php/development/security/content-security-policies/#troubleshooting 
- https://developer.adobe.com/commerce/php/development/security/content-security-policies/#whitelist-an-inline-script-or-style

