### PR TITLE
[Core] Prevent stacking SQL where prod. id conditions

### DIFF
--- a/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Fulltext/Collection.php
+++ b/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Fulltext/Collection.php
@@ -535,6 +535,7 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Product\Collection
             $docIds[] = 0;
         }
 
+        $this->getSelect()->reset(\Magento\Framework\DB\Select::WHERE);
         $this->getSelect()->where('e.entity_id IN (?)', ['in' => $docIds]);
         $orderList = join(',', $docIds);
         $this->getSelect()->reset(\Magento\Framework\DB\Select::ORDER);


### PR DESCRIPTION
That can happen when a single collection is used in a loop with different search queries each time.
While the Elasticsearch requests will be correct, the collection will only be correctly hydrated the first time.
Especially visible with a pageSize of 1 and search terms generating specific and non overlapping results sets.