### PR TITLE
Fix Call to a member function setName() on null 

### DIFF
--- a/src/module-elasticsuite-core/Search/Request/Query/Fulltext/QueryBuilder.php
+++ b/src/module-elasticsuite-core/Search/Request/Query/Fulltext/QueryBuilder.php
@@ -100,8 +100,8 @@ class QueryBuilder
             $relevanceConfig = $containerConfig->getRelevanceConfig();
             if ($relevanceConfig->getSpanMatchBoost()) {
                 $spanQuery = $this->getSpanQuery($containerConfig, $queryText, $relevanceConfig->getSpanMatchBoost());
-                $spanQuery->setName('SPAN');
                 if ($spanQuery !== null) {
+                    $spanQuery->setName('SPAN');
                     $queryParams = [
                         'must'      => [$query],
                         'should'    => [$spanQuery],


### PR DESCRIPTION
- in \Smile\ElasticsuiteCore\Search\Request\Query\Fulltext\QueryBuilder::create : 
-> move `$spanQuery->setName('SPAN');` after `if` condition 