### PR TITLE
Add Support for OpenSearch Settings in Setup ConfigOptions List

### DIFF
--- a/src/module-elasticsuite-core/Setup/ConfigOptionsList.php
+++ b/src/module-elasticsuite-core/Setup/ConfigOptionsList.php
@@ -167,10 +167,13 @@ class ConfigOptionsList implements ConfigOptionsListInterface
     private function getClientOptions(array $options, DeploymentConfig $deploymentConfig)
     {
         $clientOptions = [
-            'servers'           => $this->getServers($options, $deploymentConfig),
-            'enable_https_mode' => $this->readConfiguration($options, $deploymentConfig, self::INPUT_KEY_ES_SSL),
-            'http_auth_user'    => (string) $this->readConfiguration($options, $deploymentConfig, self::INPUT_KEY_ES_USER),
-            'http_auth_pwd'     => (string) $this->readConfiguration($options, $deploymentConfig, self::INPUT_KEY_ES_PASS),
+            'servers' => $this->getServers($options, $deploymentConfig),
+            'enable_https_mode' => $this->readConfiguration($options, $deploymentConfig, self::INPUT_KEY_ES_SSL) ?:
+                $this->readConfiguration($options, $deploymentConfig, SearchConfigOptionsList::INPUT_KEY_OPENSEARCH_ENABLE_AUTH),
+            'http_auth_user' => (string) $this->readConfiguration($options, $deploymentConfig, self::INPUT_KEY_ES_USER) ?:
+                (string) $this->readConfiguration($options, $deploymentConfig, SearchConfigOptionsList::INPUT_KEY_OPENSEARCH_USERNAME),
+            'http_auth_pwd' => (string) $this->readConfiguration($options, $deploymentConfig, self::INPUT_KEY_ES_PASS) ?:
+                (string) $this->readConfiguration($options, $deploymentConfig, SearchConfigOptionsList::INPUT_KEY_OPENSEARCH_PASSWORD),
         ];
 
         $clientOptions['enable_http_auth'] = !empty($clientOptions['http_auth_user']) && !empty($clientOptions['http_auth_pwd']);
@@ -193,8 +196,10 @@ class ConfigOptionsList implements ConfigOptionsListInterface
 
         if (null === $servers) {
             // Fallback to legacy Magento2 parameters.
-            $server  = $this->readConfiguration($options, $deploymentConfig, SearchConfigOptionsList::INPUT_KEY_ELASTICSEARCH_HOST);
-            $port    = $this->readConfiguration($options, $deploymentConfig, SearchConfigOptionsList::INPUT_KEY_ELASTICSEARCH_PORT);
+            $server = $this->readConfiguration($options, $deploymentConfig, SearchConfigOptionsList::INPUT_KEY_ELASTICSEARCH_HOST) ?:
+                $this->readConfiguration($options, $deploymentConfig, SearchConfigOptionsList::INPUT_KEY_OPENSEARCH_HOST);
+            $port = $this->readConfiguration($options, $deploymentConfig, SearchConfigOptionsList::INPUT_KEY_ELASTICSEARCH_PORT) ?:
+                $this->readConfiguration($options, $deploymentConfig, SearchConfigOptionsList::INPUT_KEY_OPENSEARCH_PORT);
             if ($server && $port) {
                 $servers = sprintf('%s:%s', $server, $port);
             }

--- a/src/module-elasticsuite-core/Setup/ConfigOptionsList.php
+++ b/src/module-elasticsuite-core/Setup/ConfigOptionsList.php
@@ -38,17 +38,17 @@ class ConfigOptionsList implements ConfigOptionsListInterface
      * Input key for the options
      */
     const INPUT_KEY_ES_HOSTS = 'es-hosts';
-    const INPUT_KEY_ES_SSL = 'es-enable-ssl';
-    const INPUT_KEY_ES_USER = 'es-user';
-    const INPUT_KEY_ES_PASS = 'es-pass';
+    const INPUT_KEY_ES_SSL   = 'es-enable-ssl';
+    const INPUT_KEY_ES_USER  = 'es-user';
+    const INPUT_KEY_ES_PASS  = 'es-pass';
 
     /**
      * Path to the values in the deployment config
      */
     const CONFIG_PATH_ES_HOSTS = self::CONF_PREFIX . '/servers';
-    const CONFIG_PATH_ES_SSL = self::CONF_PREFIX . '/enable_https_mode';
-    const CONFIG_PATH_ES_USER = self::CONF_PREFIX . '/http_auth_user';
-    const CONFIG_PATH_ES_PASS = self::CONF_PREFIX . '/http_auth_pwd';
+    const CONFIG_PATH_ES_SSL   = self::CONF_PREFIX . '/enable_https_mode';
+    const CONFIG_PATH_ES_USER  = self::CONF_PREFIX . '/http_auth_user';
+    const CONFIG_PATH_ES_PASS  = self::CONF_PREFIX . '/http_auth_pwd';
 
     /**
      * @var \Smile\ElasticsuiteCore\Client\ClientBuilder
@@ -80,8 +80,8 @@ class ConfigOptionsList implements ConfigOptionsListInterface
         SearchConfigOptionsList $searchConfigOptionsList,
         $fallbackMapping = []
     ) {
-        $this->clientBuilder = $clientBuilder;
-        $this->fallbackMapping = array_merge($this->fallbackMapping, $fallbackMapping);
+        $this->clientBuilder           = $clientBuilder;
+        $this->fallbackMapping         = array_merge($this->fallbackMapping, $fallbackMapping);
         $this->searchConfigOptionsList = $searchConfigOptionsList;
     }
 

--- a/src/module-elasticsuite-core/Setup/ConfigOptionsList.php
+++ b/src/module-elasticsuite-core/Setup/ConfigOptionsList.php
@@ -38,17 +38,17 @@ class ConfigOptionsList implements ConfigOptionsListInterface
      * Input key for the options
      */
     const INPUT_KEY_ES_HOSTS = 'es-hosts';
-    const INPUT_KEY_ES_SSL   = 'es-enable-ssl';
-    const INPUT_KEY_ES_USER  = 'es-user';
-    const INPUT_KEY_ES_PASS  = 'es-pass';
+    const INPUT_KEY_ES_SSL = 'es-enable-ssl';
+    const INPUT_KEY_ES_USER = 'es-user';
+    const INPUT_KEY_ES_PASS = 'es-pass';
 
     /**
      * Path to the values in the deployment config
      */
     const CONFIG_PATH_ES_HOSTS = self::CONF_PREFIX . '/servers';
-    const CONFIG_PATH_ES_SSL   = self::CONF_PREFIX . '/enable_https_mode';
-    const CONFIG_PATH_ES_USER  = self::CONF_PREFIX . '/http_auth_user';
-    const CONFIG_PATH_ES_PASS  = self::CONF_PREFIX . '/http_auth_pwd';
+    const CONFIG_PATH_ES_SSL = self::CONF_PREFIX . '/enable_https_mode';
+    const CONFIG_PATH_ES_USER = self::CONF_PREFIX . '/http_auth_user';
+    const CONFIG_PATH_ES_PASS = self::CONF_PREFIX . '/http_auth_pwd';
 
     /**
      * @var \Smile\ElasticsuiteCore\Client\ClientBuilder
@@ -80,8 +80,8 @@ class ConfigOptionsList implements ConfigOptionsListInterface
         SearchConfigOptionsList $searchConfigOptionsList,
         $fallbackMapping = []
     ) {
-        $this->clientBuilder           = $clientBuilder;
-        $this->fallbackMapping         = array_merge($this->fallbackMapping, $fallbackMapping);
+        $this->clientBuilder = $clientBuilder;
+        $this->fallbackMapping = array_merge($this->fallbackMapping, $fallbackMapping);
         $this->searchConfigOptionsList = $searchConfigOptionsList;
     }
 
@@ -166,15 +166,17 @@ class ConfigOptionsList implements ConfigOptionsListInterface
      */
     private function getClientOptions(array $options, DeploymentConfig $deploymentConfig)
     {
+        // phpcs:disable Squiz.WhiteSpace.OperatorSpacing.SpacingBefore
         $clientOptions = [
             'servers' => $this->getServers($options, $deploymentConfig),
-            'enable_https_mode' => $this->readConfiguration($options, $deploymentConfig, self::INPUT_KEY_ES_SSL) ?:
-                $this->readConfiguration($options, $deploymentConfig, SearchConfigOptionsList::INPUT_KEY_OPENSEARCH_ENABLE_AUTH),
-            'http_auth_user' => (string) $this->readConfiguration($options, $deploymentConfig, self::INPUT_KEY_ES_USER) ?:
-                (string) $this->readConfiguration($options, $deploymentConfig, SearchConfigOptionsList::INPUT_KEY_OPENSEARCH_USERNAME),
-            'http_auth_pwd' => (string) $this->readConfiguration($options, $deploymentConfig, self::INPUT_KEY_ES_PASS) ?:
-                (string) $this->readConfiguration($options, $deploymentConfig, SearchConfigOptionsList::INPUT_KEY_OPENSEARCH_PASSWORD),
+            'enable_https_mode' => $this->readConfiguration($options, $deploymentConfig, self::INPUT_KEY_ES_SSL)
+                ?: $this->readConfiguration($options, $deploymentConfig, SearchConfigOptionsList::INPUT_KEY_OPENSEARCH_ENABLE_AUTH),
+            'http_auth_user' => (string) $this->readConfiguration($options, $deploymentConfig, self::INPUT_KEY_ES_USER)
+                ?: (string) $this->readConfiguration($options, $deploymentConfig, SearchConfigOptionsList::INPUT_KEY_OPENSEARCH_USERNAME),
+            'http_auth_pwd' => (string) $this->readConfiguration($options, $deploymentConfig, self::INPUT_KEY_ES_PASS)
+                ?: (string) $this->readConfiguration($options, $deploymentConfig, SearchConfigOptionsList::INPUT_KEY_OPENSEARCH_PASSWORD),
         ];
+        // phpcs:enable Squiz.WhiteSpace.OperatorSpacing.SpacingBefore
 
         $clientOptions['enable_http_auth'] = !empty($clientOptions['http_auth_user']) && !empty($clientOptions['http_auth_pwd']);
 
@@ -196,10 +198,13 @@ class ConfigOptionsList implements ConfigOptionsListInterface
 
         if (null === $servers) {
             // Fallback to legacy Magento2 parameters.
-            $server = $this->readConfiguration($options, $deploymentConfig, SearchConfigOptionsList::INPUT_KEY_ELASTICSEARCH_HOST) ?:
-                $this->readConfiguration($options, $deploymentConfig, SearchConfigOptionsList::INPUT_KEY_OPENSEARCH_HOST);
-            $port = $this->readConfiguration($options, $deploymentConfig, SearchConfigOptionsList::INPUT_KEY_ELASTICSEARCH_PORT) ?:
-                $this->readConfiguration($options, $deploymentConfig, SearchConfigOptionsList::INPUT_KEY_OPENSEARCH_PORT);
+            // phpcs:disable Squiz.WhiteSpace.OperatorSpacing.SpacingBefore
+            $server = $this->readConfiguration($options, $deploymentConfig, SearchConfigOptionsList::INPUT_KEY_ELASTICSEARCH_HOST)
+                ?: $this->readConfiguration($options, $deploymentConfig, SearchConfigOptionsList::INPUT_KEY_OPENSEARCH_HOST);
+            $port = $this->readConfiguration($options, $deploymentConfig, SearchConfigOptionsList::INPUT_KEY_ELASTICSEARCH_PORT)
+                ?: $this->readConfiguration($options, $deploymentConfig, SearchConfigOptionsList::INPUT_KEY_OPENSEARCH_PORT);
+            // phpcs:enable Squiz.WhiteSpace.OperatorSpacing.SpacingBefore
+
             if ($server && $port) {
                 $servers = sprintf('%s:%s', $server, $port);
             }


### PR DESCRIPTION
This pull request introduces support for configuring OpenSearch settings within the Setup ConfigOptions list in ElasticSuite. By adding this feature, users can now specify OpenSearch-specific configurations, enhancing the flexibility and compatibility of ElasticSuite with OpenSearch.

