### PR TITLE
[Thesaurus] Cache variation according to container name

### DIFF
--- a/src/module-elasticsuite-thesaurus/Model/Index.php
+++ b/src/module-elasticsuite-thesaurus/Model/Index.php
@@ -173,8 +173,9 @@ class Index
     private function getCacheTags(ContainerConfigurationInterface $containerConfig)
     {
         $storeId = $containerConfig->getStoreId();
+        $containerName = $containerConfig->getName();
 
-        return [$this->getIndexAlias($storeId)];
+        return [$this->getIndexAlias($storeId), $containerName];
     }
 
     /**


### PR DESCRIPTION
Since the relevance configuration allows disabling synonyms and/or expansions for a given request type.