### PR TITLE
[Core] Fix #3334, adding support currency condition

### DIFF
--- a/src/module-elasticsuite-core/Search/Request/Query/Filter/QueryBuilder.php
+++ b/src/module-elasticsuite-core/Search/Request/Query/Filter/QueryBuilder.php
@@ -52,6 +52,8 @@ class QueryBuilder
         'fulltext' => 'queryText',
         'match'    => 'queryText',
         'in_set'   => 'values',
+        // Trick to silently ignore that condition if it slips along with a price range here from advanced search.
+        'currency' => 'currency',
     ];
 
     /**


### PR DESCRIPTION
Handles cases where \Magento\CatalogSearch\Model\Advanced::addFilters applies a 'price' condition with a range and an un-necessary 'currency' parameter.