### PR TITLE
[Tracking] Add query id in graphQL search response

### DIFF
--- a/src/module-elasticsuite-catalog-graph-ql/Model/Resolver/Products.php
+++ b/src/module-elasticsuite-catalog-graph-ql/Model/Resolver/Products.php
@@ -77,6 +77,7 @@ class Products implements ResolverInterface
                 'current_page' => $searchResult->getCurrentPage(),
                 'total_pages'  => $searchResult->getTotalPages(),
                 'is_spellchecked' => $searchResult->isSpellchecked(),
+                'query_id'     => $searchResult->getQueryId(),
             ],
             'search_result' => $searchResult,
             'layer_type'    => $layerType,

--- a/src/module-elasticsuite-catalog-graph-ql/Model/Resolver/Products/Query/Search.php
+++ b/src/module-elasticsuite-catalog-graph-ql/Model/Resolver/Products/Query/Search.php
@@ -114,6 +114,7 @@ class Search implements ProductQueryInterface
             'currentPage'          => $searchCriteria->getCurrentPage(),
             'totalPages'           => $maxPages,
             'isSpellchecked'       => $searchResults->__toArray()['is_spellchecked'] ?? false,
+            'queryId'              => $searchResults->__toArray()['query_id'] ?? null,
         ]);
     }
 

--- a/src/module-elasticsuite-catalog-graph-ql/Model/Resolver/Products/SearchResult.php
+++ b/src/module-elasticsuite-catalog-graph-ql/Model/Resolver/Products/SearchResult.php
@@ -44,4 +44,12 @@ class SearchResult extends \Magento\CatalogGraphQl\Model\Resolver\Products\Searc
     {
         return (bool) $this->data['isSpellchecked'] ?? false;
     }
+
+    /**
+     * @return ?int
+     */
+    public function getQueryId()
+    {
+        return $this->data['queryId'] ?? null;
+    }
 }

--- a/src/module-elasticsuite-catalog-graph-ql/etc/schema.graphqls
+++ b/src/module-elasticsuite-catalog-graph-ql/etc/schema.graphqls
@@ -20,4 +20,5 @@ type ViewMoreResult @doc(description: "The Products object is the top-level obje
 type SearchResultPageInfo
 {
     is_spellchecked: Boolean
+    query_id: Int
 }

--- a/src/module-elasticsuite-core/Model/Search.php
+++ b/src/module-elasticsuite-core/Model/Search.php
@@ -14,6 +14,11 @@
 
 namespace Smile\ElasticsuiteCore\Model;
 
+use Magento\Framework\Search\SearchEngineInterface;
+use Magento\Framework\Search\SearchResponseBuilder;
+use Smile\ElasticsuiteCore\Api\Search\ContextInterface;
+use Smile\ElasticsuiteCore\Model\Search\RequestBuilder;
+
 /**
  * SearchInterface implementation using elasticsuite.
  *
@@ -24,35 +29,43 @@ namespace Smile\ElasticsuiteCore\Model;
 class Search implements \Magento\Search\Api\SearchInterface
 {
     /**
-     * @var \Smile\ElasticsuiteCore\Model\Search\RequestBuilder
+     * @var RequestBuilder
      */
     private $searchRequestBuilder;
 
     /**
-     * @var \Magento\Framework\Search\SearchEngineInterface
+     * @var SearchEngineInterface
      */
     private $searchEngine;
 
     /**
-     * @var \Magento\Framework\Search\SearchResponseBuilder
+     * @var SearchResponseBuilder
      */
     private $searchResponseBuilder;
 
     /**
+     * @var ContextInterface
+     */
+    private $searchContext;
+
+    /**
      * Constructor.
      *
-     * @param \Magento\Framework\Search\SearchEngineInterface     $searchEngine          Search engine.
-     * @param \Smile\ElasticsuiteCore\Model\Search\RequestBuilder $searchRequestBuilder  Search request builder.
-     * @param \Magento\Framework\Search\SearchResponseBuilder     $searchResponseBuilder Search response builder.
+     * @param SearchEngineInterface $searchEngine          Search engine.
+     * @param RequestBuilder        $searchRequestBuilder  Search request builder.
+     * @param SearchResponseBuilder $searchResponseBuilder Search response builder.
+     * @param ContextInterface      $searchContext         Search context.
      */
     public function __construct(
-        \Magento\Framework\Search\SearchEngineInterface $searchEngine,
-        \Smile\ElasticsuiteCore\Model\Search\RequestBuilder $searchRequestBuilder,
-        \Magento\Framework\Search\SearchResponseBuilder $searchResponseBuilder
+        SearchEngineInterface $searchEngine,
+        RequestBuilder $searchRequestBuilder,
+        SearchResponseBuilder $searchResponseBuilder,
+        ContextInterface $searchContext
     ) {
-            $this->searchRequestBuilder  = $searchRequestBuilder;
-            $this->searchEngine          = $searchEngine;
-            $this->searchResponseBuilder = $searchResponseBuilder;
+        $this->searchRequestBuilder  = $searchRequestBuilder;
+        $this->searchEngine          = $searchEngine;
+        $this->searchResponseBuilder = $searchResponseBuilder;
+        $this->searchContext         = $searchContext;
     }
 
     /**
@@ -68,10 +81,13 @@ class Search implements \Magento\Search\Api\SearchInterface
         $searchResponse = $this->searchEngine->search($searchRequest);
         $searchResult   = $this->searchResponseBuilder->build($searchResponse);
 
+        $query = $this->searchContext->getCurrentSearchQuery();
+
         $totalCount = $searchResponse->count();
         $searchResult->setTotalCount($totalCount);
         $searchResult->setSearchCriteria($searchCriteria);
         $searchResult->setData('is_spellchecked', (bool) $searchRequest->isSpellchecked());
+        $searchResult->setData('query_id', ($query && $query->getId()) ? (int) $query->getId() : null);
 
         return $searchResult;
     }

--- a/src/module-elasticsuite-core/Test/Unit/Model/SearchTest.php
+++ b/src/module-elasticsuite-core/Test/Unit/Model/SearchTest.php
@@ -13,10 +13,11 @@
  */
 namespace Smile\ElasticsuiteCore\Test\Unit\Model;
 
-use Smile\ElasticsuiteCore\Model\Search;
+use Smile\ElasticsuiteCore\Api\Search\ContextInterface;
 
 /**
  * Search API unit testing.
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  *
  * @category  Smile
  * @package   Smile\ElasticsuiteCore
@@ -39,8 +40,9 @@ class SearchTest extends \PHPUnit\Framework\TestCase
         $searchEngine          = $this->getSearchEngine($documents, $docCount);
         $searchRequestBuilder  = $this->getSearchRequestBuilder();
         $searchResponseBuilder = $this->getSearchResponseBuilder();
+        $searchContext         = $this->createMock(ContextInterface::class);
 
-        $searchApi = new \Smile\ElasticsuiteCore\Model\Search($searchEngine, $searchRequestBuilder, $searchResponseBuilder);
+        $searchApi = new \Smile\ElasticsuiteCore\Model\Search($searchEngine, $searchRequestBuilder, $searchResponseBuilder, $searchContext);
 
         $searchCriteria = $this->createMock(\Magento\Framework\Api\Search\SearchCriteriaInterface::class);
         $searchResponse = $searchApi->search($searchCriteria);


### PR DESCRIPTION
In order to send it to the tracker in headless mode