### PR TITLE
Improve sortOrder direction fallback in case of empty string

### DIFF
--- a/src/module-elasticsuite-virtual-category/Model/Preview.php
+++ b/src/module-elasticsuite-virtual-category/Model/Preview.php
@@ -120,7 +120,11 @@ class Preview extends AbstractPreview
         $sortBy            = $this->getSortBy() ?? 'position';
         $directionFallback = $sortBy !== 'position' ? Collection::SORT_ORDER_ASC : Collection::SORT_ORDER_DESC;
 
-        $collection->setOrder($sortBy, $this->request->getParam('sort_direction', $directionFallback));
+        $direction = $this->request->getParam('sort_direction', $directionFallback);
+        if (empty($direction)) {
+            $direction = $directionFallback;
+        }
+        $collection->setOrder($sortBy, $direction);
         $collection->addPriceData(self::DEFAULT_CUSTOMER_GROUP_ID, $this->category->getStore()->getWebsiteId());
 
         return $collection;


### PR DESCRIPTION
when direction is an empty string, no results will be display in preview due to in error in the call to elastic:

```
{"error":{"root_cause":[{"type":"x_content_parse_exception","reason":"[1:50] [field_sort] failed to parse field [order]"}],"type":"x_content_parse_exception","reason":"[1:50] [field_sort] failed to parse field [order]","caused_by":{"type":"illegal_argument_exception","reason":"No enum constant org.elasticsearch.search.sort.SortOrder."}},"status":400}
```