### PR TITLE
[Core] No edge ngram decomposition in termVectors

### DIFF
--- a/src/module-elasticsuite-core/Search/Adapter/Elasticsuite/Spellchecker.php
+++ b/src/module-elasticsuite-core/Search/Adapter/Elasticsuite/Spellchecker.php
@@ -164,6 +164,7 @@ class Spellchecker implements SpellcheckerInterface
                 MappingInterface::DEFAULT_SPELLING_FIELD => $request->getQueryText(),
             ],
         ];
+        $perFieldAnalyzer = [];
 
         if ($request->isUsingReference()) {
             $doc['fields'][] = MappingInterface::DEFAULT_REFERENCE_FIELD . "." . FieldInterface::ANALYZER_REFERENCE;
@@ -172,7 +173,13 @@ class Spellchecker implements SpellcheckerInterface
 
         if ($request->isUsingEdgeNgram()) {
             $doc['fields'][] = MappingInterface::DEFAULT_EDGE_NGRAM_FIELD . "." . FieldInterface::ANALYZER_EDGE_NGRAM;
+            $perFieldAnalyzer[MappingInterface::DEFAULT_EDGE_NGRAM_FIELD . "." . FieldInterface::ANALYZER_EDGE_NGRAM]
+                = FieldInterface::ANALYZER_STANDARD;
             $doc['doc'][MappingInterface::DEFAULT_EDGE_NGRAM_FIELD] = $request->getQueryText();
+        }
+
+        if (!empty($perFieldAnalyzer)) {
+            $doc['per_field_analyzer'] = $perFieldAnalyzer;
         }
 
         $docs = [];

--- a/src/module-elasticsuite-core/Test/Unit/Search/Adapter/Elasticsuite/SpellcheckerTest.php
+++ b/src/module-elasticsuite-core/Test/Unit/Search/Adapter/Elasticsuite/SpellcheckerTest.php
@@ -184,6 +184,10 @@ class SpellcheckerTest extends TestCase
                             MappingInterface::DEFAULT_SEARCH_FIELD . "." . FieldInterface::ANALYZER_WHITESPACE,
                             MappingInterface::DEFAULT_EDGE_NGRAM_FIELD . "." . FieldInterface::ANALYZER_EDGE_NGRAM,
                         ],
+                        'per_field_analyzer' => [
+                            MappingInterface::DEFAULT_EDGE_NGRAM_FIELD . "." . FieldInterface::ANALYZER_EDGE_NGRAM
+                                => FieldInterface::ANALYZER_STANDARD,
+                        ],
                         'doc'             => [
                             MappingInterface::DEFAULT_SEARCH_FIELD   => $queryText,
                             MappingInterface::DEFAULT_SPELLING_FIELD => $queryText,
@@ -242,6 +246,10 @@ class SpellcheckerTest extends TestCase
                             MappingInterface::DEFAULT_SEARCH_FIELD . "." . FieldInterface::ANALYZER_WHITESPACE,
                             MappingInterface::DEFAULT_REFERENCE_FIELD . "." . FieldInterface::ANALYZER_REFERENCE,
                             MappingInterface::DEFAULT_EDGE_NGRAM_FIELD . "." . FieldInterface::ANALYZER_EDGE_NGRAM,
+                        ],
+                        'per_field_analyzer' => [
+                            MappingInterface::DEFAULT_EDGE_NGRAM_FIELD . "." . FieldInterface::ANALYZER_EDGE_NGRAM
+                            => FieldInterface::ANALYZER_STANDARD,
                         ],
                         'doc'             => [
                             MappingInterface::DEFAULT_SEARCH_FIELD   => $queryText,


### PR DESCRIPTION
To avoid false 'exact' matches on leading parts of a misspelled word. The logic is similar to the use of a distinct 'search_analyzer' on fields using 'standard_edge_ngram' as 'analyzer'.