### PR TITLE
[CatalogSearch] Forcefull add mview trigger removed in 2.4.6

### DIFF
--- a/src/module-elasticsuite-catalog/etc/mview.xml
+++ b/src/module-elasticsuite-catalog/etc/mview.xml
@@ -22,6 +22,8 @@
             <table name="catalog_category_product" entity_column="product_id" />
             <!-- This subscription aims to reindex products modified in the search terms merchandiser -->
             <table name="smile_elasticsuitecatalog_search_query_product_position" entity_column="product_id" />
+            <!-- Forcefully re-adding what was (or will depending on the version) removed in https://github.com/magento/magento2/commit/b3969936251e1a03427cd24c209abb6af3a0ce1b -->
+            <table name="cataloginventory_stock_item" entity_column="product_id" />
         </subscriptions>
     </view>
     <view id="elasticsuite_categories_fulltext" class="Smile\ElasticsuiteCatalog\Model\Category\Indexer\Fulltext" group="indexer">


### PR DESCRIPTION
which force a catalogsearch_fulltext reindex after the inventory has changes