### PR TITLE
Update default getNumberOfReplicas

### DIFF
--- a/src/module-elasticsuite-core/Index/IndexSettings.php
+++ b/src/module-elasticsuite-core/Index/IndexSettings.php
@@ -152,7 +152,7 @@ class IndexSettings implements IndexSettingsInterface
     {
         $settings = [
             'requests.cache.enable'            => true,
-            'number_of_replicas'               => 0,
+            'number_of_replicas'               => $this->helper->getNumberOfReplicas($indexIdentifier),
             'number_of_shards'                 => $this->helper->getNumberOfShards($indexIdentifier),
             'refresh_interval'                 => self::FULL_REINDEX_REFRESH_INTERVAL,
             'merge.scheduler.max_thread_count' => 1,


### PR DESCRIPTION
Our DevOps team reported that many indexes don't have proper number of replicas despite setting correct default values in config. 

It looks like during index creation the values is 0.

This PR changed default number_of_replicas to be read from system config.