### PR TITLE
Allow providing a value for "missing" values in sort order params

### DIFF
--- a/src/module-elasticsuite-core/Search/Request/SortOrder/SortOrderBuilder.php
+++ b/src/module-elasticsuite-core/Search/Request/SortOrder/SortOrderBuilder.php
@@ -165,7 +165,12 @@ class SortOrderBuilder
     private function getSortOrderParams(FieldInterface $field, array $sortOrderParams)
     {
         $sortOrderParams['field']   = $field->getMappingProperty(FieldInterface::ANALYZER_SORTABLE);
-        $sortOrderParams['missing'] = $field->getSortMissing($sortOrderParams['direction']);
+
+        // @codingStandardsIgnoreStart
+        if (!in_array($sortOrderParams['missing'] ?? false, [SortOrderInterface::MISSING_FIRST, SortOrderInterface::MISSING_LAST])) {
+            $sortOrderParams['missing'] = $field->getSortMissing($sortOrderParams['direction']);
+        }
+        // @codingStandardsIgnoreEnd
 
         if ($field->isNested() && !isset($sortOrderParams['nestedPath'])) {
             $sortOrderParams['nestedPath'] = $field->getNestedPath();


### PR DESCRIPTION
It should be possible to provide a value programmatically for the `missing` parameter on sort orders.
This PR allows that while preserving the previous behaviour for compatibility.