### PR TITLE
Fix #3578, add supporting PHP 8.4 for ElasticSuite 2.11.x

### DIFF
--- a/src/module-elasticsuite-catalog-graph-ql/Model/Resolver/Aggregations.php
+++ b/src/module-elasticsuite-catalog-graph-ql/Model/Resolver/Aggregations.php
@@ -78,8 +78,8 @@ class Aggregations implements ResolverInterface
         Field $field,
         $context,
         ResolveInfo $info,
-        array $value = null,
-        array $args = null
+        ?array $value = null,
+        ?array $args = null
     ) {
         if (!isset($value['layer_type']) || !isset($value['search_result'])) {
             return null;

--- a/src/module-elasticsuite-catalog-graph-ql/Model/Resolver/Layer/Filter/ViewMore.php
+++ b/src/module-elasticsuite-catalog-graph-ql/Model/Resolver/Layer/Filter/ViewMore.php
@@ -65,7 +65,7 @@ class ViewMore implements ResolverInterface
     /**
      * {@inheritDoc}
      */
-    public function resolve(Field $field, $context, ResolveInfo $info, array $value = null, array $args = null)
+    public function resolve(Field $field, $context, ResolveInfo $info, ?array $value = null, ?array $args = null)
     {
         $this->validateArgs($args);
         $this->viewMoreContext->setFilterName($args['filterName']);

--- a/src/module-elasticsuite-catalog-graph-ql/Model/Resolver/Products.php
+++ b/src/module-elasticsuite-catalog-graph-ql/Model/Resolver/Products.php
@@ -57,7 +57,7 @@ class Products implements ResolverInterface
     /**
      * {@inheritDoc}
      */
-    public function resolve(Field $field, $context, ResolveInfo $info, array $value = null, array $args = null)
+    public function resolve(Field $field, $context, ResolveInfo $info, ?array $value = null, ?array $args = null)
     {
         $this->validateArgs($args);
         $this->contextUpdater->updateSearchContext($args);

--- a/src/module-elasticsuite-catalog-graph-ql/Model/Resolver/Products/DataProvider/Product/CollectionProcessor/SearchCriteriaProcessor.php
+++ b/src/module-elasticsuite-catalog-graph-ql/Model/Resolver/Products/DataProvider/Product/CollectionProcessor/SearchCriteriaProcessor.php
@@ -20,7 +20,7 @@ use Magento\Framework\Api\SearchCriteria\CollectionProcessorInterface as SearchC
 use Magento\GraphQl\Model\Query\ContextInterface;
 
 /**
- * Dummmy Search Criteria Processor.
+ * Dummy Search Criteria Processor.
  * We do not need to filter again the product collection since the search engine is already doing it.
  *
  * @category Smile
@@ -36,7 +36,7 @@ class SearchCriteriaProcessor implements CollectionProcessorInterface
         Collection $collection,
         SearchCriteriaInterface $searchCriteria,
         array $attributeNames,
-        ContextInterface $context = null
+        ?ContextInterface $context = null
     ): Collection {
         return $collection;
     }

--- a/src/module-elasticsuite-catalog-graph-ql/Model/Resolver/Products/Query/Search.php
+++ b/src/module-elasticsuite-catalog-graph-ql/Model/Resolver/Products/Query/Search.php
@@ -79,7 +79,7 @@ class Search implements ProductQueryInterface
         FieldSelection $fieldSelection,
         ProductSearch $productProvider,
         SearchCriteriaBuilder $searchCriteriaBuilder,
-        Suggestions $suggestions = null
+        ?Suggestions $suggestions = null
     ) {
         $this->search                = $search;
         $this->searchResultFactory   = $searchResultFactory;

--- a/src/module-elasticsuite-catalog-graph-ql/Plugin/Resolver/LayerFilters.php
+++ b/src/module-elasticsuite-catalog-graph-ql/Plugin/Resolver/LayerFilters.php
@@ -64,8 +64,8 @@ class LayerFilters
         Field $field,
         $context,
         ResolveInfo $info,
-        array $value = null,
-        array $args = null
+        ?array $value = null,
+        ?array $args = null
     ) {
         if (!empty($value['search_result'])) {
             /** @var \Magento\CatalogGraphQl\Model\Resolver\Products\SearchResult $searchResult */

--- a/src/module-elasticsuite-catalog-optimizer/Model/Optimizer.php
+++ b/src/module-elasticsuite-catalog-optimizer/Model/Optimizer.php
@@ -61,15 +61,15 @@ class Optimizer extends \Magento\Framework\Model\AbstractModel implements Optimi
     /**
      * Class constructor
      *
-     * @param \Magento\Framework\Model\Context                        $context                     Context.
-     * @param \Magento\Framework\Registry                             $registry                    Registry.
-     * @param \Smile\ElasticsuiteCatalogRule\Model\RuleFactory        $ruleFactory                 Rule factory.
-     * @param \Magento\Framework\Stdlib\DateTime\Filter\Date          $dateFilter                  Date Filter.
-     * @param \Magento\Framework\Serialize\SerializerInterface        $serializer                  Serializer.
-     * @param Optimizer\Limitation\IdentitiesFactory                  $limitationIdentitiesFactory Limitation Identities.
-     * @param \Magento\Framework\Model\ResourceModel\AbstractResource $resource                    Resource.
-     * @param \Magento\Framework\Data\Collection\AbstractDb           $resourceCollection          Resource collection.
-     * @param array                                                   $data                        Data.
+     * @param \Magento\Framework\Model\Context                             $context                     Context.
+     * @param \Magento\Framework\Registry                                  $registry                    Registry.
+     * @param \Smile\ElasticsuiteCatalogRule\Model\RuleFactory             $ruleFactory                 Rule factory.
+     * @param \Magento\Framework\Stdlib\DateTime\Filter\Date               $dateFilter                  Date Filter.
+     * @param \Magento\Framework\Serialize\SerializerInterface             $serializer                  Serializer.
+     * @param Optimizer\Limitation\IdentitiesFactory                       $limitationIdentitiesFactory Limitation Identities.
+     * @param \Magento\Framework\Model\ResourceModel\AbstractResource|null $resource                    Resource.
+     * @param \Magento\Framework\Data\Collection\AbstractDb|null           $resourceCollection          Resource collection.
+     * @param array                                                        $data                        Data.
      */
     public function __construct(
         \Magento\Framework\Model\Context $context,
@@ -78,8 +78,8 @@ class Optimizer extends \Magento\Framework\Model\AbstractModel implements Optimi
         \Magento\Framework\Stdlib\DateTime\Filter\Date $dateFilter,
         \Magento\Framework\Serialize\SerializerInterface $serializer,
         Optimizer\Limitation\IdentitiesFactory $limitationIdentitiesFactory,
-        \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
-        \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
+        ?\Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
+        ?\Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
         array $data = []
     ) {
         parent::__construct($context, $registry, $resource, $resourceCollection, $data);

--- a/src/module-elasticsuite-catalog-optimizer/Model/Optimizer/Preview.php
+++ b/src/module-elasticsuite-catalog-optimizer/Model/Optimizer/Preview.php
@@ -102,7 +102,7 @@ class Preview
      * @param Preview\ResultsBuilder          $previewResultsBuilder     Preview Results Builder.
      * @param ContextInterface                $searchContext             Search Context.
      * @param CategoryInterface|null          $category                  Category Id to preview, if any.
-     * @param string                          $queryText                 Query Text.
+     * @param string|null                     $queryText                 Query Text.
      * @param int                             $size                      Preview size.
      * @param array                           $categoryPreviewContainers Category preview compatible containers.
      */
@@ -114,10 +114,10 @@ class Preview
         ContainerConfigurationInterface $containerConfig,
         Preview\ResultsBuilder $previewResultsBuilder,
         ContextInterface $searchContext,
-        CategoryInterface $category = null,
-        $queryText = null,
-        $size = 10,
-        $categoryPreviewContainers = ['catalog_view_container']
+        ?CategoryInterface $category = null,
+        ?string $queryText = null,
+        int $size = 10,
+        array $categoryPreviewContainers = ['catalog_view_container']
     ) {
         $this->size                   = $size;
         $this->previewItemFactory     = $previewItemFactory;

--- a/src/module-elasticsuite-catalog-optimizer/Model/ResourceModel/Optimizer/Collection.php
+++ b/src/module-elasticsuite-catalog-optimizer/Model/ResourceModel/Optimizer/Collection.php
@@ -56,8 +56,8 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
         \Magento\Framework\Data\Collection\Db\FetchStrategyInterface $fetchStrategy,
         \Magento\Framework\Event\ManagerInterface $eventManager,
         \Magento\Framework\Stdlib\DateTime\DateTime $date,
-        \Magento\Framework\DB\Adapter\AdapterInterface $connection = null,
-        \Magento\Framework\Model\ResourceModel\Db\AbstractDb $resource = null
+        ?\Magento\Framework\DB\Adapter\AdapterInterface $connection = null,
+        ?\Magento\Framework\Model\ResourceModel\Db\AbstractDb $resource = null
     ) {
         parent::__construct($entityFactory, $logger, $fetchStrategy, $eventManager, $connection, $resource);
 

--- a/src/module-elasticsuite-catalog-optimizer/Model/ResourceModel/Optimizer/Config/Attributes/Collection.php
+++ b/src/module-elasticsuite-catalog-optimizer/Model/ResourceModel/Optimizer/Config/Attributes/Collection.php
@@ -70,8 +70,8 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Product\Attribute\
         ManagerInterface $eventManager,
         Config $eavConfig,
         EavEntityFactory $eavEntityFactory,
-        AdapterInterface $connection = null,
-        AbstractDb $resource = null,
+        ?AdapterInterface $connection = null,
+        ?AbstractDb $resource = null,
         $availableBackendTypes = [],
         $nestedFieldAttributes = []
     ) {

--- a/src/module-elasticsuite-catalog-rule/Api/Data/ConditionInterface.php
+++ b/src/module-elasticsuite-catalog-rule/Api/Data/ConditionInterface.php
@@ -54,7 +54,7 @@ interface ConditionInterface extends \Magento\Framework\Api\ExtensibleDataInterf
      *
      * @return $this
      */
-    public function setConditions(array $conditions = null);
+    public function setConditions(?array $conditions = null);
 
     /**
      * Return the aggregator type

--- a/src/module-elasticsuite-catalog-rule/Model/Data/Condition.php
+++ b/src/module-elasticsuite-catalog-rule/Model/Data/Condition.php
@@ -60,7 +60,7 @@ class Condition extends AbstractSimpleObject implements ConditionInterface
     /**
      * {@inheritDoc}
      */
-    public function setConditions(array $conditions = null)
+    public function setConditions(?array $conditions = null)
     {
         return $this->setData(self::KEY_CONDITIONS, $conditions);
     }

--- a/src/module-elasticsuite-catalog/Model/Product/Indexer/Fulltext/Datasource/AttributeData.php
+++ b/src/module-elasticsuite-catalog/Model/Product/Indexer/Fulltext/Datasource/AttributeData.php
@@ -72,7 +72,7 @@ class AttributeData extends AbstractAttributeData implements DatasourceInterface
         AttributeHelper $attributeHelper,
         array $indexedBackendModels = [],
         array $forbiddenChildrenAttributes = [],
-        ScopeConfigInterface $scopeConfig = null
+        ?ScopeConfigInterface $scopeConfig = null
     ) {
         parent::__construct($resourceModel, $fieldFactory, $attributeHelper, $indexedBackendModels);
 

--- a/src/module-elasticsuite-catalog/Model/Product/Indexer/Fulltext/Datasource/PriceData.php
+++ b/src/module-elasticsuite-catalog/Model/Product/Indexer/Fulltext/Datasource/PriceData.php
@@ -73,7 +73,7 @@ class PriceData implements DatasourceInterface
         ResourceModel $resourceModel,
         AttributeResourceModel $attributeResourceModel,
         $priceReaderPool = [],
-        ScopeConfigInterface $scopeConfig = null
+        ?ScopeConfigInterface $scopeConfig = null
     ) {
         $this->resourceModel            = $resourceModel;
         $this->priceReaderPool          = $priceReaderPool;

--- a/src/module-elasticsuite-catalog/Model/ResourceModel/Category/Fulltext/Collection.php
+++ b/src/module-elasticsuite-catalog/Model/ResourceModel/Category/Fulltext/Collection.php
@@ -90,7 +90,7 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Category\Collectio
      * @param \Magento\Store\Model\StoreManagerInterface                   $storeManager      Store Manager
      * @param \Smile\ElasticsuiteCore\Search\Request\Builder               $requestBuilder    Search request builder.
      * @param \Magento\Search\Model\SearchEngine                           $searchEngine      Search engine
-     * @param \Magento\Framework\DB\Adapter\AdapterInterface               $connection        Db Connection.
+     * @param \Magento\Framework\DB\Adapter\AdapterInterface|null          $connection        Db Connection.
      * @param string                                                       $searchRequestName Search request name.
      */
     public function __construct(
@@ -106,8 +106,8 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Category\Collectio
         \Magento\Store\Model\StoreManagerInterface $storeManager,
         \Smile\ElasticsuiteCore\Search\Request\Builder $requestBuilder,
         \Magento\Search\Model\SearchEngine $searchEngine,
-        \Magento\Framework\DB\Adapter\AdapterInterface $connection = null,
-        $searchRequestName = 'category_search_container'
+        ?\Magento\Framework\DB\Adapter\AdapterInterface $connection = null,
+        string $searchRequestName = 'category_search_container'
     ) {
         parent::__construct(
             $entityFactory,

--- a/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Fulltext/Collection.php
+++ b/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Fulltext/Collection.php
@@ -154,8 +154,8 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Product\Collection
         \Smile\ElasticsuiteCore\Search\Request\Builder $requestBuilder,
         \Magento\Search\Model\SearchEngine $searchEngine,
         RequestFieldMapper $requestFieldMapper,
-        \Magento\Framework\DB\Adapter\AdapterInterface $connection = null,
-        $searchRequestName = 'catalog_view_container'
+        ?\Magento\Framework\DB\Adapter\AdapterInterface $connection = null,
+        string $searchRequestName = 'catalog_view_container'
     ) {
         parent::__construct(
             $entityFactory,

--- a/src/module-elasticsuite-catalog/Plugin/Catalog/Controller/Adminhtml/Category/SavePlugin.php
+++ b/src/module-elasticsuite-catalog/Plugin/Catalog/Controller/Adminhtml/Category/SavePlugin.php
@@ -52,7 +52,7 @@ class SavePlugin
      *
      * @return array
      */
-    public function afterStringToBoolConverting(Save $subject, array $result, array $data, array $stringToBoolInputs = null)
+    public function afterStringToBoolConverting(Save $subject, array $result, array $data, ?array $stringToBoolInputs = null)
     {
         return $this->stringToBoolConverting($result);
     }
@@ -63,12 +63,12 @@ class SavePlugin
      *
      * @SuppressWarnings(PHPMD.ElseExpression)
      *
-     * @param array $data               The data
-     * @param array $stringToBoolInputs The inputs
+     * @param array      $data               The data.
+     * @param array|null $stringToBoolInputs The inputs.
      *
-     * @return mixed
+     * @return array
      */
-    private function stringToBoolConverting($data, array $stringToBoolInputs = null)
+    private function stringToBoolConverting($data, ?array $stringToBoolInputs = null)
     {
         if (null === $stringToBoolInputs) {
             $stringToBoolInputs = $this->stringToBoolInputs;

--- a/src/module-elasticsuite-core/Api/Index/MappingInterface.php
+++ b/src/module-elasticsuite-core/Api/Index/MappingInterface.php
@@ -72,19 +72,19 @@ interface MappingInterface
     /**
      * Return array of indexed by mapping properties used in search and weight as values.
      *
-     * @param string|NULL          $analyzer     Search analyzer.
-     * @param string|NULL          $defaultField Default field added to the list of fields.
-     *                                           All field weighted with 1 will be ignored if present.
-     * @param integer              $boost        A multiplier applied to fields default weight.
-     * @param FieldFilterInterface $fieldFilter  A filter applied to fields.
+     * @param string|NULL               $analyzer     Search analyzer.
+     * @param string|NULL               $defaultField Default field added to the list of fields.
+     *                                                All field weighted with 1 will be ignored if present.
+     * @param integer                   $boost        A multiplier applied to fields default weight.
+     * @param FieldFilterInterface|null $fieldFilter  A filter applied to fields.
      *
      * @return float[]
      */
     public function getWeightedSearchProperties(
-        $analyzer = null,
-        $defaultField = null,
-        $boost = 1,
-        FieldFilterInterface $fieldFilter = null
+        ?string $analyzer = null,
+        ?string $defaultField = null,
+        int $boost = 1,
+        ?FieldFilterInterface $fieldFilter = null
     );
 
     /**

--- a/src/module-elasticsuite-core/Index/Mapping.php
+++ b/src/module-elasticsuite-core/Index/Mapping.php
@@ -165,10 +165,10 @@ class Mapping implements MappingInterface
      * {@inheritDoc}
      */
     public function getWeightedSearchProperties(
-        $analyzer = null,
-        $defaultField = null,
-        $boost = 1,
-        FieldFilterInterface $fieldFilter = null
+        ?string $analyzer = null,
+        ?string $defaultField = null,
+        int $boost = 1,
+        ?FieldFilterInterface $fieldFilter = null
     ) {
         $weightedFields = [];
         $fields         = $this->getFields();

--- a/src/module-elasticsuite-core/Model/ProductMetadata.php
+++ b/src/module-elasticsuite-core/Model/ProductMetadata.php
@@ -75,12 +75,12 @@ class ProductMetadata
      *
      * @param ComposerInformationProvider $composerInformationProvider Composer Information provider
      * @param string                      $packageName                 Self package name
-     * @param CacheInterface              $cache                       Cache interface
+     * @param CacheInterface|null         $cache                       Cache interface
      */
     public function __construct(
         ComposerInformationProvider $composerInformationProvider,
         string $packageName = 'smile/elasticsuite',
-        CacheInterface $cache = null
+        ?CacheInterface $cache = null
     ) {
         $this->composerInformationProvider = $composerInformationProvider;
         $this->packageName = $packageName;

--- a/src/module-elasticsuite-core/Model/ResourceModel/Search/Request/RelevanceConfig/Data/Collection/Scoped.php
+++ b/src/module-elasticsuite-core/Model/ResourceModel/Search/Request/RelevanceConfig/Data/Collection/Scoped.php
@@ -60,8 +60,8 @@ class Scoped extends \Magento\Framework\Model\ResourceModel\Db\Collection\Abstra
         ManagerInterface $eventManager,
         Data $resource,
         $scope,
-        AdapterInterface $connection = null,
-        $scopeCode = null
+        ?AdapterInterface $connection = null,
+        ?string $scopeCode = null
     ) {
         $this->scope = $scope;
         $this->scopeCode = $scopeCode;

--- a/src/module-elasticsuite-core/Search/Request.php
+++ b/src/module-elasticsuite-core/Search/Request.php
@@ -73,29 +73,29 @@ class Request extends \Magento\Framework\Search\Request implements RequestInterf
      * @param string               $name           Search request name.
      * @param string               $indexName      Index name.
      * @param QueryInterface       $query          Search query.
-     * @param QueryInterface       $filter         Search filter.
+     * @param QueryInterface|null  $filter         Search filter.
      * @param SortOrderInterface[] $sortOrders     Sort orders specification.
      * @param int|null             $from           Pagination from clause.
      * @param int|null             $size           Pagination page size clause.
      * @param Dimension[]          $dimensions     Searched store.
      * @param BucketInterface[]    $buckets        Search request aggregations definition.
-     * @param string               $spellingType   For fulltext query : the type of spellchecked applied.
-     * @param bool|int             $trackTotalHits Value of the 'track_total_hits' ES parameter.
-     * @param bool|int             $minScore       Value of the 'min_score' ES parameter.
+     * @param string|null          $spellingType   For fulltext query : the type of spellchecked applied.
+     * @param bool|int|null        $trackTotalHits Value of the 'track_total_hits' ES parameter.
+     * @param bool|int|null        $minScore       Value of the 'min_score' ES parameter.
      */
     public function __construct(
-        $name,
-        $indexName,
+        string $name,
+        string $indexName,
         QueryInterface $query,
-        QueryInterface $filter = null,
-        array $sortOrders = null,
-        $from = null,
-        $size = null,
+        ?QueryInterface $filter = null,
+        ?array $sortOrders = null,
+        ?int $from = null,
+        ?int $size = null,
         array $dimensions = [],
         array $buckets = [],
-        $spellingType = null,
-        $trackTotalHits = null,
-        $minScore = null
+        ?string $spellingType = null,
+        bool|int|null $trackTotalHits = null,
+        bool|int|null $minScore = null
     ) {
         parent::__construct($name, $indexName, $query, $from, $size, $dimensions, $buckets);
         $this->filter = $filter;

--- a/src/module-elasticsuite-core/Search/Request/Aggregation/Bucket/AbstractBucket.php
+++ b/src/module-elasticsuite-core/Search/Request/Aggregation/Bucket/AbstractBucket.php
@@ -75,19 +75,19 @@ abstract class AbstractBucket implements BucketInterface
      * @param MetricInterface[]   $metrics      Bucket metrics.
      * @param BucketInterface[]   $childBuckets Child buckets.
      * @param PipelineInterface[] $pipelines    Bucket pipelines.
-     * @param string              $nestedPath   Nested path for nested bucket.
-     * @param QueryInterface      $filter       Bucket filter.
-     * @param QueryInterface      $nestedFilter Nested filter for the bucket.
+     * @param string|null         $nestedPath   Nested path for nested bucket.
+     * @param QueryInterface|null $filter       Bucket filter.
+     * @param QueryInterface|null $nestedFilter Nested filter for the bucket.
      */
     public function __construct(
-        $name,
-        $field,
+        string $name,
+        string $field,
         array $metrics = [],
         array $childBuckets = [],
         array $pipelines = [],
-        $nestedPath = null,
-        QueryInterface $filter = null,
-        QueryInterface $nestedFilter = null
+        ?string $nestedPath = null,
+        ?QueryInterface $filter = null,
+        ?QueryInterface $nestedFilter = null
     ) {
         $this->name         = $name;
         $this->field        = $field;

--- a/src/module-elasticsuite-core/Search/Request/Aggregation/Bucket/DateHistogram.php
+++ b/src/module-elasticsuite-core/Search/Request/Aggregation/Bucket/DateHistogram.php
@@ -48,29 +48,29 @@ class DateHistogram extends Histogram
      * @param MetricInterface[]   $metrics          Bucket metrics.
      * @param BucketInterface[]   $childBuckets     Child buckets.
      * @param PipelineInterface[] $pipelines        Bucket pipelines.
-     * @param string              $nestedPath       Nested path for nested bucket.
-     * @param QueryInterface      $filter           Bucket filter.
-     * @param QueryInterface      $nestedFilter     Nested filter for the bucket.
-     * @param integer             $interval         Histogram interval.
-     * @param string              $calendarInterval Histogram interval.
+     * @param string|null         $nestedPath       Nested path for nested bucket.
+     * @param QueryInterface|null $filter           Bucket filter.
+     * @param QueryInterface|null $nestedFilter     Nested filter for the bucket.
+     * @param int                 $interval         Histogram interval.
+     * @param string|null         $calendarInterval Histogram interval.
      * @param string              $fixedInterval    Histogram interval.
      * @param integer             $minDocCount      Histogram min doc count.
      * @param array               $extendedBounds   Histogram extended bounds.
      */
     public function __construct(
-        $name,
-        $field,
+        string $name,
+        string $field,
         array $metrics = [],
         array $childBuckets = [],
         array $pipelines = [],
-        $nestedPath = null,
-        QueryInterface $filter = null,
-        QueryInterface $nestedFilter = null,
+        ?string $nestedPath = null,
+        ?QueryInterface $filter = null,
+        ?QueryInterface $nestedFilter = null,
         $interval = "1d", // Deprecated.
-        $calendarInterval = null,
-        $fixedInterval = "1d",
-        $minDocCount = 0,
-        $extendedBounds = []
+        ?string $calendarInterval = null,
+        string $fixedInterval = "1d",
+        int $minDocCount = 0,
+        array $extendedBounds = []
     ) {
         $this->calendarInterval = $calendarInterval;
         $this->fixedInterval    = $fixedInterval;

--- a/src/module-elasticsuite-core/Search/Request/Aggregation/Bucket/Histogram.php
+++ b/src/module-elasticsuite-core/Search/Request/Aggregation/Bucket/Histogram.php
@@ -53,25 +53,25 @@ class Histogram extends AbstractBucket
      * @param MetricInterface[]   $metrics        Bucket metrics.
      * @param BucketInterface[]   $childBuckets   Child buckets.
      * @param PipelineInterface[] $pipelines      Bucket pipelines.
-     * @param string              $nestedPath     Nested path for nested bucket.
-     * @param QueryInterface      $filter         Bucket filter.
-     * @param QueryInterface      $nestedFilter   Nested filter for the bucket.
+     * @param string|null         $nestedPath     Nested path for nested bucket.
+     * @param QueryInterface|null $filter         Bucket filter.
+     * @param QueryInterface|null $nestedFilter   Nested filter for the bucket.
      * @param integer             $interval       Histogram interval.
      * @param integer             $minDocCount    Histogram min doc count.
      * @param array               $extendedBounds Histogram extended bounds.
      */
     public function __construct(
-        $name,
-        $field,
+        string $name,
+        string $field,
         array $metrics = [],
         array $childBuckets = [],
         array $pipelines = [],
-        $nestedPath = null,
-        QueryInterface $filter = null,
-        QueryInterface $nestedFilter = null,
-        $interval = 1,
-        $minDocCount = 0,
-        $extendedBounds = []
+        ?string $nestedPath = null,
+        ?QueryInterface $filter = null,
+        ?QueryInterface $nestedFilter = null,
+        int $interval = 1,
+        int $minDocCount = 0,
+        array $extendedBounds = []
     ) {
         parent::__construct($name, $field, $metrics, $childBuckets, $pipelines, $nestedPath, $filter, $nestedFilter);
         $this->interval    = $interval;

--- a/src/module-elasticsuite-core/Search/Request/Aggregation/Bucket/Metric.php
+++ b/src/module-elasticsuite-core/Search/Request/Aggregation/Bucket/Metric.php
@@ -48,23 +48,23 @@ class Metric extends AbstractBucket
      * @param MetricInterface[]   $metrics      Bucket metrics.
      * @param BucketInterface[]   $childBuckets Child buckets.
      * @param PipelineInterface[] $pipelines    Bucket pipelines.
-     * @param string              $nestedPath   Nested path for nested bucket.
-     * @param QueryInterface      $filter       Bucket filter.
-     * @param QueryInterface      $nestedFilter Nested filter for the bucket.
+     * @param string|null         $nestedPath   Nested path for nested bucket.
+     * @param QueryInterface|null $filter       Bucket filter.
+     * @param QueryInterface|null $nestedFilter Nested filter for the bucket.
      * @param string              $metricType   Metric type.
      * @param array               $config       Metric extra config.
      */
     public function __construct(
-        $name,
-        $field,
+        string $name,
+        string $field,
         array $metrics = [],
         array $childBuckets = [],
         array $pipelines = [],
-        $nestedPath = null,
-        QueryInterface $filter = null,
-        QueryInterface $nestedFilter = null,
-        $metricType = MetricInterface::TYPE_STATS,
-        $config = []
+        ?string $nestedPath = null,
+        ?QueryInterface $filter = null,
+        ?QueryInterface $nestedFilter = null,
+        string $metricType = MetricInterface::TYPE_STATS,
+        array $config = []
     ) {
         parent::__construct($name, $field, $metrics, $childBuckets, $pipelines, $nestedPath, $filter, $nestedFilter);
 

--- a/src/module-elasticsuite-core/Search/Request/Aggregation/Bucket/QueryGroup.php
+++ b/src/module-elasticsuite-core/Search/Request/Aggregation/Bucket/QueryGroup.php
@@ -41,19 +41,19 @@ class QueryGroup extends AbstractBucket
      * @param MetricInterface[]   $metrics      Bucket metrics.
      * @param BucketInterface[]   $childBuckets Child buckets.
      * @param PipelineInterface[] $pipelines    Bucket pipelines.
-     * @param string              $nestedPath   Nested path for nested bucket.
-     * @param QueryInterface      $filter       Bucket filter.
-     * @param QueryInterface      $nestedFilter Nested filter for the bucket.
+     * @param string|null         $nestedPath   Nested path for nested bucket.
+     * @param QueryInterface|null $filter       Bucket filter.
+     * @param QueryInterface|null $nestedFilter Nested filter for the bucket.
      */
     public function __construct(
-        $name,
+        string $name,
         array $queries,
         array $metrics = [],
         array $childBuckets = [],
         array $pipelines = [],
-        $nestedPath = null,
-        QueryInterface $filter = null,
-        QueryInterface $nestedFilter = null
+        ?string $nestedPath = null,
+        ?QueryInterface $filter = null,
+        ?QueryInterface $nestedFilter = null
     ) {
         parent::__construct($name, $name, $metrics, $childBuckets, $pipelines, $nestedPath, $filter, $nestedFilter);
         $this->queries = $queries;

--- a/src/module-elasticsuite-core/Search/Request/Aggregation/Bucket/SignificantTerm.php
+++ b/src/module-elasticsuite-core/Search/Request/Aggregation/Bucket/SignificantTerm.php
@@ -61,25 +61,25 @@ class SignificantTerm extends AbstractBucket
      * @param MetricInterface[]   $metrics      Bucket metrics.
      * @param BucketInterface[]   $childBuckets Child buckets.
      * @param PipelineInterface[] $pipelines    Bucket pipelines.
-     * @param string              $nestedPath   Nested path for nested bucket.
-     * @param QueryInterface      $filter       Bucket filter.
-     * @param QueryInterface      $nestedFilter Nested filter for the bucket.
+     * @param string|null         $nestedPath   Nested path for nested bucket.
+     * @param QueryInterface|null $filter       Bucket filter.
+     * @param QueryInterface|null $nestedFilter Nested filter for the bucket.
      * @param integer             $size         Bucket size.
      * @param integer             $minDocCount  Min doc count.
      * @param string              $algotithm    Algorithm used
      */
     public function __construct(
-        $name,
-        $field,
+        string $name,
+        string $field,
         array $metrics = [],
         array $childBuckets = [],
         array $pipelines = [],
-        $nestedPath = null,
-        QueryInterface $filter = null,
-        QueryInterface $nestedFilter = null,
-        $size = 0,
-        $minDocCount = 5,
-        $algotithm = self::ALGORITHM_GND
+        ?string $nestedPath = null,
+        ?QueryInterface $filter = null,
+        ?QueryInterface $nestedFilter = null,
+        int $size = 0,
+        int $minDocCount = 5,
+        string $algotithm = self::ALGORITHM_GND
     ) {
         parent::__construct($name, $field, $metrics, $childBuckets, $pipelines, $nestedPath, $filter, $nestedFilter);
 

--- a/src/module-elasticsuite-core/Search/Request/Aggregation/Bucket/Term.php
+++ b/src/module-elasticsuite-core/Search/Request/Aggregation/Bucket/Term.php
@@ -63,29 +63,29 @@ class Term extends AbstractBucket
      * @param MetricInterface[]   $metrics      Bucket metrics.
      * @param BucketInterface[]   $childBuckets Child buckets.
      * @param PipelineInterface[] $pipelines    Bucket pipelines.
-     * @param string              $nestedPath   Nested path for nested bucket.
-     * @param QueryInterface      $filter       Bucket filter.
-     * @param QueryInterface      $nestedFilter Nested filter for the bucket.
+     * @param string|null         $nestedPath   Nested path for nested bucket.
+     * @param QueryInterface|null $filter       Bucket filter.
+     * @param QueryInterface|null $nestedFilter Nested filter for the bucket.
      * @param integer             $size         Bucket size.
      * @param string              $sortOrder    Bucket sort order.
      * @param array               $include      Include bucket filter.
      * @param array               $exclude      Exclude bucket filter.
-     * @param int                 $minDocCount  Min doc count bucket filter.
+     * @param int|null            $minDocCount  Min doc count bucket filter.
      */
     public function __construct(
-        $name,
-        $field,
+        string $name,
+        string $field,
         array $metrics = [],
         array $childBuckets = [],
         array $pipelines = [],
-        $nestedPath = null,
-        QueryInterface $filter = null,
-        QueryInterface $nestedFilter = null,
-        $size = 0,
-        $sortOrder = BucketInterface::SORT_ORDER_COUNT,
-        $include = [],
-        $exclude = [],
-        $minDocCount = null
+        ?string $nestedPath = null,
+        ?QueryInterface $filter = null,
+        ?QueryInterface $nestedFilter = null,
+        int $size = 0,
+        string $sortOrder = BucketInterface::SORT_ORDER_COUNT,
+        array $include = [],
+        array $exclude = [],
+        ?int $minDocCount = null
     ) {
         parent::__construct($name, $field, $metrics, $childBuckets, $pipelines, $nestedPath, $filter, $nestedFilter);
 

--- a/src/module-elasticsuite-core/Search/Request/Aggregation/Bucket/TopHits.php
+++ b/src/module-elasticsuite-core/Search/Request/Aggregation/Bucket/TopHits.php
@@ -54,21 +54,21 @@ class TopHits extends AbstractBucket
      * @param MetricInterface[]   $metrics      Bucket metrics.
      * @param BucketInterface[]   $childBuckets Child buckets.
      * @param PipelineInterface[] $pipelines    Bucket pipelines.
-     * @param string              $nestedPath   Nested path for nested bucket.
-     * @param QueryInterface      $filter       Bucket filter.
-     * @param QueryInterface      $nestedFilter Nested filter for the bucket.
+     * @param string|null         $nestedPath   Nested path for nested bucket.
+     * @param QueryInterface|null $filter       Bucket filter.
+     * @param QueryInterface|null $nestedFilter Nested filter for the bucket.
      */
     public function __construct(
-        $name,
+        string $name,
         array $sourceFields = [],
         int $size = 1,
-        $sortOrder = BucketInterface::SORT_ORDER_COUNT,
+        string $sortOrder = BucketInterface::SORT_ORDER_COUNT,
         array $metrics = [],
         array $childBuckets = [],
         array $pipelines = [],
-        $nestedPath = null,
-        QueryInterface $filter = null,
-        QueryInterface $nestedFilter = null
+        ?string $nestedPath = null,
+        ?QueryInterface $filter = null,
+        ?QueryInterface $nestedFilter = null
     ) {
         parent::__construct($name, $name, $metrics, $childBuckets, $pipelines, $nestedPath, $filter, $nestedFilter);
         $this->sourceFields = $sourceFields;

--- a/src/module-elasticsuite-core/Search/Request/ContainerConfiguration/RelevanceConfig.php
+++ b/src/module-elasticsuite-core/Search/Request/ContainerConfiguration/RelevanceConfig.php
@@ -149,23 +149,23 @@ class RelevanceConfig implements RelevanceConfigurationInterface
      *                                                                                   boost value) should apply
      */
     public function __construct(
-        $minimumShouldMatch,
-        $tieBreaker,
-        $phraseMatchBoost,
-        $cutOffFrequency,
-        FuzzinessConfigurationInterface $fuzziness = null,
-        $enablePhoneticSearch = false,
-        $spanMatchBoost = null,
-        $spanSize = null,
-        $minScore = null,
-        $useReferenceInExactMatchFilter = false,
-        $useDefaultAnalyzerInExactMatchFilter = false,
-        $useAllTokens = false,
-        $useReferenceAnalyzer = false,
-        $useEdgeNgramAnalyzer = false,
-        $exactMatchSingleTermBoostsCustomized = false,
-        $exactMatchSingleTermPhraseMatchBoost = null,
-        $exactMatchSingleTermSortableBoost = null
+        string $minimumShouldMatch,
+        float $tieBreaker,
+        int|null $phraseMatchBoost,
+        float $cutOffFrequency,
+        ?FuzzinessConfigurationInterface $fuzziness = null,
+        bool $enablePhoneticSearch = false,
+        ?int $spanMatchBoost = null,
+        int|null $spanSize = null,
+        int|null $minScore = null,
+        bool $useReferenceInExactMatchFilter = false,
+        bool $useDefaultAnalyzerInExactMatchFilter = false,
+        bool $useAllTokens = false,
+        bool $useReferenceAnalyzer = false,
+        bool $useEdgeNgramAnalyzer = false,
+        bool $exactMatchSingleTermBoostsCustomized = false,
+        ?int $exactMatchSingleTermPhraseMatchBoost = null,
+        ?int $exactMatchSingleTermSortableBoost = null
     ) {
         $this->minimumShouldMatch     = $minimumShouldMatch;
         $this->tieBreaker             = $tieBreaker;

--- a/src/module-elasticsuite-core/Search/Request/Query/Filtered.php
+++ b/src/module-elasticsuite-core/Search/Request/Query/Filtered.php
@@ -47,16 +47,16 @@ class Filtered implements QueryInterface
 
     /**
      *
-     * @param \Magento\Framework\Search\Request\QueryInterface $query  Query part of the filtered query.
-     * @param \Magento\Framework\Search\Request\QueryInterface $filter Filter part of the filtered query.
-     * @param string                                           $name   Query name.
-     * @param integer                                          $boost  Query boost.
+     * @param \Magento\Framework\Search\Request\QueryInterface|null $query  Query part of the filtered query.
+     * @param \Magento\Framework\Search\Request\QueryInterface|null $filter Filter part of the filtered query.
+     * @param string|null                                           $name   Query name.
+     * @param integer                                               $boost  Query boost.
      */
     public function __construct(
-        \Magento\Framework\Search\Request\QueryInterface $query = null,
-        \Magento\Framework\Search\Request\QueryInterface $filter = null,
-        $name = null,
-        $boost = QueryInterface::DEFAULT_BOOST_VALUE
+        ?\Magento\Framework\Search\Request\QueryInterface $query = null,
+        ?\Magento\Framework\Search\Request\QueryInterface $filter = null,
+        ?string $name = null,
+        int $boost = QueryInterface::DEFAULT_BOOST_VALUE
     ) {
         $this->name   = $name;
         $this->boost  = $boost;

--- a/src/module-elasticsuite-core/Search/Request/Query/Fulltext/QueryBuilder.php
+++ b/src/module-elasticsuite-core/Search/Request/Query/Fulltext/QueryBuilder.php
@@ -354,8 +354,8 @@ class QueryBuilder
      * Build an array of weighted fields to be searched with the ability to apply a filter callback method and a default field.
      *
      * @param ContainerConfigurationInterface $containerConfig Search request container config.
-     * @param string                          $analyzer        Target analyzer.
-     * @param FieldFilterInterface            $fieldFilter     Field filter.
+     * @param string|null                     $analyzer        Target analyzer.
+     * @param FieldFilterInterface|null       $fieldFilter     Field filter.
      * @param string|null                     $defaultField    Default search field.
      * @param integer                         $boost           Additional boost applied to the fields (multiplicative).
      *
@@ -363,10 +363,10 @@ class QueryBuilder
      */
     private function getWeightedFields(
         ContainerConfigurationInterface $containerConfig,
-        $analyzer = null,
-        FieldFilterInterface $fieldFilter = null,
-        $defaultField = null,
-        $boost = 1
+        ?string $analyzer = null,
+        ?FieldFilterInterface $fieldFilter = null,
+        ?string $defaultField = null,
+        int $boost = 1
     ) {
 
         $mapping = $containerConfig->getMapping();

--- a/src/module-elasticsuite-core/Search/Request/Query/MultiMatch.php
+++ b/src/module-elasticsuite-core/Search/Request/Query/MultiMatch.php
@@ -91,22 +91,22 @@ class MultiMatch implements QueryInterface
      * @param array                                $fields             Query fields as key with their weigth as values.
      * @param string                               $minimumShouldMatch Minimum should match for the match query.
      * @param integer                              $tieBreaker         Tie breaker for the multi_match query.
-     * @param string                               $name               Query name.
+     * @param string|null                          $name               Query name.
      * @param int                                  $boost              Query boost.
-     * @param FuzzinessConfigurationInterface|null $fuzzinessConfig    The fuzziness Configuration
-     * @param float                                $cutoffFrequency    Cutoff frequency.
+     * @param FuzzinessConfigurationInterface|null $fuzzinessConfig    The fuzziness Configuration.
+     * @param float|null                           $cutoffFrequency    Cutoff frequency.
      * @param string                               $matchType          The match type.
      */
     public function __construct(
-        $queryText,
+        string $queryText,
         array $fields,
-        $minimumShouldMatch = self::DEFAULT_MINIMUM_SHOULD_MATCH,
-        $tieBreaker = self::DEFAULT_TIE_BREAKER,
-        $name = null,
-        $boost = QueryInterface::DEFAULT_BOOST_VALUE,
-        FuzzinessConfigurationInterface $fuzzinessConfig = null,
-        $cutoffFrequency = null,
-        $matchType = self::DEFAULT_MATCH_TYPE
+        string $minimumShouldMatch = self::DEFAULT_MINIMUM_SHOULD_MATCH,
+        int $tieBreaker = self::DEFAULT_TIE_BREAKER,
+        ?string $name = null,
+        int $boost = QueryInterface::DEFAULT_BOOST_VALUE,
+        ?FuzzinessConfigurationInterface $fuzzinessConfig = null,
+        ?float $cutoffFrequency = null,
+        string $matchType = self::DEFAULT_MATCH_TYPE
     ) {
         $this->name               = $name;
         $this->queryText          = $queryText;

--- a/src/module-elasticsuite-core/Search/Request/Query/Nested.php
+++ b/src/module-elasticsuite-core/Search/Request/Query/Nested.php
@@ -58,18 +58,18 @@ class Nested implements QueryInterface
 
     /**
      *
-     * @param string                                           $path      Nested path.
-     * @param \Magento\Framework\Search\Request\QueryInterface $query     Nested query.
-     * @param string                                           $scoreMode Score mode of the nested query..
-     * @param string                                           $name      Query name.
-     * @param integer                                          $boost     Query boost.
+     * @param string                                                $path      Nested path.
+     * @param \Magento\Framework\Search\Request\QueryInterface|null $query     Nested query.
+     * @param string                                                $scoreMode Score mode of the nested query.
+     * @param string|null                                           $name      Query name.
+     * @param integer                                               $boost     Query boost.
      */
     public function __construct(
-        $path,
-        \Magento\Framework\Search\Request\QueryInterface $query = null,
-        $scoreMode = self::SCORE_MODE_NONE,
-        $name = null,
-        $boost = QueryInterface::DEFAULT_BOOST_VALUE
+        string $path,
+        ?\Magento\Framework\Search\Request\QueryInterface $query = null,
+        string $scoreMode = self::SCORE_MODE_NONE,
+        ?string $name = null,
+        int $boost = QueryInterface::DEFAULT_BOOST_VALUE
     ) {
         $this->name      = $name;
         $this->boost     = $boost;

--- a/src/module-elasticsuite-core/Search/Request/Query/Not.php
+++ b/src/module-elasticsuite-core/Search/Request/Query/Not.php
@@ -42,14 +42,14 @@ class Not implements QueryInterface
 
     /**
      * Constructor.
-     * @param \Magento\Framework\Search\Request\QueryInterface $query Negated query.
-     * @param string                                           $name  Query name.
-     * @param integer                                          $boost Query boost.
+     * @param \Magento\Framework\Search\Request\QueryInterface|null $query Negated query.
+     * @param string|null                                           $name  Query name.
+     * @param integer                                               $boost Query boost.
      */
     public function __construct(
-        \Magento\Framework\Search\Request\QueryInterface $query = null,
-        $name = null,
-        $boost = QueryInterface::DEFAULT_BOOST_VALUE
+        ?\Magento\Framework\Search\Request\QueryInterface $query = null,
+        ?string $name = null,
+        int $boost = QueryInterface::DEFAULT_BOOST_VALUE
     ) {
         $this->name      = $name;
         $this->boost     = $boost;

--- a/src/module-elasticsuite-core/Search/Request/Query/Span/SpanContaining.php
+++ b/src/module-elasticsuite-core/Search/Request/Query/Span/SpanContaining.php
@@ -53,13 +53,13 @@ class SpanContaining implements SpanQueryInterface
      *
      * @param \Smile\ElasticsuiteCore\Search\Request\Query\SpanQueryInterface $big    Span Query of the "big" clause
      * @param \Smile\ElasticsuiteCore\Search\Request\Query\SpanQueryInterface $little Span Query of the "little" clause
-     * @param string                                                          $name   Query Name
+     * @param string|null                                                     $name   Query Name
      * @param int                                                             $boost  Query Boost
      */
     public function __construct(
         SpanQueryInterface $big,
         SpanQueryInterface $little,
-        string             $name = null,
+        ?string            $name = null,
         int                $boost = QueryInterface::DEFAULT_BOOST_VALUE
     ) {
         $this->big    = $big;

--- a/src/module-elasticsuite-core/Search/Request/Query/Span/SpanFieldMasking.php
+++ b/src/module-elasticsuite-core/Search/Request/Query/Span/SpanFieldMasking.php
@@ -50,16 +50,16 @@ class SpanFieldMasking implements SpanQueryInterface
     /**
      * The SpanFieldMasking query produce an Elasticsearch span_field_masking query.
      *
-     * @param \Smile\ElasticsuiteCore\Search\Request\Query\SpanQueryInterface $query Span Query
-     * @param string                                                          $field Field
-     * @param string|null                                                     $name  Query Name
-     * @param                                                                 $boost Boost
+     * @param \Smile\ElasticsuiteCore\Search\Request\Query\SpanQueryInterface $query Span Query.
+     * @param string                                                          $field Field.
+     * @param string|null                                                     $name  Query Name.
+     * @param integer                                                         $boost Boost.
      */
     public function __construct(
         SpanQueryInterface $query,
         string $field,
-        string $name = null,
-        $boost = QueryInterface::DEFAULT_BOOST_VALUE
+        ?string $name = null,
+        int $boost = QueryInterface::DEFAULT_BOOST_VALUE
     ) {
         $this->query = $query;
         $this->field = $field;

--- a/src/module-elasticsuite-core/Search/Request/Query/Span/SpanNear.php
+++ b/src/module-elasticsuite-core/Search/Request/Query/Span/SpanNear.php
@@ -65,11 +65,11 @@ class SpanNear implements SpanQueryInterface
      * @param string      $boost   Query boost
      */
     public function __construct(
-        array  $clauses = [],
-        int    $slop = 12,
-        bool   $inOrder = true,
-        string $name = null,
-        string $boost = QueryInterface::DEFAULT_BOOST_VALUE
+        array   $clauses = [],
+        int     $slop = 12,
+        bool    $inOrder = true,
+        ?string $name = null,
+        string  $boost = QueryInterface::DEFAULT_BOOST_VALUE
     ) {
         $this->clauses = $clauses;
         $this->slop    = $slop;

--- a/src/module-elasticsuite-core/Search/Request/Query/Span/SpanNot.php
+++ b/src/module-elasticsuite-core/Search/Request/Query/Span/SpanNot.php
@@ -52,13 +52,13 @@ class SpanNot implements SpanQueryInterface
      *
      * @param \Smile\ElasticsuiteCore\Search\Request\Query\SpanQueryInterface $include Span Query of the "include" clause
      * @param \Smile\ElasticsuiteCore\Search\Request\Query\SpanQueryInterface $exclude Span Query of the "exclude" clause
-     * @param string                                                          $name    Query Name
+     * @param string|null                                                     $name    Query Name
      * @param int                                                             $boost   Query Boost
      */
     public function __construct(
         SpanQueryInterface $include,
         SpanQueryInterface $exclude,
-        string             $name = null,
+        ?string            $name = null,
         int                $boost = QueryInterface::DEFAULT_BOOST_VALUE
     ) {
         $this->include = $include;

--- a/src/module-elasticsuite-core/Search/Request/Query/Span/SpanOr.php
+++ b/src/module-elasticsuite-core/Search/Request/Query/Span/SpanOr.php
@@ -50,9 +50,9 @@ class SpanOr implements SpanQueryInterface
      * @param string      $boost   Query boost
      */
     public function __construct(
-        array  $clauses = [],
-        string $name = null,
-        string $boost = QueryInterface::DEFAULT_BOOST_VALUE
+        array   $clauses = [],
+        ?string $name    = null,
+        string  $boost   = QueryInterface::DEFAULT_BOOST_VALUE
     ) {
         $this->clauses = $clauses;
         $this->name    = $name;

--- a/src/module-elasticsuite-core/Search/Request/Query/Span/SpanWithin.php
+++ b/src/module-elasticsuite-core/Search/Request/Query/Span/SpanWithin.php
@@ -58,7 +58,7 @@ class SpanWithin implements SpanQueryInterface
     public function __construct(
         SpanQueryInterface $big,
         SpanQueryInterface $little,
-        string             $name = null,
+        ?string            $name = null,
         int                $boost = QueryInterface::DEFAULT_BOOST_VALUE
     ) {
         $this->big    = $big;

--- a/src/module-elasticsuite-core/Search/Request/Query/Vector/Opensearch/Neural.php
+++ b/src/module-elasticsuite-core/Search/Request/Query/Vector/Opensearch/Neural.php
@@ -72,7 +72,7 @@ class Neural implements QueryInterface
         string $field = self::DEFAULT_EMBEDDING_FIELD,
         ?string $name = null,
         float $boost = QueryInterface::DEFAULT_BOOST_VALUE,
-        string $modelId = null
+        ?string $modelId = null
     ) {
         $this->field     = $field;
         $this->queryText = $queryText;

--- a/src/module-elasticsuite-core/Search/Request/SortOrder/Nested.php
+++ b/src/module-elasticsuite-core/Search/Request/SortOrder/Nested.php
@@ -43,22 +43,22 @@ class Nested extends Standard
 
     /**
      * Constructor.
-     * @param string         $field        Sort order field.
-     * @param string         $direction    Sort order direction.
-     * @param string         $nestedPath   Nested sort path.
-     * @param QueryInterface $nestedFilter The filter applied to the nested sort.
-     * @param string         $scoreMode    Method used to aggregate the sort if there is many match for the filter.
-     * @param string         $name         Sort order name.
-     * @param string         $missing      How to treat missing values.
+     * @param string              $field        Sort order field.
+     * @param string              $direction    Sort order direction.
+     * @param string              $nestedPath   Nested sort path.
+     * @param QueryInterface|null $nestedFilter The filter applied to the nested sort.
+     * @param string              $scoreMode    Method used to aggregate the sort if there is many match for the filter.
+     * @param string|null         $name         Sort order name.
+     * @param string|null         $missing      How to treat missing values.
      */
     public function __construct(
         $field,
         $direction,
         $nestedPath,
-        QueryInterface $nestedFilter = null,
-        $scoreMode = self::SCORE_MODE_MIN,
-        $name = null,
-        $missing = null
+        ?QueryInterface $nestedFilter = null,
+        string $scoreMode = self::SCORE_MODE_MIN,
+        ?string $name = null,
+        ?string $missing = null
     ) {
         parent::__construct($field, $direction, $name, $missing);
 

--- a/src/module-elasticsuite-thesaurus/Model/ResourceModel/Thesaurus/Collection.php
+++ b/src/module-elasticsuite-thesaurus/Model/ResourceModel/Thesaurus/Collection.php
@@ -61,8 +61,8 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
      * @param \Magento\Framework\Event\ManagerInterface                    $eventManager   Event Manager
      * @param \Magento\Store\Model\StoreManagerInterface                   $storeManager   Store Manager
      * @param \Magento\Framework\DB\Helper                                 $resourceHelper Resource Helper
-     * @param \Magento\Framework\DB\Adapter\AdapterInterface               $connection     Database Connection
-     * @param \Magento\Framework\Model\ResourceModel\Db\AbstractDb         $resource       Abstract Resource
+     * @param \Magento\Framework\DB\Adapter\AdapterInterface|null          $connection     Database Connection
+     * @param \Magento\Framework\Model\ResourceModel\Db\AbstractDb|null    $resource       Abstract Resource
      */
     public function __construct(
         \Magento\Framework\Data\Collection\EntityFactoryInterface $entityFactory,
@@ -71,8 +71,8 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
         \Magento\Framework\Event\ManagerInterface $eventManager,
         \Magento\Store\Model\StoreManagerInterface $storeManager,
         \Magento\Framework\DB\Helper $resourceHelper,
-        \Magento\Framework\DB\Adapter\AdapterInterface $connection = null,
-        \Magento\Framework\Model\ResourceModel\Db\AbstractDb $resource = null
+        ?\Magento\Framework\DB\Adapter\AdapterInterface $connection = null,
+        ?\Magento\Framework\Model\ResourceModel\Db\AbstractDb $resource = null
     ) {
         $this->storeManager = $storeManager;
         $this->resourceHelper = $resourceHelper;

--- a/src/module-elasticsuite-thesaurus/Model/Thesaurus.php
+++ b/src/module-elasticsuite-thesaurus/Model/Thesaurus.php
@@ -102,16 +102,16 @@ class Thesaurus extends \Magento\Framework\Model\AbstractModel implements Thesau
      *
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      *
-     * @param \Magento\Framework\Model\Context                        $context            Magento Context
-     * @param \Magento\Framework\Registry                             $registry           Magento Registry
-     * @param IndexerRegistry                                         $indexerRegistry    Indexers registry
-     * @param ThesaurusFactory                                        $thesaurusFactory   Thesaurus Factory
-     * @param ResourceConnection                                      $resourceConnection Resource Connection
-     * @param \Magento\Store\Model\StoreManagerInterface              $storeManager       Store Manager
-     * @param ManagerInterface                                        $messageManager     Message Manager
-     * @param \Magento\Framework\Model\ResourceModel\AbstractResource $resource           Magento Resource
-     * @param \Magento\Framework\Data\Collection\AbstractDb           $resourceCollection Magento Collection
-     * @param array                                                   $data               Magento Data
+     * @param \Magento\Framework\Model\Context                             $context            Magento Context.
+     * @param \Magento\Framework\Registry                                  $registry           Magento Registry.
+     * @param IndexerRegistry                                              $indexerRegistry    Indexers registry.
+     * @param ThesaurusFactory                                             $thesaurusFactory   Thesaurus Factory.
+     * @param ResourceConnection                                           $resourceConnection Resource Connection.
+     * @param \Magento\Store\Model\StoreManagerInterface                   $storeManager       Store Manager.
+     * @param ManagerInterface                                             $messageManager     Message Manager.
+     * @param \Magento\Framework\Model\ResourceModel\AbstractResource|null $resource           Magento Resource.
+     * @param \Magento\Framework\Data\Collection\AbstractDb|null           $resourceCollection Magento Collection.
+     * @param array                                                        $data               Magento Data.
      */
     public function __construct(
         \Magento\Framework\Model\Context $context,
@@ -121,8 +121,8 @@ class Thesaurus extends \Magento\Framework\Model\AbstractModel implements Thesau
         ResourceConnection $resourceConnection,
         StoreManagerInterface $storeManager,
         ManagerInterface $messageManager,
-        \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
-        \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
+        ?\Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
+        ?\Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
         array $data = []
     ) {
         $this->indexerRegistry    = $indexerRegistry;

--- a/src/module-elasticsuite-tracker/Api/CustomerTrackingServiceInterface.php
+++ b/src/module-elasticsuite-tracker/Api/CustomerTrackingServiceInterface.php
@@ -49,7 +49,7 @@ interface CustomerTrackingServiceInterface
      *
      * @return void
      */
-    public function anonymizeCustomerData(int $customerId, \DateTime $delay = null);
+    public function anonymizeCustomerData(int $customerId, ?\DateTime $delay = null);
 
     /**
      * Process cleaning of all expired customer data.

--- a/src/module-elasticsuite-tracker/Console/CheckData.php
+++ b/src/module-elasticsuite-tracker/Console/CheckData.php
@@ -52,7 +52,7 @@ class CheckData extends Command
      *
      * @throws LogicException When the command name is empty
      */
-    public function __construct(DataChecker $checker, StoreManagerInterface $storeManager, string $name = null)
+    public function __construct(DataChecker $checker, StoreManagerInterface $storeManager, ?string $name = null)
     {
         parent::__construct($name);
         $this->checker = $checker;

--- a/src/module-elasticsuite-tracker/Console/FixData.php
+++ b/src/module-elasticsuite-tracker/Console/FixData.php
@@ -52,7 +52,7 @@ class FixData extends Command
      *
      * @throws LogicException When the command name is empty
      */
-    public function __construct(DataChecker $checker, StoreManagerInterface $storeManager, string $name = null)
+    public function __construct(DataChecker $checker, StoreManagerInterface $storeManager, ?string $name = null)
     {
         parent::__construct($name);
         $this->checker = $checker;

--- a/src/module-elasticsuite-tracker/Model/Customer/TrackingService.php
+++ b/src/module-elasticsuite-tracker/Model/Customer/TrackingService.php
@@ -95,7 +95,7 @@ class TrackingService implements \Smile\ElasticsuiteTracker\Api\CustomerTracking
     /**
      * {@inheritdoc}
      */
-    public function anonymizeCustomerData(int $customerId, \DateTime $delay = null)
+    public function anonymizeCustomerData(int $customerId, ?\DateTime $delay = null)
     {
         // If delay is not null, apply this delay to the customer data.
         if ($delay !== null) {

--- a/src/module-elasticsuite-virtual-category/Model/Preview.php
+++ b/src/module-elasticsuite-virtual-category/Model/Preview.php
@@ -80,8 +80,8 @@ class Preview extends AbstractPreview
      * @param ContextInterface          $searchContext            Search Context
      * @param int                       $size                     Preview size.
      * @param string                    $search                   Preview search.
-     * @param RequestInterface          $request                  HTTP Request.
-     * @param Config                    $categoryConfig           Category config.
+     * @param RequestInterface|null     $request                  HTTP Request.
+     * @param Config|null               $categoryConfig           Category config.
      */
     public function __construct(
         CategoryInterface $category,
@@ -89,10 +89,10 @@ class Preview extends AbstractPreview
         ItemDataFactory $previewItemFactory,
         QueryFactory $queryFactory,
         ContextInterface $searchContext,
-        $size = 10,
-        $search = '',
-        RequestInterface $request = null,
-        Config $categoryConfig = null
+        int $size = 10,
+        string $search = '',
+        ?RequestInterface $request = null,
+        ?Config $categoryConfig = null
     ) {
         parent::__construct($productCollectionFactory, $previewItemFactory, $queryFactory, $category->getStoreId(), $size, $search);
         $this->category      = $category;

--- a/src/module-elasticsuite-virtual-category/Model/Rule.php
+++ b/src/module-elasticsuite-virtual-category/Model/Rule.php
@@ -382,7 +382,7 @@ class Rule extends \Smile\ElasticsuiteCatalogRule\Model\Rule implements VirtualR
      * @return CategoryInterface
      * @throws NoSuchEntityException
      */
-    private function getRootCategory(int $rootCategoryId, int $storeId = null)
+    private function getRootCategory(int $rootCategoryId, ?int $storeId = null)
     {
         $cacheKey = $storeId ?? 'all';
         if (!isset($this->instances[$rootCategoryId][$cacheKey])) {


### PR DESCRIPTION
With PHP 8.4, we have many deprecated functionalities in our modules. PHP 8.4 wants to be explicit with nullable types now.