### PR TITLE
[Compat] Fixes Smile-SA#3578 PHP 8.4 deprecation: Implicitly marking parameter as nullable is deprecated

### DIFF
--- a/src/module-elasticsuite-catalog-graph-ql/Model/Resolver/Products/Query/Search.php
+++ b/src/module-elasticsuite-catalog-graph-ql/Model/Resolver/Products/Query/Search.php
@@ -79,7 +79,7 @@ class Search implements ProductQueryInterface
         FieldSelection $fieldSelection,
         ProductSearch $productProvider,
         SearchCriteriaBuilder $searchCriteriaBuilder,
-        Suggestions $suggestions = null
+        ?Suggestions $suggestions = null
     ) {
         $this->search                = $search;
         $this->searchResultFactory   = $searchResultFactory;

--- a/src/module-elasticsuite-catalog-rule/Test/Unit/Model/Rule/Condition/Product/SpecialAttributeProviderTest.php
+++ b/src/module-elasticsuite-catalog-rule/Test/Unit/Model/Rule/Condition/Product/SpecialAttributeProviderTest.php
@@ -13,6 +13,7 @@
 
 namespace Smile\ElasticsuiteCatalogRule\Test\Unit\Model\Rule\Condition\Product;
 
+use Error;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Error\Warning;
 use Smile\ElasticsuiteCatalogRule\Model\Rule\Condition\Product\SpecialAttributesProvider;
@@ -33,6 +34,7 @@ class SpecialAttributeProviderTest extends TestCase
      * Test listing special attributes.
      *
      * @return void
+     * @SuppressWarnings(PHPMD.ErrorControlOperator)
      */
     public function testGetList()
     {
@@ -67,8 +69,14 @@ class SpecialAttributeProviderTest extends TestCase
         $this->assertEquals('isUpdatedWithinLastXdays', $specialAttributesProvider->getAttribute('is_updated_within_last_x_days'));
         $this->assertEquals(StockQty::class, $specialAttributesProvider->getAttribute('stock.qty'));
 
-        $this->expectWarning();
-        $this->expectWarningMessage('Undefined array key "unknownAttribute"');
-        $specialAttributesProvider->getAttribute('unknownAttribute');
+        /*
+         * expectWarning and expectWarningMessage removed in PHPUnit 10
+         * see https://github.com/sebastianbergmann/phpunit/issues/5062#issuecomment-1416362657.
+         */
+        @$specialAttributesProvider->getAttribute('unknownAttribute');
+        $lastError = error_get_last();
+        $this->assertNotNull($lastError);
+        $this->assertArrayHasKey('message', $lastError);
+        $this->assertEquals('Undefined array key "unknownAttribute"', $lastError['message']);
     }
 }

--- a/src/module-elasticsuite-core/Search/Request/Query/Vector/Opensearch/Neural.php
+++ b/src/module-elasticsuite-core/Search/Request/Query/Vector/Opensearch/Neural.php
@@ -72,7 +72,7 @@ class Neural implements QueryInterface
         string $field = self::DEFAULT_EMBEDDING_FIELD,
         ?string $name = null,
         float $boost = QueryInterface::DEFAULT_BOOST_VALUE,
-        string $modelId = null
+        ?string $modelId = null
     ) {
         $this->field     = $field;
         $this->queryText = $queryText;


### PR DESCRIPTION
…