### PR TITLE
[Indices] #3592 #3596 Better performance when getting indices stats

### DIFF
--- a/src/module-elasticsuite-core/Api/Client/ClientInterface.php
+++ b/src/module-elasticsuite-core/Api/Client/ClientInterface.php
@@ -120,6 +120,16 @@ interface ClientInterface
     public function getSettings($indexName);
 
     /**
+     * Get specific settings of an Index
+     *
+     * @param string $indexName Index name or alias or wildcard.
+     * @param array  $settings  Settings to collect.
+     *
+     * @return array
+     */
+    public function getSpecificSettings($indexName, $settings);
+
+    /**
      * Optimize an index (force segment merging).
      *
      * @param string $indexName Index name.

--- a/src/module-elasticsuite-core/Client/Client.php
+++ b/src/module-elasticsuite-core/Client/Client.php
@@ -158,6 +158,14 @@ class Client implements ClientInterface
     /**
      * {@inheritDoc}
      */
+    public function getSpecificSettings($indexName, $settings)
+    {
+        return $this->getEsClient()->indices()->getSettings(['index' => $indexName, 'name' => $settings]);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function forceMerge($indexName)
     {
         $this->getEsClient()->indices()->forceMerge(['index' => $indexName]);


### PR DESCRIPTION
Changes 
* One single request for all indices instead of one request per index
* Single cache entry
* Only desired settings grabbed

I could have even removed the use of the system cache and opted for pure memory cache, but let's do one step at a time