### PR TITLE
fix: [3617] Elasticsuite is not indexing url_key in Magento 2.4.8

### DIFF
--- a/src/module-elasticsuite-catalog/Model/Eav/Indexer/Fulltext/Datasource/AbstractAttributeData.php
+++ b/src/module-elasticsuite-catalog/Model/Eav/Indexer/Fulltext/Datasource/AbstractAttributeData.php
@@ -70,6 +70,7 @@ abstract class AbstractAttributeData
         \Magento\Eav\Model\Entity\Attribute\Backend\DefaultBackend::class,
         \Magento\Catalog\Model\Product\Attribute\Backend\Weight::class,
         \Magento\Catalog\Model\Product\Attribute\Backend\Price::class,
+        \Magento\Catalog\Model\Product\Attribute\Backend\Url::class,
     ];
 
     /**


### PR DESCRIPTION
Fixing issue:
https://github.com/Smile-SA/elasticsuite/issues/3617