### PR TITLE
[Optimizers] Conditions engine useable when Virtual Categories module disabled

### DIFF
--- a/src/module-elasticsuite-catalog-optimizer/etc/adminhtml/di.xml
+++ b/src/module-elasticsuite-catalog-optimizer/etc/adminhtml/di.xml
@@ -17,6 +17,14 @@
  -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
 
+    <type name="Smile\ElasticsuiteCatalogRule\Controller\Adminhtml\Product\Rule\Conditions">
+        <arguments>
+            <argument name="acls" xsi:type="array">
+                <item name="manage_optimizers" xsi:type="string">Smile_ElasticsuiteCatalogOptimizer::manage</item>
+            </argument>
+        </arguments>
+    </type>
+
     <virtualType name="Smile\ElasticsuiteCatalogOptimizer\Ui\Component\Optimizer\Form\Modifier\Pool" type="Magento\Ui\DataProvider\Modifier\Pool">
         <arguments>
             <argument name="modifiers" xsi:type="array">


### PR DESCRIPTION
When Smile_ElasticsuiteVirtualCategory is disabled, [no acls would be passed to \Smile\ElasticsuiteCatalogRule\Controller\Adminhtml\Product\Rule\Conditions](https://github.com/Smile-SA/elasticsuite/blob/7cf904f78fead3bbf40b3be7bae4587db6057027/src/module-elasticsuite-virtual-category/etc/di.xml#L47-L53), generating a 404/security error because its [_isAllowed method](https://github.com/Smile-SA/elasticsuite/blob/7cf904f78fead3bbf40b3be7bae4587db6057027/src/module-elasticsuite-catalog-rule/Controller/Adminhtml/Product/Rule/Conditions.php#L94-L103) would always return false.

Now, 
* Smile_ElasticsuiteCatalogOptimizer injects Smile_ElasticsuiteCatalogOptimizer::manage
* Smile_ElasticsuiteVirtualCategory injects Magento_Catalog::categories