### PR TITLE
Fix for upcoming PHP 8.5 deprecation, casting to double is no longer …

### DIFF
--- a/src/module-elasticsuite-catalog/Model/Layer/Filter/DataProvider/Decimal.php
+++ b/src/module-elasticsuite-catalog/Model/Layer/Filter/DataProvider/Decimal.php
@@ -46,7 +46,7 @@ class Decimal extends \Magento\Catalog\Model\Layer\Filter\DataProvider\Price
 
         // Legacy check for >=0 is also removed here.
         foreach ($filter as $v) {
-            if ($v === false || is_infinite((double) $v)) {
+            if ($v === false || is_infinite((float) $v)) {
                 return false;
             }
         }


### PR DESCRIPTION
…allowed, need to use float, which is exactly the same.

See: https://php.watch/versions/8.5/boolean-double-integer-binary-casts-deprecated



Discovered with the [phpcompatibility checker tool](https://github.com/PHPCompatibility/PHPCompatibility) (using latest `develop` branch which has some checks for PHP 8.5 now):

```
➜ ./vendor/bin/phpcs -s --standard=PHPCompatibility --extensions=php --runtime-set testVersion 8.3- vendor/smile

FILE: vendor/smile/elasticsuite/src/module-elasticsuite-catalog/Model/Layer/Filter/DataProvider/Decimal.php
--------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
--------------------------------------------------------------------------------------------------------------------------------------------------------
 49 | WARNING | The double cast is deprecated since PHP 8.5; Use (float) instead (PHPCompatibility.TypeCasts.RemovedTypeCasts.doubleDeprecated)
--------------------------------------------------------------------------------------------------------------------------------------------------------
```