### PR TITLE
[Thesaurus] Disabling by default stemming in thesaurus rules.

### DIFF
--- a/src/module-elasticsuite-thesaurus/etc/config.xml
+++ b/src/module-elasticsuite-thesaurus/etc/config.xml
@@ -23,7 +23,7 @@
                 <min_rewrites>0</min_rewrites>
             </cache>
             <analysis>
-                <use_stemming>1</use_stemming>
+                <use_stemming>0</use_stemming>
             </analysis>
         </smile_elasticsuite_thesaurus_settings>
     </default>


### PR DESCRIPTION
Since there is currently a negative side-effect on multi-words synonyms.