### PR TITLE
Fix: Prevent XSS in the filter's search box

### DIFF
--- a/src/module-elasticsuite-catalog/view/frontend/web/js/attribute-filter.js
+++ b/src/module-elasticsuite-catalog/view/frontend/web/js/attribute-filter.js
@@ -147,7 +147,8 @@ define([
          * Search result message
          */
         getSearchResultMessage : function() {
-            return this.noSearchResultLabel.replace("%s", '"' + this.fulltextSearch() + '"')
+            const escapedSearch = $('<div/>').text(this.fulltextSearch()).html();
+            return this.noSearchResultLabel.replace("%s", `"${escapedSearch}"`);
         },
         
         /**


### PR DESCRIPTION
## Description

This PR fixes a Cross-Site Scripting vulnerability in the layered navigation filter search.

It was possible to inject and execute arbitrary JavaScript code via the filter search input on category pages.

## Steps to reproduce

1. Go to any category page with filters.
2. Expand a filter that contains a search input field.
3. Enter a simple script payload into the filter search field, e.g.:
`<script>alert("xss")</script>`
4. Submit the search and observe the results.

## Expected result

The injected script should be properly escaped and rendered as plain text.
No JavaScript code should be executed.

## Actual result

The injected script is executed automatically, resulting in a JavaScript alert being triggered.

## Root cause

User input from the filter search field was rendered without proper escaping, allowing arbitrary script execution.

## Fix

User input is now properly escaped before being rendered in the output.
This prevents execution of injected JavaScript code while preserving expected search functionality.