### PR TITLE
Fix virtual category child filtering

### DIFF
--- a/src/module-elasticsuite-virtual-category/Model/Layer/Filter/Category.php
+++ b/src/module-elasticsuite-virtual-category/Model/Layer/Filter/Category.php
@@ -128,10 +128,19 @@ class Category extends \Smile\ElasticsuiteCatalog\Model\Layer\Filter\Category
                 $rootCategory = $this->virtualCategoryRoot->getVirtualCategoryRoot($currentCategory);
                 if ($rootCategory->getId()) {
                     $this->childrenCategories = $rootCategory->getChildrenCategories();
-                    $this->childrenCategories->clear()->addFieldToFilter(
-                        'entity_id',
-                        ['neq' => $currentCategory->getId()]
-                    );
+                    if ($this->childrenCategories instanceof \Magento\Catalog\Model\ResourceModel\Category\Collection) {
+                        $this->childrenCategories->clear()->addFieldToFilter(
+                            'entity_id',
+                            ['neq' => $currentCategory->getId()]
+                        );
+                    } else {
+                        $this->childrenCategories = array_filter(
+                            $this->childrenCategories,
+                            static function ($category) use ($currentCategory) {
+                                return (int) $category->getId() !== (int) $currentCategory->getId();
+                            }
+                        );
+                    }
                 }
             }
         }

--- a/src/module-elasticsuite-virtual-category/Model/Layer/Filter/Category.php
+++ b/src/module-elasticsuite-virtual-category/Model/Layer/Filter/Category.php
@@ -117,6 +117,8 @@ class Category extends \Smile\ElasticsuiteCatalog\Model\Layer\Filter\Category
     /**
      * Retrieve currently selected category children categories.
      *
+     * @SuppressWarnings(PHPMD.ElseExpression)
+     *
      * @return \Magento\Catalog\Model\ResourceModel\Category\Collection|\Magento\Catalog\Model\Category[]
      */
     protected function getChildrenCategories()

--- a/src/module-elasticsuite-virtual-category/Model/Layer/Filter/Category.php
+++ b/src/module-elasticsuite-virtual-category/Model/Layer/Filter/Category.php
@@ -15,6 +15,7 @@
 namespace Smile\ElasticsuiteVirtualCategory\Model\Layer\Filter;
 
 use Magento\Catalog\Api\Data\CategoryInterface;
+use Magento\Catalog\Model\ResourceModel\Category\Collection;
 use Smile\ElasticsuiteCatalog\Model\Search\Request\Field\Mapper as RequestFieldMapper;
 
 /**
@@ -127,17 +128,18 @@ class Category extends \Smile\ElasticsuiteCatalog\Model\Layer\Filter\Category
             if ($this->virtualCategoryRoot->useVirtualRootCategorySubtree($currentCategory)) {
                 $rootCategory = $this->virtualCategoryRoot->getVirtualCategoryRoot($currentCategory);
                 if ($rootCategory->getId()) {
+                    $currentCategoryId = (int) $currentCategory->getId();
                     $this->childrenCategories = $rootCategory->getChildrenCategories();
-                    if ($this->childrenCategories instanceof \Magento\Catalog\Model\ResourceModel\Category\Collection) {
+                    if ($this->childrenCategories instanceof Collection) {
                         $this->childrenCategories->clear()->addFieldToFilter(
                             'entity_id',
-                            ['neq' => $currentCategory->getId()]
+                            ['neq' => $currentCategoryId]
                         );
                     } else {
                         $this->childrenCategories = array_filter(
                             $this->childrenCategories,
-                            static function ($category) use ($currentCategory) {
-                                return (int) $category->getId() !== (int) $currentCategory->getId();
+                            static function ($category) use ($currentCategoryId) {
+                                return (int) $category->getId() !== $currentCategoryId;
                             }
                         );
                     }


### PR DESCRIPTION
Virtual category child filtering assumed `getChildrenCategories()` always returned a Magento category collection. In stores where the virtual root subtree returns an array of category objects instead, the layer filter fails while building pages such as `/our-brands`.

- **Problem**
  - `Smile\ElasticsuiteVirtualCategory\Model\Layer\Filter\Category::getChildrenCategories()` switched to the virtual root subtree and immediately called collection methods on the result.
  - That breaks when `getChildrenCategories()` returns an array rather than `\Magento\Catalog\Model\ResourceModel\Category\Collection`.

- **Change**
  - Preserve the existing collection path when the virtual root returns a category collection.
  - Add an array fallback that filters children with `array_filter(...)`.
  - Exclude the current category in both paths so subtree navigation behavior stays consistent.

- **Implementation details**
  - Added an explicit `Collection` type check before calling `clear()->addFieldToFilter(...)`.
  - Cached the current category ID once and reused it for both collection and array filtering paths.
