### PR TITLE
Fix condition check for mouseout event

### DIFF
--- a/src/module-elasticsuite-core/view/frontend/web/js/form-mini.js
+++ b/src/module-elasticsuite-core/view/frontend/web/js/form-mini.js
@@ -301,7 +301,7 @@ define([
                                 self._resetResponseList(false);
                             })
                             .on('mouseout', function () {
-                                if (!self._getLastElement() && self._getLastElement().hasClass(self.options.selectClass)) {
+                                if (self._getLastElement() && self._getLastElement().hasClass(self.options.selectClass)) {
                                     $(this).removeClass(self.options.selectClass);
                                     self._resetResponseList(false);
                                 }


### PR DESCRIPTION
Currently this is causing JS errors:

self._getLastElement().hasClass is not a function. (In 'self._getLastElement().hasClass(self.options.selectClass)', 'self._getLastElement().hasClass' is undefined)