### PR TITLE
Fix condition check for mouseout event (2.10.x)

### DIFF
--- a/src/module-elasticsuite-core/view/frontend/web/js/form-mini.js
+++ b/src/module-elasticsuite-core/view/frontend/web/js/form-mini.js
@@ -301,7 +301,7 @@ define([
                                 self._resetResponseList(false);
                             })
                             .on('mouseout', function () {
-                                if (!self._getLastElement() && self._getLastElement().hasClass(self.options.selectClass)) {
+                                if (self._getLastElement() && self._getLastElement().hasClass(self.options.selectClass)) {
                                     $(this).removeClass(self.options.selectClass);
                                     self._resetResponseList(false);
                                 }


### PR DESCRIPTION
(2.10.x version of @groomershop-mt's https://github.com/Smile-SA/elasticsuite/pull/3833)

Currently this is causing JS errors:

self._getLastElement().hasClass is not a function. (In 'self._getLastElement().hasClass(self.options.selectClass)', 'self._getLastElement().hasClass' is undefined)