### PR TITLE
fix(catalog): use catalog_product_entity join for visibility in category position migrate

### DIFF
--- a/src/module-elasticsuite-catalog/Model/CategoryPositionMigrator.php
+++ b/src/module-elasticsuite-catalog/Model/CategoryPositionMigrator.php
@@ -23,7 +23,7 @@ use Magento\Framework\DB\Adapter\AdapterInterface;
 use Magento\Framework\Exception\LocalizedException;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use \Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Framework\EntityManager\MetadataPool;
 
 /**
@@ -304,13 +304,23 @@ class CategoryPositionMigrator
             }
         }
 
+        $entityTable = $this->resource->getTableName('catalog_product_entity');
+
         do {
             // Fetch a batch of products with left join to visibility.
+            // Join through catalog_product_entity to resolve the correct link field
+            // (entity_id on CE, row_id on EE), since catalog_category_product.product_id
+            // always stores entity_id regardless of edition.
             $select = $this->connection->select()
                 ->from(['ccp' => $legacyTable], ['product_id', 'position'])
                 ->joinLeft(
+                    ['cpe' => $entityTable],
+                    'cpe.entity_id = ccp.product_id',
+                    []
+                )
+                ->joinLeft(
                     ['cpei' => $visibilityTable],
-                    'cpei.' . $linkField . ' = ccp.product_id'
+                    'cpei.' . $linkField . ' = cpe.' . $linkField
                     . ' AND cpei.attribute_id = ' . $visibilityAttributeId
                     . ' AND cpei.store_id = ' . $storeId,
                     ['']


### PR DESCRIPTION
## Problem

`elasticsuite:category-position:migrate` crashes on Magento Open Source (CE) with:

```
SQLSTATE[42S22]: Column not found: 1054 Unknown column 'cpei.row_id' in 'on clause'
```

Fixes #3840

## Root Cause

`catalog_category_product.product_id` always stores `entity_id` regardless of Magento edition. The original code joined `catalog_product_entity_int` directly against `ccp.product_id` using `getLinkField()`:

```php
'cpei.' . $linkField . ' = ccp.product_id'
```

- **CE**: `getLinkField()` → `entity_id` ✓ column exists, but only by coincidence
- **EE**: `getLinkField()` → `row_id` ✓ column exists in EAV table, but `row_id ≠ entity_id` (staging versioning), so semantically wrong

## Fix

Add an intermediate join through `catalog_product_entity` to bridge `entity_id` (from `catalog_category_product`) to the correct link field used by EAV attribute tables:

```php
->joinLeft(['cpe' => $entityTable], 'cpe.entity_id = ccp.product_id', [])
->joinLeft(
    ['cpei' => $visibilityTable],
    'cpei.' . $linkField . ' = cpe.' . $linkField . ' AND ...',
    ['']
)
```

- **CE**: `cpe.entity_id = cpe.entity_id` — correct
- **EE**: `cpe.row_id = cpe.row_id` — correct, maps through the entity table which holds both `entity_id` and `row_id`

## Testing

Verified against Magento Open Source 2.4.7 with ElasticSuite latest. Command processes all categories without SQL errors.