### PR TITLE
Quote column names in Optimizer/Collection.php

### DIFF
--- a/src/module-elasticsuite-catalog-optimizer/Model/ResourceModel/Optimizer/Collection.php
+++ b/src/module-elasticsuite-catalog-optimizer/Model/ResourceModel/Optimizer/Collection.php
@@ -131,8 +131,8 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
         }
 
         $this->getSelect()
-            ->where('from_date is null or from_date <= ?', $date)
-            ->where('to_date is null or to_date >= ?', $date);
+            ->where('`from_date` is null or `from_date` <= ?', $date)
+            ->where('`to_date` is null or `to_date` >= ?', $date);
 
         return $this;
     }

--- a/src/module-elasticsuite-catalog-optimizer/Model/ResourceModel/Optimizer/Collection.php
+++ b/src/module-elasticsuite-catalog-optimizer/Model/ResourceModel/Optimizer/Collection.php
@@ -130,9 +130,11 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
             $date = $this->date->date('Y-m-d');
         }
 
+        $fromDateCol = $this->getConnection()->quoteIdentifier('from_date');
+        $toDateCol = $this->getConnection()->quoteIdentifier('to_date');
         $this->getSelect()
-            ->where('`from_date` is null or `from_date` <= ?', $date)
-            ->where('`to_date` is null or `to_date` >= ?', $date);
+            ->where(sprintf("%s is null or %s <= ?", $fromDateCol, $fromDateCol), $date)
+            ->where(sprintf("%s is null or %s >= ?", $toDateCol, $toDateCol), $date);
 
         return $this;
     }


### PR DESCRIPTION
Unquoted use of `from_date` in a raw WHERE clause triggers a MariaDB reserved-word syntax error. Quoting both date columns fixes compatibility with strict MariaDB versions