### PR TITLE
[VirtualCategories] Replaces null frontend_input for virtual cat. attributes

### DIFF
--- a/src/module-elasticsuite-virtual-category/Setup/UpgradeData.php
+++ b/src/module-elasticsuite-virtual-category/Setup/UpgradeData.php
@@ -86,6 +86,10 @@ class UpgradeData implements UpgradeDataInterface
             $this->virtualCategorySetup->addGenerateVirtualCategorySubtreeAttribute($this->eavSetupFactory->create(['setup' => $setup]));
         }
 
+        if (version_compare($context->getVersion(), '1.5.1', '<')) {
+            $this->virtualCategorySetup->updateVirtualCategoriesAttrNullFrontendInput($this->eavSetupFactory->create(['setup' => $setup]));
+        }
+
         $setup->endSetup();
     }
 }

--- a/src/module-elasticsuite-virtual-category/Setup/VirtualCategorySetup.php
+++ b/src/module-elasticsuite-virtual-category/Setup/VirtualCategorySetup.php
@@ -512,6 +512,31 @@ class VirtualCategorySetup
     }
 
     /**
+     * Replace the null frontend_input for legacy virtual categories related attributes
+     * 'is_virtual_category' (int/boolean), 'virtual_category_root' (int) and 'virtual_rule' (text)
+     * with a 'hidden' frontend_input.
+     * Those attributes are handled by UI components and not legacy input field logic, so 'hidden' fits.
+     * This prevents an error down the line in \Magento\Catalog\Model\Category\DataProvider in Magento 2.4.9 / PHP 8.5.
+     *
+     * @param \Magento\Eav\Setup\EavSetup $eavSetup EAV module Setup
+     *
+     * @return $this
+     */
+    public function updateVirtualCategoriesAttrNullFrontendInput(\Magento\Eav\Setup\EavSetup $eavSetup)
+    {
+        foreach (['is_virtual_category', 'virtual_category_root', 'virtual_rule'] as $attributeCode) {
+            $eavSetup->updateAttribute(
+                Category::ENTITY,
+                $attributeCode,
+                'frontend_input',
+                'hidden'
+            );
+        }
+
+        return $this;
+    }
+
+    /**
      * Process full reindexing of flat categories if enabled and not scheduled.
      */
     private function reindexFlatCategories()

--- a/src/module-elasticsuite-virtual-category/etc/module.xml
+++ b/src/module-elasticsuite-virtual-category/etc/module.xml
@@ -16,7 +16,7 @@
  */
  -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Smile_ElasticsuiteVirtualCategory" setup_version="1.5.0">
+    <module name="Smile_ElasticsuiteVirtualCategory" setup_version="1.5.1">
         <sequence>
             <module name="Smile_ElasticsuiteCatalogRule" />
             <module name="Magento_Rule" />


### PR DESCRIPTION
Prevents an error down the line in Magento 2.4.9 / PHP 8.5, see https://github.com/magento/magento2/issues/40908