### PR TITLE
Fix PHP 8.5 fatal on product pages viewed without a category context

### DIFF
--- a/src/module-elasticsuite-virtual-category/Plugin/Catalog/Product/ProductPlugin.php
+++ b/src/module-elasticsuite-virtual-category/Plugin/Catalog/Product/ProductPlugin.php
@@ -95,13 +95,17 @@ class ProductPlugin
      */
     public function aroundCanBeShowInCategory(Product $product, ClosureAlias $proceed, $categoryId): bool
     {
-        try {
-            $category = $this->categoryRepository->get($categoryId);
-            if ((bool) $category->getIsVirtualCategory() === true) {
-                return true;
+        // get(null) uses null as an array offset in CategoryRepository, a fatal deprecation
+        // on PHP 8.5 that fires before the catch below can handle it. Null means "not shown".
+        if ($categoryId !== null) {
+            try {
+                $category = $this->categoryRepository->get($categoryId);
+                if ((bool) $category->getIsVirtualCategory() === true) {
+                    return true;
+                }
+            } catch (NoSuchEntityException $e) {
+                $category = null;
             }
-        } catch (NoSuchEntityException $e) {
-            $category = null;
         }
 
         return $proceed($categoryId);

--- a/src/module-elasticsuite-virtual-category/Plugin/Catalog/ProductPlugin.php
+++ b/src/module-elasticsuite-virtual-category/Plugin/Catalog/ProductPlugin.php
@@ -94,13 +94,17 @@ class ProductPlugin
      */
     public function aroundCanBeShowInCategory(Product $product, \Closure $proceed, $categoryId)
     {
-        try {
-            $category = $this->categoryRepository->get($categoryId);
-            if ((bool) $category->getIsVirtualCategory() === true) {
-                return true;
+        // get(null) uses null as an array offset in CategoryRepository, a fatal deprecation
+        // on PHP 8.5 that fires before the catch below can handle it. Null means "not shown".
+        if ($categoryId !== null) {
+            try {
+                $category = $this->categoryRepository->get($categoryId);
+                if ((bool) $category->getIsVirtualCategory() === true) {
+                    return true;
+                }
+            } catch (NoSuchEntityException $e) {
+                $category = null;
             }
-        } catch (NoSuchEntityException $e) {
-            $category = null;
         }
 
         return $proceed($categoryId);


### PR DESCRIPTION
On PHP 8.5, opening a product page with no category context fatals before it renders:

```
Deprecated: Using null as an array offset is deprecated, use an empty string instead
in .../module-catalog/Model/CategoryRepository.php:153
```

`Design::getDesignSettings()` calls `canBeShowInCategory(null)` when a product is
viewed without a category (no category in the registry, no last-visited category in
the session). `ProductPlugin::aroundCanBeShowInCategory()` forwards that `null` into
`CategoryRepositoryInterface::get()`, which uses it as an array offset
(`$this->instances[null]`) — newly deprecated on PHP 8.5, and promoted to a fatal in
developer mode. It fires before the plugin's own `NoSuchEntityException` catch can run.
On PHP ≤ 8.4 it was silent.

**Fix:** skip the lookup when `$categoryId` is `null` (a null category means "not
shown", matching the legacy result). `!== null` rather than `!empty()` — only `null`
triggers the deprecation; real ids stay untouched. Applied to both plugin classes
registered on `Magento\Catalog\Model\Product`.

## Steps to reproduce

1. Mage-OS 3.2 / Magento 2.4.9 on PHP 8.5 with Elasticsuite, in **developer mode**.
2. Keep *Use Categories Path for Product URLs = No* (default).
3. In a fresh session, open any product URL directly.

Result: fatal `Using null as an array offset … CategoryRepository.php:153`.
Expected: the product page renders.
