### PR TITLE
[CatalogRule] Fixes #3873 Backport of ACSD-64111

### DIFF
--- a/src/module-elasticsuite-catalog-rule/Model/Rule/Condition/Combine.php
+++ b/src/module-elasticsuite-catalog-rule/Model/Rule/Condition/Combine.php
@@ -109,14 +109,16 @@ class Combine extends \Magento\Rule\Model\Condition\Combine
 
         if (!empty($arr[$key]) && is_array($arr[$key])) {
             foreach ($arr[$key] as $conditionArr) {
-                try {
-                    $condition = $this->_conditionFactory->create($conditionArr['type']);
-                    $condition->setElementName($this->elementName);
-                    $condition->setRule($this->getRule());
-                    $this->addCondition($condition);
-                    $condition->loadArray($conditionArr, $key);
-                } catch (\Exception $exception) {
-                    $this->_logger->critical($exception);
+                if (!empty($conditionArr['type'])) {
+                    try {
+                        $condition = $this->_conditionFactory->create($conditionArr['type']);
+                        $condition->setElementName($this->elementName);
+                        $condition->setRule($this->getRule());
+                        $this->addCondition($condition);
+                        $condition->loadArray($conditionArr, $key);
+                    } catch (\Exception $exception) {
+                        $this->_logger->critical($exception);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Backport of the logic of ACSD-64111 without the heavy refactoring.
Note: original bug not necessarily reproducible on 2.10.x/M2 2.4.5-pX