### PR TITLE
[CatalogRule] Use a single terms query for SKU "is one of" conditions

### DIFF
--- a/src/module-elasticsuite-catalog-rule/Model/Rule/Condition/Product/QueryBuilder.php
+++ b/src/module-elasticsuite-catalog-rule/Model/Rule/Condition/Product/QueryBuilder.php
@@ -146,12 +146,24 @@ class QueryBuilder
 
             $clause = (substr($productCondition->getOperator(), 0, 1) === '!') ? 'mustNot' : 'should';
             // SKU values can be an array of value, due to the picker.
-            foreach (explode(',', $productCondition->getValue()) as $value) {
-                // Instead of just a "should" clause, we will have "should" or "must_not" depending on the rule operator.
+            $values = array_map('trim', explode(',', $productCondition->getValue()));
+
+            if (in_array($productCondition->getOperator(), ['()', '!()'])) {
+                // Those operators run on the untouched (keyword) field, where a single terms clause is
+                // equivalent to one match clause per value, but counts as a single clause in Lucene.
                 $queryParams[$clause][] = $this->prepareQuery(
-                    QueryInterface::TYPE_MATCH,
-                    ['field' => $fieldName, 'queryText' => trim($value), 'minimumShouldMatch' => "100%"]
+                    QueryInterface::TYPE_TERMS,
+                    ['field' => $fieldName, 'values' => $values]
                 );
+            } else {
+                foreach ($values as $value) {
+                    // Instead of just a "should" clause, we will have "should" or "must_not"
+                    // depending on the rule operator.
+                    $queryParams[$clause][] = $this->prepareQuery(
+                        QueryInterface::TYPE_MATCH,
+                        ['field' => $fieldName, 'queryText' => $value, 'minimumShouldMatch' => "100%"]
+                    );
+                }
             }
 
             // One clause must match between all.

--- a/src/module-elasticsuite-catalog-rule/Test/Unit/Model/Rule/Condition/Product/QueryBuilderTest.php
+++ b/src/module-elasticsuite-catalog-rule/Test/Unit/Model/Rule/Condition/Product/QueryBuilderTest.php
@@ -306,13 +306,66 @@ class QueryBuilderTest extends TestCase
 
         $clause = current($searchQuery->getShould());
         $this->assertInstanceOf(QueryInterface::class, $clause);
-        $this->assertInstanceOf(MatchQuery::class, $clause);
-        $this->assertEquals(QueryInterface::TYPE_MATCH, $clause->getType());
+        $this->assertInstanceOf(Terms::class, $clause);
+        $this->assertEquals(QueryInterface::TYPE_TERMS, $clause->getType());
 
-        /** @var MatchQuery $clause */
+        /** @var Terms $clause */
         $this->assertEquals('sku.untouched', $clause->getField());
-        $this->assertEquals('ABC123', $clause->getQueryText());
-        $this->assertEquals('100%', $clause->getMinimumShouldMatch());
+        $this->assertEquals(['ABC123'], $clause->getValues());
+    }
+
+    /**
+     * Test query builder with several sku values through the "is one of" operator.
+     *
+     * @return void
+     */
+    public function testSpecialAttributesMultipleSkuIsOneOfQuery()
+    {
+        $fields = [
+            new Field('entity_id', FieldInterface::FIELD_TYPE_INTEGER),
+            new Field('category.category_id', FieldInterface::FIELD_TYPE_INTEGER, 'category'),
+            new Field('category.category_uid', FieldInterface::FIELD_TYPE_TEXT, 'category'),
+            new Field('category.position', FieldInterface::FIELD_TYPE_INTEGER, 'category'),
+            new Field('price.price', FieldInterface::FIELD_TYPE_DOUBLE, 'price'),
+            new Field('sku', FieldInterface::FIELD_TYPE_TEXT, null, ['is_searchable' => 1, 'default_analyzer' => 'reference']),
+            new Field('brand', FieldInterface::FIELD_TYPE_INTEGER),
+            new Field('option_text_brand', FieldInterface::FIELD_TYPE_TEXT),
+        ];
+
+        $attributeList = $this->getAdvancedAttributeList($fields);
+        $specialAttributesProvider = $this->getSpecialAttributesProvider();
+        $queryBuilder = new QueryBuilder(
+            $attributeList,
+            $this->getQueryFactory(),
+            $specialAttributesProvider,
+        );
+
+        $productCondition = $this->getProductConditionMock();
+        $productCondition->method('getValue')->willReturn("ABC123, DEF456");
+        $productCondition->method('__call')->willReturnMap([
+            ['getAttribute', [], 'sku'],
+            ['getOperator', [], '()'],
+        ]);
+
+        $searchQuery = $queryBuilder->getSearchQuery($productCondition);
+
+        $this->assertInstanceOf(QueryInterface::class, $searchQuery);
+        $this->assertInstanceOf(Boolean::class, $searchQuery);
+        $this->assertEquals(QueryInterface::TYPE_BOOL, $searchQuery->getType());
+
+        /** @var Boolean $searchQuery */
+        $this->assertEmpty($searchQuery->getMust());
+        $this->assertEmpty($searchQuery->getMustNot());
+        $this->assertCount(1, $searchQuery->getShould());
+
+        $clause = current($searchQuery->getShould());
+        $this->assertInstanceOf(QueryInterface::class, $clause);
+        $this->assertInstanceOf(Terms::class, $clause);
+        $this->assertEquals(QueryInterface::TYPE_TERMS, $clause->getType());
+
+        /** @var Terms $clause */
+        $this->assertEquals('sku.untouched', $clause->getField());
+        $this->assertEquals(['ABC123', 'DEF456'], $clause->getValues());
     }
 
     /**
@@ -370,29 +423,17 @@ class QueryBuilderTest extends TestCase
 
         /** @var Boolean $searchQuery */
         $this->assertEmpty($searchQuery->getMust());
-        $this->assertCount(2, $searchQuery->getMustNot());
+        $this->assertCount(1, $searchQuery->getMustNot());
         $this->assertEmpty($searchQuery->getShould());
 
-        $clauses = $searchQuery->getMustNot();
-        $clause = array_pop($clauses);
+        $clause = current($searchQuery->getMustNot());
         $this->assertInstanceOf(QueryInterface::class, $clause);
-        $this->assertInstanceOf(MatchQuery::class, $clause);
-        $this->assertEquals(QueryInterface::TYPE_MATCH, $clause->getType());
+        $this->assertInstanceOf(Terms::class, $clause);
+        $this->assertEquals(QueryInterface::TYPE_TERMS, $clause->getType());
 
-        /** @var MatchQuery $clause */
+        /** @var Terms $clause */
         $this->assertEquals('sku.untouched', $clause->getField());
-        $this->assertEquals('DEF456', $clause->getQueryText());
-        $this->assertEquals('100%', $clause->getMinimumShouldMatch());
-
-        $clause = array_pop($clauses);
-        $this->assertInstanceOf(QueryInterface::class, $clause);
-        $this->assertInstanceOf(MatchQuery::class, $clause);
-        $this->assertEquals(QueryInterface::TYPE_MATCH, $clause->getType());
-
-        /** @var MatchQuery $clause */
-        $this->assertEquals('sku.untouched', $clause->getField());
-        $this->assertEquals('ABC123', $clause->getQueryText());
-        $this->assertEquals('100%', $clause->getMinimumShouldMatch());
+        $this->assertEquals(['ABC123', 'DEF456'], $clause->getValues());
     }
 
     /**


### PR DESCRIPTION
## Problem

`QueryBuilder::getSpecialAttributesSearchQuery()` expands a condition on `sku` into one `match` clause per value, whatever the operator. A rule holding a list of SKUs therefore costs as many Lucene leaf clauses as it has values.

On a production catalog, a virtual category with `sku is one of <3111 SKUs>` produced 3111 clauses. Every category whose query embeds that rule went over `indices.query.bool.max_clause_count` (5416 on that cluster) and silently returned zero products:

```json
{
  "type": "illegal_argument_exception",
  "reason": "Query rewrite failed: too many clauses",
  "caused_by": {
    "type": "too_many_nested_clauses",
    "reason": "maxClauseCount is set to 5416"
  }
}
```

## Steps to reproduce

1. Create a virtual category with a single rule condition `SKU is one of <a few thousand SKUs>`.
2. Browse it, or any category whose subtree references it.
3. The listing is empty and `var/log/system.log` shows the error above.

## Change

`()` and `!()` now emit a single `terms` clause. The `contains` path is left untouched.

`getSearchFieldName()` already resolves those two operators to the untouched field, which is mapped as `keyword` with a no-op normalizer. A `match` with `minimum_should_match: 100%` on a `keyword` field resolves to a single term, so N `match` clauses in a `should` are equivalent to one `terms` of N values.

|        | clauses      | DSL size    |
| ------ | ------------ | ----------- |
| before | 3111 `match` | 272 707 B   |
| after  | 1 `terms`    | 30 089 B    |

## Tests

`QueryBuilderTest`: added `testSpecialAttributesMultipleSkuIsOneOfQuery`, and updated `testSpecialAttributesSkuQuery` / `testSpecialAttributesMultipleSkuQuery` to the new contract. `testSpecialAttributesMultipleSkuAnalyzedQuery` covers the `contains` path and is unchanged.