### PR TITLE
[VirtualCategories] Fix query caching and subquery duplication

### DIFF
--- a/src/module-elasticsuite-virtual-category/Model/Rule.php
+++ b/src/module-elasticsuite-virtual-category/Model/Rule.php
@@ -201,18 +201,19 @@ class Rule extends \Smile\ElasticsuiteCatalogRule\Model\Rule implements VirtualR
             ]
         );
 
-        $query = $this->getFromLocalCache($categoryId);
+        $query = $this->getFromLocalCache($categoryId, $excludedCategories);
 
+        // Only a query built without any excluded category can be shared between requests: excluding
+        // categories changes which children are skipped, so such a query describes that context alone.
         // If the category is not an object, it can't be in a "draft" mode.
-        if ($query === false && (!is_object($category) || !$category->getHasDraftVirtualRule())) {
-            // If the category virtual root is one of the excluded categories, we must recalculate the query.
-            // We can't use the cached one in order to avoid loop and very big queries.
-            if (!is_object($category) || !$this->isVirtualCategoryRootInExcludeCategories($category, $excludedCategories)) {
-                // Due to the fact we serialize/unserialize completely pre-built queries as object.
-                // We cannot use any implementation of SerializerInterface.
-                $query = $this->sharedCache->load($cacheKey);
-                $query = $query ? unserialize($query) : false;
-            }
+        if ($query === false
+            && empty($excludedCategories)
+            && (!is_object($category) || !$category->getHasDraftVirtualRule())
+        ) {
+            // Due to the fact we serialize/unserialize completely pre-built queries as object.
+            // We cannot use any implementation of SerializerInterface.
+            $query = $this->sharedCache->load($cacheKey);
+            $query = $query ? unserialize($query) : false;
         }
 
         if ($query === false) {
@@ -221,14 +222,14 @@ class Rule extends \Smile\ElasticsuiteCatalogRule\Model\Rule implements VirtualR
             }
             $query = $this->buildCategorySearchQuery($category, $excludedCategories);
 
-            if (!$category->getHasDraftVirtualRule() && $query !== null && !in_array($categoryId, $excludedCategories)) {
+            if (!$category->getHasDraftVirtualRule() && $query !== null && empty($excludedCategories)) {
                 $cacheData   = serialize($query);
                 $this->sharedCache->save($cacheData, $cacheKey, $category->getCacheTags());
             }
         }
 
         if (!in_array($categoryId, $excludedCategories)) {
-            $this->saveInLocalCache($categoryId, $query);
+            $this->saveInLocalCache($categoryId, $query, $excludedCategories);
         }
 
         \Magento\Framework\Profiler::stop('ES:Virtual Rule ' . __FUNCTION__);
@@ -490,9 +491,16 @@ class Rule extends \Smile\ElasticsuiteCatalogRule\Model\Rule implements VirtualR
 
         if ($query !== null && $childrenCategories->getSize() > 0) {
             $queryParams = ['should' => [$query], 'cached' => empty($excludedCategories)];
+            $expandedCategoriesIds = [];
 
-            foreach ($childrenCategories as $childrenCategory) {
+            foreach ($this->sortByDepth($childrenCategories) as $childrenCategory) {
                 if (((bool) $childrenCategory->getIsVirtualCategory()) === true) {
+                    // A virtual category query already expands its own descendants. Adding them here as well
+                    // duplicates the whole subquery, once per virtual ancestor they have below this category.
+                    if (!empty(array_intersect($childrenCategory->getPathIds(), $expandedCategoriesIds))) {
+                        continue;
+                    }
+
                     $childrenQuery = $this->getCategorySearchQuery($childrenCategory, $excludedCategories);
                     if ($childrenQuery !== null) {
                         $childrenQuery->setName(
@@ -504,6 +512,7 @@ class Rule extends \Smile\ElasticsuiteCatalogRule\Model\Rule implements VirtualR
                             )
                         );
                         $queryParams['should'][] = $childrenQuery;
+                        $expandedCategoriesIds[] = $childrenCategory->getId();
                     }
                 } else {
                     $childrenCategoriesIds[] = $childrenCategory->getId();
@@ -538,6 +547,27 @@ class Rule extends \Smile\ElasticsuiteCatalogRule\Model\Rule implements VirtualR
         }
 
         return $query;
+    }
+
+    /**
+     * Sort categories by depth, so a category is always handled before its own descendants.
+     *
+     * @param Collection $categories Categories to sort.
+     *
+     * @return CategoryInterface[]
+     */
+    private function sortByDepth(Collection $categories): array
+    {
+        $sortedCategories = iterator_to_array($categories, false);
+
+        usort(
+            $sortedCategories,
+            function (CategoryInterface $first, CategoryInterface $second) {
+                return strlen((string) $first->getPath()) <=> strlen((string) $second->getPath());
+            }
+        );
+
+        return $sortedCategories;
     }
 
     /**
@@ -590,25 +620,48 @@ class Rule extends \Smile\ElasticsuiteCatalogRule\Model\Rule implements VirtualR
     /**
      * Get category query from local cache.
      *
-     * @param int $categoryId In of the category.
+     * @param int   $categoryId         In of the category.
+     * @param array $excludedCategories Categories excluded from the query building.
+     *
      * @return QueryInterface|bool|null
      */
-    private function getFromLocalCache(int $categoryId)
+    private function getFromLocalCache(int $categoryId, array $excludedCategories = [])
     {
-        return self::$localCache[$categoryId] ?? false;
+        return self::$localCache[$this->getLocalCacheKey($categoryId, $excludedCategories)] ?? false;
     }
 
     /**
      * Save category query in local cache.
      *
-     * @param int                      $categoryId Id of the category.
-     * @param QueryInterface|bool|null $query      Query of the category.
+     * @param int                      $categoryId         Id of the category.
+     * @param QueryInterface|bool|null $query              Query of the category.
+     * @param array                    $excludedCategories Categories excluded from the query building.
      */
-    private function saveInLocalCache(int $categoryId, $query): void
+    private function saveInLocalCache(int $categoryId, $query, array $excludedCategories = []): void
     {
         if ($query !== null) {
-            self::$localCache[$categoryId] = $query;
+            self::$localCache[$this->getLocalCacheKey($categoryId, $excludedCategories)] = $query;
         }
+    }
+
+    /**
+     * Local cache key of a category query, including the building context it depends on.
+     *
+     * @param int   $categoryId         Id of the category.
+     * @param array $excludedCategories Categories excluded from the query building.
+     *
+     * @return string
+     */
+    private function getLocalCacheKey(int $categoryId, array $excludedCategories): string
+    {
+        if (empty($excludedCategories)) {
+            return (string) $categoryId;
+        }
+
+        $excludedCategories = array_map('intval', $excludedCategories);
+        sort($excludedCategories);
+
+        return $categoryId . '|' . implode(',', $excludedCategories);
     }
 
     /**

--- a/src/module-elasticsuite-virtual-category/Model/Rule.php
+++ b/src/module-elasticsuite-virtual-category/Model/Rule.php
@@ -201,7 +201,7 @@ class Rule extends \Smile\ElasticsuiteCatalogRule\Model\Rule implements VirtualR
             ]
         );
 
-        $query = $this->getFromLocalCache($categoryId, $excludedCategories);
+        $query = $this->getFromLocalCache($cacheKey, $excludedCategories);
 
         // Only a query built without any excluded category can be shared between requests: excluding
         // categories changes which children are skipped, so such a query describes that context alone.
@@ -229,7 +229,7 @@ class Rule extends \Smile\ElasticsuiteCatalogRule\Model\Rule implements VirtualR
         }
 
         if (!in_array($categoryId, $excludedCategories)) {
-            $this->saveInLocalCache($categoryId, $query, $excludedCategories);
+            $this->saveInLocalCache($cacheKey, $query, $excludedCategories);
         }
 
         \Magento\Framework\Profiler::stop('ES:Virtual Rule ' . __FUNCTION__);
@@ -620,48 +620,48 @@ class Rule extends \Smile\ElasticsuiteCatalogRule\Model\Rule implements VirtualR
     /**
      * Get category query from local cache.
      *
-     * @param int   $categoryId         In of the category.
-     * @param array $excludedCategories Categories excluded from the query building.
+     * @param string $cacheKey          Base cache key of the category query.
+     * @param array  $excludedCategories Categories excluded from the query building.
      *
      * @return QueryInterface|bool|null
      */
-    private function getFromLocalCache(int $categoryId, array $excludedCategories = [])
+    private function getFromLocalCache(string $cacheKey, array $excludedCategories = [])
     {
-        return self::$localCache[$this->getLocalCacheKey($categoryId, $excludedCategories)] ?? false;
+        return self::$localCache[$this->getLocalCacheKey($cacheKey, $excludedCategories)] ?? false;
     }
 
     /**
      * Save category query in local cache.
      *
-     * @param int                      $categoryId         Id of the category.
-     * @param QueryInterface|bool|null $query              Query of the category.
+     * @param string                   $cacheKey          Base cache key of the category query.
+     * @param QueryInterface|bool|null $query             Query of the category.
      * @param array                    $excludedCategories Categories excluded from the query building.
      */
-    private function saveInLocalCache(int $categoryId, $query, array $excludedCategories = []): void
+    private function saveInLocalCache(string $cacheKey, $query, array $excludedCategories = []): void
     {
         if ($query !== null) {
-            self::$localCache[$this->getLocalCacheKey($categoryId, $excludedCategories)] = $query;
+            self::$localCache[$this->getLocalCacheKey($cacheKey, $excludedCategories)] = $query;
         }
     }
 
     /**
      * Local cache key of a category query, including the building context it depends on.
      *
-     * @param int   $categoryId         Id of the category.
-     * @param array $excludedCategories Categories excluded from the query building.
+     * @param string $cacheKey          Base cache key of the category query.
+     * @param array  $excludedCategories Categories excluded from the query building.
      *
      * @return string
      */
-    private function getLocalCacheKey(int $categoryId, array $excludedCategories): string
+    private function getLocalCacheKey(string $cacheKey, array $excludedCategories): string
     {
         if (empty($excludedCategories)) {
-            return (string) $categoryId;
+            return $cacheKey;
         }
 
         $excludedCategories = array_map('intval', $excludedCategories);
         sort($excludedCategories);
 
-        return $categoryId . '|' . implode(',', $excludedCategories);
+        return $cacheKey . '|' . implode(',', $excludedCategories);
     }
 
     /**

--- a/src/module-elasticsuite-virtual-category/Test/Unit/Model/RuleTest.php
+++ b/src/module-elasticsuite-virtual-category/Test/Unit/Model/RuleTest.php
@@ -1,0 +1,334 @@
+<?php
+/**
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer versions in the future.
+ *
+ * @category  Smile
+ * @package   Smile\ElasticsuiteVirtualCategory
+ * @copyright 2026 Smile
+ * @license   Open Software License ("OSL") v. 3.0
+ */
+
+namespace Smile\ElasticsuiteVirtualCategory\Test\Unit\Model;
+
+use Magento\Catalog\Model\Category;
+use Magento\Catalog\Model\ResourceModel\Category\Collection;
+use Magento\Customer\Model\Session;
+use Magento\Framework\App\CacheInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Smile\ElasticsuiteCatalogRule\Model\Rule\Condition\Product as ProductCondition;
+use Smile\ElasticsuiteCatalogRule\Model\Rule\Condition\Product\QueryBuilder;
+use Smile\ElasticsuiteCore\Search\Request\Query\Boolean;
+use Smile\ElasticsuiteCore\Search\Request\Query\Terms;
+use Smile\ElasticsuiteCore\Search\Request\QueryInterface;
+use Smile\ElasticsuiteVirtualCategory\Helper\Config;
+use Smile\ElasticsuiteCatalogRule\Model\Rule\Condition\Combine;
+use Smile\ElasticsuiteVirtualCategory\Model\Rule;
+
+/**
+ * Virtual category rule unit tests.
+ *
+ * @category Smile
+ * @package  Smile\ElasticsuiteVirtualCategory
+ */
+class RuleTest extends TestCase
+{
+    /**
+     * @var CacheInterface|MockObject
+     */
+    private $sharedCache;
+
+    /**
+     * @var QueryBuilder|MockObject
+     */
+    private $queryBuilder;
+
+    /**
+     * @var MockObject[]
+     */
+    private $conditions = [];
+
+    /**
+     * Reset the rule static local cache, shared by every instance.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $localCache = new \ReflectionProperty(Rule::class, 'localCache');
+        $localCache->setAccessible(true);
+        $localCache->setValue(null, []);
+    }
+
+    /**
+     * A query built while categories were excluded is context dependent: it must never be served
+     * to a later context free call, which is the one a category page issues.
+     *
+     * @return void
+     */
+    public function testContextualQueryIsNotServedToAContextFreeCall()
+    {
+        $rule = $this->getRule();
+
+        $contextual = $rule->getCategorySearchQuery(42, [1337]);
+        $contextFree = $rule->getCategorySearchQuery(42, []);
+
+        $this->assertInstanceOf(QueryInterface::class, $contextual);
+        $this->assertInstanceOf(QueryInterface::class, $contextFree);
+        $this->assertNotSame($contextual, $contextFree);
+    }
+
+    /**
+     * Only the context free query is shared across requests: a contextual one would be served later
+     * under a key that does not describe it.
+     *
+     * @return void
+     */
+    public function testOnlyTheContextFreeQueryIsStoredInTheSharedCache()
+    {
+        $saved = [];
+        $rule = $this->getRule();
+        $this->sharedCache->method('save')->willReturnCallback(
+            function ($data, $key) use (&$saved) {
+                $saved[] = $key;
+
+                return true;
+            }
+        );
+
+        $rule->getCategorySearchQuery(42, [1337]);
+        $this->assertSame([], $saved);
+
+        $rule->getCategorySearchQuery(42, []);
+        $this->assertCount(1, $saved);
+    }
+
+    /**
+     * A virtual category already expands its own descendants. Listing every descendant of the current
+     * category duplicates whole subqueries, once per virtual ancestor.
+     *
+     * @return void
+     */
+    public function testVirtualDescendantsAreNotExpandedTwice()
+    {
+        $child = $this->getVirtualCategoryMock(100, '1/2/42/100');
+        $grandChild = $this->getVirtualCategoryMock(200, '1/2/42/100/200');
+
+        // The grand child is already covered by the child query, it must not be built again.
+        $this->getConditionsOf($child)->expects($this->once())->method('getSearchQuery');
+        $this->getConditionsOf($grandChild)->expects($this->never())->method('getSearchQuery');
+
+        $rule = $this->getRule([$child, $grandChild]);
+        $query = $rule->getCategorySearchQuery(42, []);
+
+        $this->assertInstanceOf(Boolean::class, $query);
+        $this->assertCount(2, $query->getShould());
+    }
+
+    /**
+     * Build a virtual category mock, with its own rule conditions.
+     *
+     * @param int    $categoryId Category id.
+     * @param string $path       Category path.
+     *
+     * @return Category|MockObject
+     */
+    private function getVirtualCategoryMock(int $categoryId, string $path)
+    {
+        $conditions = $this->getMockBuilder(Combine::class)->disableOriginalConstructor()
+            ->onlyMethods(['getSearchQuery'])->getMock();
+        $conditions->method('getSearchQuery')->willReturnCallback(
+            function () use ($categoryId) {
+                return new Terms([$categoryId], 'category.category_id');
+            }
+        );
+
+        $virtualRule = $this->getMockBuilder(Rule::class)->disableOriginalConstructor()
+            ->onlyMethods(['getConditions'])->getMock();
+        $virtualRule->method('getConditions')->willReturn($conditions);
+
+        $category = $this->getCategoryMock($categoryId, $path, true, false);
+        $category->method('getVirtualRule')->willReturn($virtualRule);
+
+        $this->conditions[$categoryId] = $conditions;
+
+        return $category;
+    }
+
+    /**
+     * Rule conditions of a mocked category.
+     *
+     * @param Category|MockObject $category Category.
+     *
+     * @return MockObject
+     */
+    private function getConditionsOf($category)
+    {
+        return $this->conditions[$category->getId()];
+    }
+
+    /**
+     * Build a category mock.
+     *
+     * @param int    $categoryId  Category id.
+     * @param string $path        Category path.
+     * @param bool   $isVirtual   Whether the category is virtual.
+     * @param bool   $hasChildren Whether the category has children.
+     *
+     * @return Category|MockObject
+     */
+    private function getCategoryMock(int $categoryId, string $path, bool $isVirtual, bool $hasChildren)
+    {
+        $category = $this->getMockBuilder(Category::class)->disableOriginalConstructor()
+            ->addMethods(['getHasDraftVirtualRule', 'getIsVirtualCategory', 'getVirtualCategoryRoot', 'getVirtualRule'])
+            ->onlyMethods(
+                [
+                    'getId', 'getIsActive', 'hasChildren', 'getPath', 'getPathIds', 'getName',
+                    'getCacheTags', 'getStoreId', 'setStoreId', 'load',
+                ]
+            )
+            ->getMock();
+
+        $category->method('getId')->willReturn($categoryId);
+        $category->method('getIsActive')->willReturn(true);
+        $category->method('getIsVirtualCategory')->willReturn($isVirtual);
+        $category->method('getVirtualCategoryRoot')->willReturn(null);
+        $category->method('getHasDraftVirtualRule')->willReturn(false);
+        $category->method('hasChildren')->willReturn($hasChildren);
+        $category->method('getPath')->willReturn($path);
+        $category->method('getPathIds')->willReturn(explode('/', $path));
+        $category->method('getName')->willReturn('Category ' . $categoryId);
+        $category->method('getCacheTags')->willReturn([]);
+        $category->method('getStoreId')->willReturn(1);
+        $category->method('setStoreId')->willReturnSelf();
+        $category->method('load')->willReturnSelf();
+
+        return $category;
+    }
+
+    /**
+     * Build a rule with every collaborator stubbed, on a standard category.
+     *
+     * @param array $descendants Virtual descendants returned by the children collection.
+     *
+     * @return Rule
+     */
+    private function getRule(array $descendants = []): Rule
+    {
+        $this->sharedCache = $this->getMockBuilder(CacheInterface::class)->getMock();
+        $this->sharedCache->method('load')->willReturn(false);
+
+        $this->queryBuilder = $this->getMockBuilder(QueryBuilder::class)
+            ->disableOriginalConstructor()->getMock();
+        // A distinct query instance per call, so the test can tell two builds apart.
+        $this->queryBuilder->method('getSearchQuery')->willReturnCallback(
+            function () {
+                return new Terms([42], 'category.category_id');
+            }
+        );
+
+        $customerSession = $this->getMockBuilder(Session::class)->disableOriginalConstructor()->getMock();
+        $customerSession->method('getCustomerGroupId')->willReturn(0);
+
+        $config = $this->getMockBuilder(Config::class)->disableOriginalConstructor()->getMock();
+        $config->method('isForceZeroResultsForDisabledCategoriesEnabled')->willReturn(false);
+
+        $storeManager = $this->getMockBuilder(StoreManagerInterface::class)->getMock();
+
+        $category = $this->getCategoryMock(42, '1/2/42', false, !empty($descendants));
+
+        $collection = $this->getMockBuilder(Collection::class)->disableOriginalConstructor()
+            ->onlyMethods(
+                [
+                    'setStoreId', 'addIsActiveFilter', 'addPathFilter', 'addFieldToFilter',
+                    'addAttributeToFilter', 'addAttributeToSelect', 'getSize', 'getIterator',
+                ]
+            )
+            ->getMock();
+        $fluentMethods = [
+            'setStoreId', 'addIsActiveFilter', 'addPathFilter',
+            'addFieldToFilter', 'addAttributeToFilter', 'addAttributeToSelect',
+        ];
+        foreach ($fluentMethods as $method) {
+            $collection->method($method)->willReturnSelf();
+        }
+        $collection->method('getSize')->willReturn(count($descendants));
+        $collection->method('getIterator')->willReturnCallback(
+            function () use ($descendants) {
+                return new \ArrayIterator($descendants);
+            }
+        );
+
+        $rule = (new \ReflectionClass(Rule::class))->newInstanceWithoutConstructor();
+
+        $properties = [
+            'sharedCache'              => $this->sharedCache,
+            'queryBuilder'             => $this->queryBuilder,
+            'customerSession'          => $customerSession,
+            'config'                   => $config,
+            'storeManager'             => $storeManager,
+            'categoryFactory'          => $this->getFactoryStub($category),
+            'categoryCollectionFactory' => $this->getFactoryStub($collection),
+            'productConditionsFactory' => $this->getFactoryStub(
+                $this->getMockBuilder(ProductCondition::class)->disableOriginalConstructor()->getMock()
+            ),
+            'queryFactory'             => new class {
+                /**
+                 * @param string $type   Query type.
+                 * @param array  $params Query parameters.
+                 * @return Boolean
+                 */
+                public function create($type, $params = [])
+                {
+                    return new Boolean(
+                        $params['must'] ?? [],
+                        $params['should'] ?? [],
+                        $params['mustNot'] ?? []
+                    );
+                }
+            },
+        ];
+        foreach ($properties as $name => $value) {
+            $property = new \ReflectionProperty(Rule::class, $name);
+            $property->setAccessible(true);
+            $property->setValue($rule, $value);
+        }
+
+        $data = new \ReflectionProperty(\Magento\Framework\DataObject::class, '_data');
+        $data->setAccessible(true);
+        $data->setValue($rule, ['store_id' => 1]);
+
+        return $rule;
+    }
+
+    /**
+     * A factory stub always returning the same instance.
+     *
+     * @param object $instance Instance returned by the factory.
+     *
+     * @return object
+     */
+    private function getFactoryStub($instance)
+    {
+        return new class ($instance) {
+            /**
+             * @param object $instance Instance returned by the factory.
+             */
+            public function __construct(private $instance)
+            {
+            }
+
+            /**
+             * @param array $data Unused creation data.
+             * @return object
+             */
+            public function create($data = [])
+            {
+                return $this->instance;
+            }
+        };
+    }
+}

--- a/src/module-elasticsuite-virtual-category/Test/Unit/Model/RuleTest.php
+++ b/src/module-elasticsuite-virtual-category/Test/Unit/Model/RuleTest.php
@@ -82,6 +82,25 @@ class RuleTest extends TestCase
     }
 
     /**
+     * The local cache must preserve every dimension already used by the shared cache key.
+     *
+     * @return void
+     */
+    public function testLocalCacheIsScopedByStoreCustomerGroupAndDisabledCategoryConfig()
+    {
+        $defaultContext = $this->getRule();
+        $otherStore = $this->getRule([], 2);
+        $otherCustomerGroup = $this->getRule([], 1, 1);
+        $forceDisabledCategories = $this->getRule([], 1, 0, true);
+
+        $defaultQuery = $defaultContext->getCategorySearchQuery(42);
+
+        $this->assertNotSame($defaultQuery, $otherStore->getCategorySearchQuery(42));
+        $this->assertNotSame($defaultQuery, $otherCustomerGroup->getCategorySearchQuery(42));
+        $this->assertNotSame($defaultQuery, $forceDisabledCategories->getCategorySearchQuery(42));
+    }
+
+    /**
      * Only the context free query is shared across requests: a contextual one would be served later
      * under a key that does not describe it.
      *
@@ -212,11 +231,19 @@ class RuleTest extends TestCase
     /**
      * Build a rule with every collaborator stubbed, on a standard category.
      *
-     * @param array $descendants Virtual descendants returned by the children collection.
+     * @param array $descendants        Virtual descendants returned by the children collection.
+     * @param int   $storeId            Store identifier used to build the query.
+     * @param int   $customerGroupId    Customer group identifier used to build the query.
+     * @param bool  $forceZeroResults   Whether disabled categories must return zero results.
      *
      * @return Rule
      */
-    private function getRule(array $descendants = []): Rule
+    private function getRule(
+        array $descendants = [],
+        int $storeId = 1,
+        int $customerGroupId = 0,
+        bool $forceZeroResults = false
+    ): Rule
     {
         $this->sharedCache = $this->getMockBuilder(CacheInterface::class)->getMock();
         $this->sharedCache->method('load')->willReturn(false);
@@ -231,10 +258,10 @@ class RuleTest extends TestCase
         );
 
         $customerSession = $this->getMockBuilder(Session::class)->disableOriginalConstructor()->getMock();
-        $customerSession->method('getCustomerGroupId')->willReturn(0);
+        $customerSession->method('getCustomerGroupId')->willReturn($customerGroupId);
 
         $config = $this->getMockBuilder(Config::class)->disableOriginalConstructor()->getMock();
-        $config->method('isForceZeroResultsForDisabledCategoriesEnabled')->willReturn(false);
+        $config->method('isForceZeroResultsForDisabledCategoriesEnabled')->willReturn($forceZeroResults);
 
         $storeManager = $this->getMockBuilder(StoreManagerInterface::class)->getMock();
 
@@ -299,7 +326,7 @@ class RuleTest extends TestCase
 
         $data = new \ReflectionProperty(\Magento\Framework\DataObject::class, '_data');
         $data->setAccessible(true);
-        $data->setValue($rule, ['store_id' => 1]);
+        $data->setValue($rule, ['store_id' => $storeId]);
 
         return $rule;
     }


### PR DESCRIPTION
## Problem 1 — cache key ignores the building context

`Rule::getCategorySearchQuery($category, $excludedCategories)` builds a different query depending on `$excludedCategories`: it drives which children are skipped, whether `isVirtualCategoryRootInExcludeCategories()` short-circuits, and the cached flag. Yet the shared cache key and the static `$localCache` are keyed on the category id alone, and both are written from any context.

The last build wins, so the query a category page is served depends on what else the process happened to build. Measured on a real catalog: building the 831 categories of a store in one process makes category 42866 match 9 products with a 12 clause query, while building that same category alone gives 7 products and 906 clauses.

## Problem 2 — descendants expanded twice

`getChildrenCategories()` returns every descendant at any depth (`path REGEXP '<path>/.*'`). `addChildrenQueries()` ORs the full query of each virtual descendant, and each of those expands its own descendants again.

A virtual category nested under another one therefore has its whole subquery serialised several times over, and the waste grows with the depth of virtual nesting — enough for a large category to exceed `indices.query.bool.max_clause_count`, at which point Elasticsearch rejects the query and the category shows no product at all.

## Change

The shared cache is read and written only for the context free build, the one a category page issues; the local cache key now carries the excluded ids, so contextual queries stay memoized within a request without leaking.

Descendants are handled shallowest first, and a virtual descendant is skipped when an ancestor already had its query emitted: that ancestor's own recursion already covers it.

## Verification

Products matched by every category query of a store, before vs after:

|                       | categories whose product count changes | leaf clauses            |
| --------------------- | -------------------------------------- | ----------------------- |
| deduplication alone   | 0 / 831                                | 20 524 → 18 996 (−7.4%) |
| both changes          | 1 / 831                                | 20 524 → 19 660         |


## Tests

New `Test/Unit/Model/RuleTest.php`.